### PR TITLE
docs: record that main is protected, and how to bypass it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,26 @@ gh pr checks                          # CI
 gh pr merge --squash --delete-branch
 ```
 
+## `main` is protected
+
+Pushing straight to `main` is rejected — including for the repository owner, which is the only
+setting that makes the rule mean anything on a one-person project. Everything lands through a
+pull request whose `check` run has passed, and force pushes and branch deletion are off.
+
+```
+remote: error: GH006: Protected branch update failed for refs/heads/main.
+```
+
+If you ever genuinely need to bypass it:
+
+```bash
+gh api -X DELETE repos/difficcd/Easy-Mv-Maker/branches/main/protection/enforce_admins
+# ... push ...
+gh api -X POST   repos/difficcd/Easy-Mv-Maker/branches/main/protection/enforce_admins
+```
+
+Turning it back on is the part that gets forgotten, so do both in one sitting.
+
 ## Verifying
 
 ```bash


### PR DESCRIPTION
## What / why

`main` is now protected: direct pushes are rejected, force pushes and deletion are off, and every change needs a PR whose `check` run has passed. Admin enforcement is on, which is the setting that makes it mean anything here — without it the protection is advisory and the one person it should apply to walks straight through.

That was confirmed the embarrassing way. A test push landed on `main` before admin enforcement was enabled (`bac51a0`, an empty commit). It is still there: removing it needs the force push that is now correctly disabled, and the cost of unpicking that outweighs one empty commit.

The bypass procedure is written down because it will be needed eventually, and because turning enforcement back on is the half that gets forgotten.

## Verified

- [x] Direct push to `main` rejected with `GH006: Protected branch update failed`
- [x] Documentation only

## Needs looking at

Nothing in the app. Worth knowing that from now on `git push origin main` will fail by design — use a branch.