### PR TITLE
fix: stop polling a server that is never coming, and let the reason be tapped

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1759,3 +1759,14 @@ html {
     font-size: 11px;
     color: #9a9aa8;
 }
+
+/* A status badge that can also be tapped for the explanation its tooltip carries. A tablet has
+   no hover, so a title attribute alone means the reason is unreachable on the device this app
+   is mainly used on. */
+.badge-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import { closeLassoPath, lassoBounds, applyResize } from './core/lassoOps.js';
 import { useTimelineGestures } from './hooks/useTimelineGestures.js';
 import { fmt, parseClock } from './core/timeCode.js';
 import { pushSnapshot, step } from './core/historyOps.js';
+import { nextProbeDelay } from './core/probeBackoff.js';
 import { cloneCutContents as cloneCutContentsPure } from './core/cutClone.js';
 import { DEFAULT_KEYS, KEY_LABELS, keyOf, matchShortcut, loadKeymap } from './core/shortcuts.js';
 import { derivePartsFrom, deriveVideoBatches } from './core/partOps.js';
@@ -1564,16 +1565,36 @@ export default function App() {
         // never render at all, so clicking does nothing and the console stays empty - which is
         // exactly how one bug here hid for so long. Re-checking periodically lets it reconnect
         // on its own once the server comes back.
+        //
+        // The interval backs off as failures pile up (see probeBackoff). A deployment has no
+        // server and never will until one is hosted, so a fixed poll there is a request failing
+        // every ten seconds for as long as the tab is open. Focus still forces an immediate
+        // check, so starting the server locally and switching back does not wait for the timer.
+        let failures = 0;
+        let timer = /** @type {any} */ (0);
+        const schedule = () => {
+            if (!alive) return;
+            clearTimeout(timer);
+            timer = setTimeout(probe, nextProbeDelay(failures));
+        };
         const probe = () => fetch('/api/projects', { method: 'GET' })
-            .then(r => { if (alive) setServerAvailable(r.ok); })
-            .catch(() => { if (alive) setServerAvailable(false); });
+            .then(r => {
+                if (!alive) return;
+                failures = r.ok ? 0 : failures + 1;
+                setServerAvailable(r.ok);
+            })
+            .catch(() => {
+                if (!alive) return;
+                failures++;
+                setServerAvailable(false);
+            })
+            .finally(schedule);
         probe();
-        const id = setInterval(probe, 10000);
-        // Re-check immediately on refocus, since starting the server and coming back is the
-        // common flow.
-        const onFocus = () => probe();
+        // Coming back to the tab is the moment the server has most likely just been started, so
+        // the backoff is reset rather than merely interrupted.
+        const onFocus = () => { failures = 0; probe(); };
         window.addEventListener('focus', onFocus);
-        return () => { alive = false; clearInterval(id); window.removeEventListener('focus', onFocus); };
+        return () => { alive = false; clearTimeout(timer); window.removeEventListener('focus', onFocus); };
     }, []);
 
     // Debounced autosave to IndexedDB so a refresh/crash never loses work.
@@ -3861,7 +3882,7 @@ export default function App() {
                 handleAudioUpload={handleAudioUpload} loadYoutubeAudio={loadYoutubeAudio}
                 handleDeleteAudio={handleDeleteAudio} audioFile={audioFile} openVideoImport={openVideoImport}
                 loadYoutubeVideo={loadYoutubeVideo} videoFileRef={videoFileRef} recentVideos={recentVideos}
-                reimportRecent={reimportRecent} serverAvailable={serverAvailable} showFileMenu={showFileMenu}
+                reimportRecent={reimportRecent} serverAvailable={serverAvailable} setToast={setToast} showFileMenu={showFileMenu}
                 setShowFileMenu={setShowFileMenu} showMediaMenu={showMediaMenu} setShowMediaMenu={setShowMediaMenu}
                 fileMenuRef={fileMenuRef} mediaMenuRef={mediaMenuRef} canvasW={CANVAS_W} canvasH={CANVAS_H}
                 setCanvasSize={setCanvasSize} setShowHelp={setShowHelp} setShowSettings={setShowSettings}

--- a/src/core/probeBackoff.js
+++ b/src/core/probeBackoff.js
@@ -1,0 +1,35 @@
+// How often to ask whether the project-storage server is there.
+//
+// Locally the server comes and goes — it is started in a second terminal, and the common flow is
+// "start it, switch back to the tab" — so the app has to keep checking rather than deciding once
+// at load. A fixed ten-second poll does that, and for local work it is fine.
+//
+// On a deployment there is no server and there never will be until one is hosted, so that same
+// poll is a request that fails every ten seconds for as long as the tab is open: console noise
+// for anyone who opens it, and pointless radio on a tablet.
+//
+// Backing off gets both. The first few failures are retried quickly, because that is the case
+// where the server is about to appear; after that the interval grows until it is checking every
+// few minutes, which costs nothing. Focus still forces an immediate check, so the local flow
+// does not have to wait for the timer.
+
+const BASE_MS = 10_000;   // the original poll, kept for the first failures
+const MAX_MS = 300_000;   // five minutes; a deployment settles here
+const QUICK_TRIES = 3;    // how many failures stay at the base interval
+
+/**
+ * Delay before the next probe, given how many have failed in a row.
+ *
+ * @param {number} failures consecutive failures; 0 means the last probe succeeded
+ * @returns {number} milliseconds
+ */
+export function nextProbeDelay(failures) {
+    const n = Number.isFinite(failures) ? Math.max(0, Math.floor(failures)) : 0;
+    if (n <= QUICK_TRIES) return BASE_MS;
+    // Doubling from the base once the quick tries are used up.
+    return Math.min(MAX_MS, BASE_MS * 2 ** (n - QUICK_TRIES));
+}
+
+export const PROBE_BASE_MS = BASE_MS;
+export const PROBE_MAX_MS = MAX_MS;
+export const PROBE_QUICK_TRIES = QUICK_TRIES;

--- a/src/ui/TopBar.jsx
+++ b/src/ui/TopBar.jsx
@@ -7,7 +7,7 @@ export function TopBar({
     doNew, doSave, doOpen, doLocalSave, openLocalList,
     doServerSave, openServerList, doServerBackup, openBackupList, backupBusy,
     handleAudioUpload, loadYoutubeAudio, handleDeleteAudio, audioFile, openVideoImport,
-    loadYoutubeVideo, videoFileRef, recentVideos, reimportRecent, serverAvailable,
+    loadYoutubeVideo, videoFileRef, recentVideos, reimportRecent, serverAvailable, setToast,
     showFileMenu, setShowFileMenu, showMediaMenu, setShowMediaMenu, fileMenuRef,
     mediaMenuRef, canvasW, canvasH, setCanvasSize, setShowHelp,
     setShowSettings, keymap, view, zoomCanvas, resetView,
@@ -114,7 +114,11 @@ export function TopBar({
             {/* Say plainly that without a server the work stays local. Working on unaware and
                 then losing it is the worst outcome here. */}
             {!serverAvailable
-                ? <span style={{ fontSize: 11, color: '#e0a84e' }} title={tr('API 서버에 연결할 수 없어 서버 저장/백업이 비활성화됩니다. 작업은 이 브라우저에만 저장됩니다.')}>{tr('⚠ 로컬 전용')}</span>
+                ? <button className="badge-btn" style={{ fontSize: 11, color: '#e0a84e' }}
+                    title={tr('API 서버에 연결할 수 없어 서버 저장/백업이 비활성화됩니다. 작업은 이 브라우저에만 저장됩니다.')}
+                    onClick={() => setToast(tr('서버가 없어 서버 저장·백업은 쓸 수 없습니다. 작업은 이 브라우저에 자동저장되고, 파일로 저장하면 안전하게 보관됩니다.'))}>
+                    {tr('⚠ 로컬 전용')}
+                </button>
                 : backupAt && <span style={{ fontSize: 11, color: 'var(--accent-pale)' }} title={tr('서버에 백업된 시각 (파일 > 백업에서 되돌리기)')}>⛁ {tr('백업')} {new Date(backupAt).toLocaleTimeString()}</span>}
             {storageInfo && storageInfo.pct > 0.8 && (
                 <span style={{ fontSize: 11, color: storageInfo.pct > 0.92 ? '#f66' : '#e0a84e' }}

--- a/test/probeBackoff.test.js
+++ b/test/probeBackoff.test.js
@@ -1,0 +1,54 @@
+// How often to ask whether the storage server is there. Locally it comes and goes, so the app
+// has to keep checking; on a deployment there is no server at all, and a fixed poll is a request
+// failing every ten seconds for as long as the tab stays open.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { nextProbeDelay, PROBE_BASE_MS, PROBE_MAX_MS, PROBE_QUICK_TRIES } from '../src/core/probeBackoff.js';
+
+test('a working server is checked at the base interval', () => {
+    assert.equal(nextProbeDelay(0), PROBE_BASE_MS);
+});
+
+test('the first few failures retry quickly, since that is when it is about to appear', () => {
+    // Starting the server in another terminal and switching back is the common local flow.
+    for (let n = 0; n <= PROBE_QUICK_TRIES; n++) {
+        assert.equal(nextProbeDelay(n), PROBE_BASE_MS, `failure ${n}`);
+    }
+});
+
+test('after that it backs off, so a deployment is not polled forever', () => {
+    const a = nextProbeDelay(PROBE_QUICK_TRIES + 1);
+    const b = nextProbeDelay(PROBE_QUICK_TRIES + 2);
+    assert.ok(a > PROBE_BASE_MS, 'grows past the base');
+    assert.ok(b > a, 'and keeps growing');
+});
+
+test('the interval never grows without limit', () => {
+    for (const n of [20, 100, 1e6]) {
+        assert.equal(nextProbeDelay(n), PROBE_MAX_MS, `${n} failures`);
+    }
+    // Doubling from a large exponent must not overflow into Infinity or NaN.
+    assert.ok(Number.isFinite(nextProbeDelay(5000)));
+});
+
+test('the delay never goes below the base, whatever it is handed', () => {
+    for (const n of [-1, -100, NaN, undefined, null, 'x']) {
+        const d = nextProbeDelay(/** @type {any} */(n));
+        assert.ok(d >= PROBE_BASE_MS && Number.isFinite(d), `${String(n)} -> ${d}`);
+    }
+});
+
+test('it is monotonic: more failures never means checking sooner', () => {
+    let prev = 0;
+    for (let n = 0; n <= 30; n++) {
+        const d = nextProbeDelay(n);
+        assert.ok(d >= prev, `failure ${n} waited less than the one before`);
+        prev = d;
+    }
+});
+
+test('an unreachable server settles within a couple of minutes of waiting, not seconds', () => {
+    // Rough shape check: ten failures in, it should be checking on the order of minutes.
+    assert.ok(nextProbeDelay(10) >= 60_000, `${nextProbeDelay(10)}ms`);
+});


### PR DESCRIPTION
## What / why

Closes #2

Reading the code first changed what this issue was. **The premise was partly wrong**: the
deployment does not fail silently. Server menu entries are hidden when the API is unreachable,
and a `⚠ 로컬 전용` badge is shown. That part was already handled.

Two real problems were underneath it.

**The probe never gave up.** It polls `/api/projects` every ten seconds, forever. Locally that
is correct — the server is started in a second terminal and the app has to notice — but on a
deployment there is no server and will not be until one is hosted, so it is a request failing
every ten seconds for as long as the tab stays open. Console noise for anyone the link is
shared with, and pointless radio on a tablet.

It backs off now: the base interval for the first few failures, because that is exactly when
the server is about to appear, then doubling to a five-minute ceiling. Focus resets the backoff
and probes immediately, so the local flow (start the server, switch back) still reconnects at
once rather than waiting out a long timer.

**The explanation was unreachable on a tablet.** The badge carried its reason in a `title`
attribute, which needs hover. This is a pen-and-tablet app, so on the device it is mainly used
on there was no way to find out why server save had disappeared. The badge is a button now and
says it in a toast when tapped.

## Verified

- [x] `npm run check` passes — 247 tests, hook baseline within limit, build clean
- [x] 7 new tests on the backoff: monotonic, bounded, never below the base, finite for any input

## Needs looking at

On the **Vercel preview** (no server there, which is the case under test):

1. The `⚠ 로컬 전용` badge appears in the top bar — **tap it**, a toast should explain
2. Open DevTools → Network and leave it a minute: `/api/projects` requests should get further
   apart rather than continuing every 10s
3. File menu shows local save/open but no server section
4. Local `.emv` save and browser autosave still work

Locally (`npm run dev`, server running): the badge should be absent and the server section
present. Then stop the server, tab away and back — the badge should appear within a probe.

## Left out

Deploying a real backend. That is Render, with TiDB for the database, and belongs in its own
issue — this only covers the deployment behaving sensibly until then.
