### PR TITLE
docs: keep the repository in English

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,29 +1,30 @@
 ---
-name: 버그
-about: 잘못 동작하는 것
+name: Bug
+about: Something behaves wrongly
 labels: bug
 ---
 
-## 증상
+## Symptom
 
-<!-- 무엇이 잘못됐는지 한두 줄. -->
+<!-- A line or two on what is wrong. -->
 
-## 재현
+## Steps to reproduce
 
-<!-- 순서대로. 이게 곧 스펙이고, 고쳤는지 판단하는 기준입니다.
-     조건이 중요하면 꼭 적어주세요 — "자글자글 켠 상태", "펜으로 빠르게" 같은 것들이
-     실제로 원인이었던 적이 여러 번 있습니다. -->
+<!-- In order. This is the spec, and the test for whether it is fixed.
+     Include the conditions if they matter — in this project the cause has several times
+     turned out to be a condition ("with boiling on", "drawing quickly with the pen")
+     rather than the action. -->
 
 1.
 2.
 
-**기대:**
-**실제:**
+**Expected:**
+**Actual:**
 
-## 환경
+## Environment
 
-<!-- 해당하는 것만. 태블릿/펜, 배포본(Vercel)인지 로컬인지, 프로젝트 크기 등 -->
+<!-- Only what applies: tablet/pen, deployed (Vercel) or local, project size. -->
 
-## 짐작 (선택)
+## Guess (optional)
 
-<!-- 없으면 비워두세요. 틀린 짐작은 조사를 엉뚱한 데로 보냅니다. -->
+<!-- Leave empty if you have none. A wrong guess sends the investigation the wrong way. -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,26 +1,26 @@
 ---
-name: 작업
-about: 기능, 리팩토링, 성능 등 버그가 아닌 것
+name: Task
+about: A feature, refactor, or anything that is not a bug
 labels: enhancement
 ---
 
-## 무엇을
+## What
 
-<!-- 한두 줄. -->
+<!-- A line or two. -->
 
-## 왜
+## Why
 
-<!-- 지금 무엇이 불편한지. 이게 없으면 나중에 "이거 왜 하려던 거지"가 됩니다. -->
+<!-- What is awkward today. Without this it becomes "why were we doing this again?". -->
 
-## 범위
+## Scope
 
-<!-- 포함되는 것과 **포함되지 않는 것**. 후자가 스코프 크립을 막습니다. -->
+<!-- What is included, and **what is not**. The second part is what stops scope creep. -->
 
 - [ ]
 - [ ]
 
-**하지 않을 것:**
+**Not doing:**
 
-## 완료 기준
+## Done when
 
-<!-- 무엇을 보면 끝났다고 판단할지. 성능이면 숫자로. -->
+<!-- What you would look at to call it finished. Numbers, if it is about performance. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,22 @@
-## 무엇을 / 왜
+## What / why
 
-<!-- 무엇을 했는지는 diff가 말해줍니다. 여기에는 **왜**를 쓰세요. -->
+<!-- The diff says what changed. Use this for **why**. -->
 
 Closes #
 
-## 검증
+## Verified
 
-- [ ] `npm run check` 통과 (타입체크 · 테스트 · 훅 기준선 · 빌드)
-- [ ] 브라우저에서 직접 확인
+- [ ] `npm run check` passes (typecheck · tests · hook baseline · build)
+- [ ] Checked in the browser
 
-<!-- 성능 변경이면 before/after 숫자를 넣으세요. 문장보다 훨씬 잘 전달됩니다.
-     예)  p95 프레임 27.8ms -> 10.9ms (획 15개, 일시정지) -->
+<!-- For a performance change, put the before/after numbers here. They carry far better
+     than a sentence.  e.g.  p95 frame 27.8ms -> 10.9ms (15 strokes, paused) -->
 
-## 직접 봐야 하는 것
+## Needs looking at
 
-<!-- 자동 검사가 못 잡는 부분. 무엇을 클릭하고 무엇을 봐야 하는지.
-     "빌드 통과"가 증명하는 게 거의 없는 코드베이스입니다. -->
+<!-- What the automated checks cannot catch: what to click, what to look for.
+     A green `npm run check` proves very little in this codebase. -->
 
-## 남긴 것 (선택)
+## Left out (optional)
 
-<!-- 일부러 안 한 것과 그 이유. -->
+<!-- Anything deliberately not done, and why. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,74 +1,79 @@
-# 작업 방식
+# How work happens here
 
-혼자 만드는 프로젝트지만 브랜치와 PR을 거칩니다. 이유는 세 가지입니다: PR마다 Vercel
-프리뷰가 생겨 병합 전에 실제 배포본으로 확인할 수 있고, CI가 관문이 되어 깨진 코드가
-main에 들어오지 못하며, "왜 이렇게 했는지"가 코드와 함께 남습니다.
+This is a one-person project, but changes still go through a branch and a pull request. Three
+reasons: every PR gets a Vercel preview, so it can be tried as a real deployment before it
+lands; CI is a gate, so broken code cannot reach `main`; and why something was done stays with
+the code.
 
-## 한 바퀴
+**Write issues, pull requests, commit messages and code comments in English.** It is the
+convention for a public repository and keeps everything in one language.
+
+## The loop
 
 ```bash
-gh issue create                       # 무엇을 왜 하는지 먼저 적는다
-git switch -c fix/12-짧은-설명         # 이슈 번호를 브랜치에
-# ... 작업 ...
-npm run check                         # 통과하지 않으면 커밋하지 않는다
+gh issue create                       # say what and why first
+git switch -c fix/12-short-description
+# ... work ...
+npm run check                         # do not commit until this passes
 git commit -m "fix: ..."
 git push -u origin HEAD
-gh pr create --fill                   # 본문에 Closes #12
+gh pr create --fill                   # put "Closes #12" in the body
 gh pr checks                          # CI
 gh pr merge --squash --delete-branch
 ```
 
-## 검증
+## Verifying
 
 ```bash
-npm run check   # 타입체크 → 테스트 → 훅 경고 기준선 → 빌드
+npm run check   # typecheck → tests → hook-warning baseline → build
 ```
 
-**이것이 통과해도 증명되는 것은 많지 않습니다.** `undefined`를 반환하는 컴포넌트는 합법적인
-React이고 유효한 JS라, 화면이 비어 있는데도 타입체크와 빌드가 모두 통과한 적이 있습니다.
-구조를 바꿨다면 해당 화면이 실제로 뜨는지 눈으로 확인하세요.
+**Passing this proves less than it looks.** A component that returns `undefined` is legal
+React and valid JS, so the typecheck and the build have both passed while a screen rendered
+nothing. If you changed structure, open the affected screen and look at it.
 
-훅 기준선(`scripts/hook-baseline.mjs`)은 `react-hooks/exhaustive-deps` 경고 **개수**를
-지킵니다. 줄면 통과, 늘면 실패입니다. 늘었다면 대개 effect가 컴포넌트 안에서 매번 새로
-만들어지는 함수를 참조하게 된 경우이고, 해법은 의존성에 넣는 것이 아니라 ref를 경유하는
-것입니다 — 넣으면 매 렌더마다 effect가 다시 돕니다.
+The hook baseline (`scripts/hook-baseline.mjs`) holds the *count* of
+`react-hooks/exhaustive-deps` warnings: fewer passes, more fails. More usually means an effect
+now references a function that the component rebuilds every render. The fix is a ref, not
+adding it to the dependency list — adding it re-runs the effect on every render.
 
-## 커밋
+## Commits
 
-하나의 커밋은 하나의 논리적 변경입니다. 판단 기준은 **이 커밋만 되돌렸을 때 말이 되는가**.
-대략 100줄 이상이거나 의미 있는 기능 하나가 될 때 커밋하고, 버그 하나마다 쪼개지 않습니다.
+One commit is one logical change. The test is whether reverting just that commit would make
+sense. Commit at roughly 100+ lines or one meaningful piece of work, not once per bug fixed.
 
 ```
-<type>: <명령형 한 줄>
+<type>: <imperative one-line summary>
 
-<왜 이렇게 했는지. 무엇을 했는지는 diff가 말해준다.>
+<why it was done this way. the diff already says what changed.>
 ```
 
 `feat` `fix` `refactor` `perf` `docs` `test` `chore`
 
-성능 변경이면 측정값을 본문에 넣으세요. 6개월 뒤에 그 숫자가 유일한 근거가 됩니다.
+For a performance change, put the measurements in the body. Six months later they are the only
+evidence you will have.
 
-## 코드를 어디에 둘 것인가
+## Where code goes
 
-`src/` 폴더는 그 파일이 무엇에 손대도 되는지를 뜻합니다. 자세한 것은
-[ARCHITECTURE.md](ARCHITECTURE.md) — **App.jsx를 고치기 전에 읽으세요.**
+The folders under `src/` say what a file is allowed to touch. The details are in
+[ARCHITECTURE.md](ARCHITECTURE.md) — **read it before editing App.jsx.**
 
 ```
-core/     순수 로직 — React·DOM·canvas 금지. 전부 테스트가 있습니다.
-canvas/   그리기. 넘겨받은 2D 컨텍스트 외에는 순수합니다.
-ui/       컴포넌트
-hooks/    상태와 동작을 잇는 훅
+core/     pure logic — no React, no DOM, no canvas. Everything here has tests.
+canvas/   drawing. Pure apart from the 2D context it is handed.
+ui/       components
+hooks/    React hooks wiring state to behaviour
 ```
 
-새 로직은 App.jsx가 아니라 모듈에 둡니다. 인자의 함수인 것은 테스트 옆에 있어야 합니다.
-불순한 부분은 인자로 받으면 됩니다 — `measureTextBox`가 컨텍스트를, `cloneCutContents`가
-비트맵 복사기를, `loadKeymap`이 storage를 받는 이유입니다.
+New logic goes in a module, not in App.jsx: anything that is a function of its arguments
+belongs next to its tests. Take the impure part as an argument — that is why `measureTextBox`
+takes a context, `cloneCutContents` takes a bitmap copier, and `loadKeymap` takes its storage.
 
-`core/`의 파일이 React를 import하거나 `document`를 찾고 있다면 폴더가 틀렸거나, 그것이
-필요한 부분은 컴포넌트에 남겼어야 한다는 신호입니다.
+A file in `core/` importing React or reaching for `document` means it is in the wrong folder,
+or the part that needs them should have stayed in the component.
 
-## 문서
+## Documentation
 
-`ARCHITECTURE.md`는 틀리면 없느니만 못합니다. 한동안 캔버스 크기를 854×480(실제
-1920×1080)이라 적어두고, 이미 있는 비트맵 수집기를 없다고 적어두고 있었습니다. 구조를
-바꿨다면 같은 PR에서 고치세요.
+`ARCHITECTURE.md` is worse than nothing when it is wrong. It spent a while claiming the canvas
+was 854×480 (it is 1920×1080) and that bitmaps were never collected, months after a collector
+was added. If you changed the structure, fix it in the same PR.


### PR DESCRIPTION
## What / why

Issues, PRs, commit messages and code comments are already English; the templates and the
contributing guide were the odd ones out. The convention matters more than which language it
is — a repository that switches halfway is harder to read than one that picks either.

The three open issues (#2, #3, #4) have been rewritten to match.

While translating, the templates kept the parts that exist for a reason rather than for form:

- the bug template presses on reproduction **conditions**, because in this project the cause
  has repeatedly been a condition ("with boiling on", "drawing quickly with the pen") rather
  than the action
- the task template asks what is **not** included, which is what actually stops scope creep
- the PR template asks what needs looking at by eye, because a green `npm run check` proves
  very little here

## Verified

- [x] `npm run check` passes — 240 tests, hook baseline within limit, build clean
- [x] Documentation only; no code touched

## Needs looking at

Open **New issue** on GitHub and confirm both templates (Bug / Task) appear and read sensibly.
This PR's own body is the PR template in use.
