### PR TITLE
refactor: make the audio and video tracks a reducer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,10 @@ import { useTimelineGestures } from './hooks/useTimelineGestures.js';
 import { fmt, parseClock } from './core/timeCode.js';
 import { pushSnapshot, step } from './core/historyOps.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
+import {
+    mediaReducer, EMPTY_MEDIA, loadAudio, setAudioDuration, setAudioClip, clearAudio,
+    loadVideo, clearVideo, setVideoCuts, moveTrack, resizeAudio,
+} from './core/mediaReducer.js';
 import { cloneCutContents as cloneCutContentsPure } from './core/cutClone.js';
 import { DEFAULT_KEYS, KEY_LABELS, keyOf, matchShortcut, loadKeymap } from './core/shortcuts.js';
 import { derivePartsFrom, deriveVideoBatches } from './core/partOps.js';
@@ -215,15 +219,16 @@ export default function App() {
     const [panelDrag, setPanelDrag] = useState(null);
 
     const [snapLinePos, setSnapLinePos] = useState(null);
-    const [audioFile, setAudioFile] = useState(null);
-    const [audioUrl, setAudioUrl] = useState(null);
-    const [audioDuration, setAudioDuration] = useState(30);
-    const [audioData, setAudioData] = useState(null);
+    // The audio and video tracks move together - loading audio sets four of these at once - so
+    // they are one reducer. Destructured here so every read site keeps the name it always had;
+    // only the writes go through an action. See core/mediaReducer.
+    const [media, dispatchMedia] = React.useReducer(mediaReducer, EMPTY_MEDIA);
+    const { audioFile, audioUrl, audioDuration, audioData } = media;
     const audioRef = useRef(null);
     const audioB64Ref = useRef(null); // audio as base64 data URL, embedded into saves
     // Video overlay track: play the original video underneath the drawing layers (no per-frame
     // cuts) - for drawing over a video. Like audio, but painted onto the canvas each frame.
-    const [videoOverlay, setVideoOverlay] = useState(null); // { name, startTime, endTime, offset, duration, w, h, cuts? }
+    const { videoOverlay } = media; // { name, startTime, endTime, offset, duration, w, h, cuts? }
     const [sceneDetect, setSceneDetect] = useState(null);   // { done, total } while auto-detecting scene cuts
     const [sceneCfg, setSceneCfg] = useState(null);         // scene-detect settings modal { threshold, rangeOn, startText, endText }
     const videoElRef = useRef(null);      // hidden <video> element that decodes/plays the overlay
@@ -684,7 +689,7 @@ export default function App() {
         const s = JSON.parse(JSON.stringify(snap));
         isUndoRedoRef.current = true;
         dispatchCuts(replaceCuts(s.cuts));
-        setAudioData(s.audioData ?? null);
+        dispatchMedia(setAudioClip(s.audioData ?? null));
         setNumTracks(s.numTracks ?? 2);
     };
     const stepHistory = (dir) => {
@@ -988,11 +993,14 @@ export default function App() {
                 const dt = (e.clientX - resizingData.startX) / pps;
                 const i0 = resizingData.initialStart, i1 = resizingData.initialEnd;
                 if (resizingData.cutId === 'audio') {
-                    setAudioData(prev => {
-                        if (!prev) return prev;
-                        if (resizingData.edge === 'left') { const ns = Math.max(0, Math.min(i1 - 0.1, i0 + dt)); return { ...prev, startTime: ns, offset: Math.max(0, (resizingData.initialOffset ?? 0) + (ns - i0)) }; }
-                        return { ...prev, endTime: Math.max(i0 + 0.1, i1 + dt) };
-                    });
+                    // Both edges are computed from where the drag began plus the delta, so the
+                    // result does not depend on the previous value and the reducer stays pure.
+                    if (resizingData.edge === 'left') {
+                        const ns = Math.max(0, Math.min(i1 - 0.1, i0 + dt));
+                        dispatchMedia(resizeAudio('left', ns, null, (resizingData.initialOffset ?? 0) + (ns - i0)));
+                    } else {
+                        dispatchMedia(resizeAudio('right', null, Math.max(i0 + 0.1, i1 + dt), null));
+                    }
                     return;
                 }
                 // The geometry is in cutOps and unit tested; only the guide line is a side
@@ -1017,10 +1025,10 @@ export default function App() {
                 cutDragMovedRef.current = true;
                 const dt = (e.clientX - draggingCutData.startX) / pps, trackOff = Math.round((e.clientY - draggingCutData.startY) / 60);
                 if (draggingCutData.cutId === 'audio') {
-                    setAudioData(prev => { if (!prev) return prev; const ns = Math.max(0, draggingCutData.initialStart + dt); return { ...prev, startTime: ns, endTime: ns + (prev.endTime - prev.startTime) }; }); return;
+                    dispatchMedia(moveTrack('audio', draggingCutData.initialStart + dt)); return;
                 }
                 if (draggingCutData.cutId === 'video') {
-                    setVideoOverlay(prev => { if (!prev) return prev; const ns = Math.max(0, draggingCutData.initialStart + dt); return { ...prev, startTime: ns, endTime: ns + (prev.endTime - prev.startTime) }; }); return;
+                    dispatchMedia(moveTrack('video', draggingCutData.initialStart + dt)); return;
                 }
                 // Multi-cut drag: move the whole selected group by the same delta (keeps their
                 // relative layout), clamped so none crosses t=0 or the track range.
@@ -1206,15 +1214,14 @@ export default function App() {
         }
         if (audioDataUrl) {
             audioB64Ref.current = audioDataUrl;
-            setAudioFile({ name: data.audio.name || tr('오디오') });
-            setAudioUrl(audioDataUrl);
-            setAudioDuration(data.audio.duration || 30);
-            setAudioData({ startTime: data.audio.startTime ?? 0, endTime: data.audio.endTime ?? (data.audio.duration || 30), offset: data.audio.offset ?? 0 });
+            dispatchMedia(loadAudio(data.audio.name || tr('오디오'), audioDataUrl));
+            dispatchMedia(setAudioDuration(data.audio.duration || 30));
+            dispatchMedia(setAudioClip({ startTime: data.audio.startTime ?? 0, endTime: data.audio.endTime ?? (data.audio.duration || 30), offset: data.audio.offset ?? 0 }));
             if (audioRef.current) audioRef.current.src = audioDataUrl;
         } else {
             audioB64Ref.current = null;
             if (audioRef.current) { audioRef.current.pause(); try { audioRef.current.removeAttribute('src'); audioRef.current.load(); } catch { } }
-            setAudioFile(null); setAudioUrl(null); setAudioData(null);
+            dispatchMedia(clearAudio());
         }
         // Restore the video overlay track (Blob from IDB / server asset / embedded dataURL).
         let videoBlob = null;
@@ -1226,9 +1233,9 @@ export default function App() {
             const url = URL.createObjectURL(videoBlob);
             const v = videoElRef.current;
             if (v) { v.muted = true; v.playsInline = true; v.src = url; v.onseeked = () => setFrameDecodeTick(t => t + 1); v.onloadedmetadata = () => { try { v.currentTime = data.video.offset || 0; } catch { } }; }
-            setVideoOverlay({ name: data.video.name || tr('영상'), startTime: data.video.startTime ?? 0, endTime: data.video.endTime ?? (data.video.duration || 0), offset: data.video.offset ?? 0, duration: data.video.duration || 0, w: data.video.w || 0, h: data.video.h || 0, cuts: data.video.cuts, cutStart: data.video.cutStart, cutOffset: data.video.cutOffset });
+            dispatchMedia(loadVideo({ name: data.video.name || tr('영상'), startTime: data.video.startTime ?? 0, endTime: data.video.endTime ?? (data.video.duration || 0), offset: data.video.offset ?? 0, duration: data.video.duration || 0, w: data.video.w || 0, h: data.video.h || 0, cuts: data.video.cuts, cutStart: data.video.cutStart, cutOffset: data.video.cutOffset }));
         } else {
-            videoBlobRef.current = null; setVideoOverlay(null);
+            videoBlobRef.current = null; dispatchMedia(clearVideo());
             if (videoElRef.current) { try { videoElRef.current.pause(); videoElRef.current.removeAttribute('src'); videoElRef.current.load(); } catch { } }
         }
         } finally { setLoadProgress(null); }
@@ -1283,8 +1290,8 @@ export default function App() {
         setLayerCanvasCache({});
         serverIdRef.current = null; serverNameRef.current = '';
         if (audioRef.current) { audioRef.current.pause(); try { audioRef.current.removeAttribute('src'); audioRef.current.load(); } catch { } }
-        audioB64Ref.current = null; setAudioFile(null); setAudioUrl(null); setAudioData(null);
-        videoBlobRef.current = null; setVideoOverlay(null); setSceneCfg(null);
+        audioB64Ref.current = null; dispatchMedia(clearAudio());
+        videoBlobRef.current = null; dispatchMedia(clearVideo()); setSceneCfg(null);
         if (videoElRef.current) { try { videoElRef.current.pause(); videoElRef.current.removeAttribute('src'); videoElRef.current.load(); } catch { } }
     };
     const doNew = () => {
@@ -3342,15 +3349,15 @@ export default function App() {
     });
 
     const loadAudioUrl = (url, name, startAt = 0, offset = 0, clipDur = null) => {
-        setAudioFile({ name }); setAudioUrl(url);
+        dispatchMedia(loadAudio(name, url));
         const audio = new Audio(url);
         // startAt aligns the track to a given timeline position (e.g. the first imported video frame);
         // offset/clipDur select a sub-range of the source audio (used when only a video segment is
         // imported), so audio + frames extracted together stay mechanically in sync.
         audio.onloadedmetadata = () => {
-            setAudioDuration(audio.duration);
+            dispatchMedia(setAudioDuration(audio.duration));
             const dur = clipDur != null ? Math.min(clipDur, Math.max(0, audio.duration - offset)) : Math.max(0, audio.duration - offset);
-            setAudioData({ startTime: startAt, endTime: startAt + dur, offset });
+            dispatchMedia(setAudioClip({ startTime: startAt, endTime: startAt + dur, offset }));
             if (audioRef.current) audioRef.current.src = url;
         };
         // Capture base64 once so the project can be saved "with the music".
@@ -3369,7 +3376,7 @@ export default function App() {
         v.muted = true; v.playsInline = true; v.src = url;
         v.onloadedmetadata = () => {
             const dur = clipDur != null ? Math.min(clipDur, Math.max(0, v.duration - offset)) : Math.max(0, v.duration - offset);
-            setVideoOverlay({ name: name || tr('영상'), startTime: startAt, endTime: startAt + dur, offset, duration: v.duration, w: v.videoWidth, h: v.videoHeight });
+            dispatchMedia(loadVideo({ name: name || tr('영상'), startTime: startAt, endTime: startAt + dur, offset, duration: v.duration, w: v.videoWidth, h: v.videoHeight }));
             // Prime the first frame so a paused canvas shows something immediately.
             try { v.currentTime = offset; } catch { }
         };
@@ -3388,12 +3395,12 @@ export default function App() {
         const rEnd = rangeOn && rEndRaw > rStart ? rEndRaw : null;
         setSceneDetect({ done: 0, total: 0 });
         detectSceneCuts(blob, { start: rStart, end: rEnd, threshold, onProgress: (d, t) => setSceneDetect({ done: d, total: t }) })
-            .then(cuts => setVideoOverlay(prev => prev ? { ...prev, cuts, cutStart: cs, cutOffset: co } : prev))
+            .then(cuts => dispatchMedia(setVideoCuts(cuts, cs, co)))
             .catch(() => { })
             .finally(() => setSceneDetect(null));
     };
     const removeVideoOverlay = () => {
-        setVideoOverlay(null); videoBlobRef.current = null; setSceneCfg(null);
+        dispatchMedia(clearVideo()); videoBlobRef.current = null; setSceneCfg(null);
         const v = videoElRef.current; if (v) { try { v.pause(); v.removeAttribute('src'); v.load(); } catch { } }
     };
     // Remember fetched/opened videos so they can be re-imported with different settings
@@ -3573,7 +3580,7 @@ export default function App() {
         if (audioRef.current) { audioRef.current.pause(); try { audioRef.current.removeAttribute('src'); audioRef.current.load(); } catch { } }
         if (audioUrl && audioUrl.startsWith('blob:')) { try { URL.revokeObjectURL(audioUrl); } catch { } }
         audioB64Ref.current = null;
-        setAudioFile(null); setAudioUrl(null); setAudioData(null);
+        dispatchMedia(clearAudio());
     };
     const loadYoutubeAudio = async (presetUrl) => {
         const url = typeof presetUrl === 'string' ? presetUrl : null;

--- a/src/core/mediaReducer.js
+++ b/src/core/mediaReducer.js
@@ -1,0 +1,110 @@
+// The audio and video tracks, as a reducer.
+//
+// These were five pieces of state that only ever moved together: loading a piece of audio set
+// four of them, clearing it set three, and forgetting one left the app in a state it has no name
+// for — a URL with no clip range, or a clip range pointing at audio that is gone. The same
+// argument that moved `cuts` to a reducer applies, on a smaller scale.
+//
+// What is *not* here: the audio element, the video element, and the blobs behind them. Those are
+// browser objects with a lifetime of their own, so they stay in refs beside the component and
+// this only describes where the tracks sit on the timeline.
+//
+// Actions are built by the exported creators, so a mistyped one is a type error rather than a
+// silent no-op.
+
+/** Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */
+export const EMPTY_MEDIA = {
+    audioFile: null,      // { name } — the label shown on the track
+    audioUrl: null,       // object URL or data URL being played
+    audioDuration: 30,    // length of the source, from the audio element
+    audioData: null,      // { startTime, endTime, offset } — where the clip sits on the timeline
+    videoOverlay: null,   // { name, startTime, endTime, offset, duration, w, h, cuts?, ... }
+};
+
+// ── action creators ────────────────────────────────────────────────────────
+
+/** A piece of audio arrived. Its length is not known yet — the element reports that later. */
+export const loadAudio = (name, url) => ({ type: 'loadAudio', name, url });
+/** The audio element has read the source and knows how long it is. */
+export const setAudioDuration = (duration) => ({ type: 'setAudioDuration', duration });
+/** Where the clip sits on the timeline, and which part of the source it plays. */
+export const setAudioClip = (clip) => ({ type: 'setAudioClip', clip });
+export const clearAudio = () => ({ type: 'clearAudio' });
+
+export const loadVideo = (overlay) => ({ type: 'loadVideo', overlay });
+export const clearVideo = () => ({ type: 'clearVideo' });
+/** Scene-cut markers found by the detector, in video time. */
+export const setVideoCuts = (cuts, cutStart, cutOffset) => ({ type: 'setVideoCuts', cuts, cutStart, cutOffset });
+
+/** Drag a track along the timeline, keeping its length. */
+export const moveTrack = (which, startTime) => ({ type: 'moveTrack', which, startTime });
+/** Drag one edge of the audio clip. The left edge also moves into the source. */
+export const resizeAudio = (edge, startTime, endTime, offset) => ({ type: 'resizeAudio', edge, startTime, endTime, offset });
+
+/** Restore both tracks at once, opening a project. */
+export const restoreMedia = (media) => ({ type: 'restoreMedia', media });
+/** Everything gone: a new project. */
+export const clearMedia = () => ({ type: 'clearMedia' });
+
+// ── the reducer ────────────────────────────────────────────────────────────
+
+/** Move a track to an absolute start, keeping its duration and never before zero. */
+const shifted = (track, startTime) => {
+    if (!track) return track;
+    const start = Math.max(0, startTime);
+    return { ...track, startTime: start, endTime: start + (track.endTime - track.startTime) };
+};
+
+export function mediaReducer(state, action) {
+    const s = state || EMPTY_MEDIA;
+    switch (action.type) {
+        case 'loadAudio':
+            // The clip range is cleared rather than kept: it described the previous audio, and
+            // leaving it would place the new track using the old one's bounds until the element
+            // reports back.
+            return { ...s, audioFile: { name: action.name }, audioUrl: action.url, audioData: null };
+        case 'setAudioDuration':
+            return { ...s, audioDuration: action.duration || 30 };
+        case 'setAudioClip':
+            return { ...s, audioData: action.clip };
+        case 'clearAudio':
+            // Duration is left as it is: it belongs to the source that has gone, and resetting it
+            // would shrink the timeline under the user mid-edit.
+            return { ...s, audioFile: null, audioUrl: null, audioData: null };
+
+        case 'loadVideo':
+            return { ...s, videoOverlay: action.overlay };
+        case 'clearVideo':
+            return { ...s, videoOverlay: null };
+        case 'setVideoCuts':
+            // Only meaningful while that video is still loaded; detection finishes asynchronously
+            // and can land after the video was removed.
+            return s.videoOverlay
+                ? { ...s, videoOverlay: { ...s.videoOverlay, cuts: action.cuts, cutStart: action.cutStart, cutOffset: action.cutOffset } }
+                : s;
+
+        case 'moveTrack':
+            return action.which === 'audio'
+                ? { ...s, audioData: shifted(s.audioData, action.startTime) }
+                : { ...s, videoOverlay: shifted(s.videoOverlay, action.startTime) };
+
+        case 'resizeAudio': {
+            if (!s.audioData) return s;
+            // Dragging the left edge scrubs into the source as well as moving the clip: the audio
+            // under the new start has to be the audio that was there before, or the track slides
+            // out of sync with everything cut against it. The right edge is a plain trim.
+            const next = action.edge === 'left'
+                ? { ...s.audioData, startTime: action.startTime, offset: Math.max(0, action.offset) }
+                : { ...s.audioData, endTime: action.endTime };
+            return { ...s, audioData: next };
+        }
+
+        case 'restoreMedia':
+            return { ...EMPTY_MEDIA, ...(action.media || {}) };
+        case 'clearMedia':
+            return { ...EMPTY_MEDIA };
+
+        default:
+            return s;
+    }
+}

--- a/test/mediaReducer.test.js
+++ b/test/mediaReducer.test.js
@@ -1,0 +1,154 @@
+// The audio and video tracks. These were five pieces of state that only ever moved together —
+// loading audio set four of them — and the interesting cases are the ones where forgetting one
+// leaves a combination the app has no name for: a URL with no clip range, or a clip range
+// describing audio that is gone.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    mediaReducer, EMPTY_MEDIA,
+    loadAudio, setAudioDuration, setAudioClip, clearAudio,
+    loadVideo, clearVideo, setVideoCuts, moveTrack, resizeAudio,
+    restoreMedia, clearMedia,
+} from '../src/core/mediaReducer.js';
+
+const clip = (startTime, endTime, offset = 0) => ({ startTime, endTime, offset });
+const withAudio = (c = clip(0, 10)) => mediaReducer(
+    mediaReducer(EMPTY_MEDIA, loadAudio('song.mp3', 'blob:x')), setAudioClip(c));
+const withVideo = (o = { name: 'clip.mp4', startTime: 0, endTime: 10, offset: 0, duration: 10 }) =>
+    mediaReducer(EMPTY_MEDIA, loadVideo(o));
+
+// ── audio ──────────────────────────────────────────────────────────────────
+test('loadAudio: the track is named and playable before its length is known', () => {
+    const s = mediaReducer(EMPTY_MEDIA, loadAudio('song.mp3', 'blob:x'));
+    assert.deepEqual(s.audioFile, { name: 'song.mp3' });
+    assert.equal(s.audioUrl, 'blob:x');
+    assert.equal(s.audioData, null, 'the element has not reported a duration yet');
+});
+
+test('loadAudio: replacing audio drops the old clip range', () => {
+    // Keeping it would place the new track using the previous one's bounds until the element
+    // reports back — the wrong length, in the wrong place, for a moment.
+    const s = mediaReducer(withAudio(clip(5, 15, 2)), loadAudio('other.mp3', 'blob:y'));
+    assert.equal(s.audioData, null);
+    assert.equal(s.audioUrl, 'blob:y');
+});
+
+test('setAudioDuration: a missing or zero duration falls back rather than collapsing the timeline', () => {
+    assert.equal(mediaReducer(EMPTY_MEDIA, setAudioDuration(214)).audioDuration, 214);
+    assert.equal(mediaReducer(EMPTY_MEDIA, setAudioDuration(0)).audioDuration, 30);
+    assert.equal(mediaReducer(EMPTY_MEDIA, setAudioDuration(undefined)).audioDuration, 30);
+});
+
+test('clearAudio: the track goes, the duration stays', () => {
+    // Resetting the duration would shrink the timeline under the user mid-edit.
+    const s = mediaReducer(mediaReducer(withAudio(), setAudioDuration(214)), clearAudio());
+    assert.equal(s.audioFile, null);
+    assert.equal(s.audioUrl, null);
+    assert.equal(s.audioData, null);
+    assert.equal(s.audioDuration, 214);
+});
+
+test('clearAudio: the video track is untouched', () => {
+    const both = mediaReducer(withAudio(), loadVideo({ name: 'v', startTime: 0, endTime: 5 }));
+    assert.equal(mediaReducer(both, clearAudio()).videoOverlay.name, 'v');
+});
+
+// ── dragging a track ───────────────────────────────────────────────────────
+test('moveTrack: an absolute move that keeps the length', () => {
+    const s = mediaReducer(withAudio(clip(2, 12)), moveTrack('audio', 7));
+    assert.deepEqual([s.audioData.startTime, s.audioData.endTime], [7, 17]);
+});
+
+test('moveTrack: dragged before zero, a track stops at zero and keeps its length', () => {
+    const s = mediaReducer(withAudio(clip(2, 12)), moveTrack('audio', -50));
+    assert.deepEqual([s.audioData.startTime, s.audioData.endTime], [0, 10], 'not squashed to nothing');
+});
+
+test('moveTrack: video moves the same way, and the two are independent', () => {
+    const both = mediaReducer(withAudio(clip(0, 10)), loadVideo({ name: 'v', startTime: 0, endTime: 4 }));
+    const s = mediaReducer(both, moveTrack('video', 3));
+    assert.deepEqual([s.videoOverlay.startTime, s.videoOverlay.endTime], [3, 7]);
+    assert.equal(s.audioData.startTime, 0, 'the audio did not move');
+});
+
+test('moveTrack: dragging a track that is not loaded does nothing', () => {
+    assert.equal(mediaReducer(EMPTY_MEDIA, moveTrack('audio', 5)).audioData, null);
+    assert.equal(mediaReducer(EMPTY_MEDIA, moveTrack('video', 5)).videoOverlay, null);
+});
+
+// ── trimming audio ─────────────────────────────────────────────────────────
+test('resizeAudio: the left edge moves into the source as well as along the timeline', () => {
+    // Without the offset the audio under the new start would not be the audio that was there,
+    // and the track slides out of sync with everything cut against it.
+    const s = mediaReducer(withAudio(clip(0, 10, 0)), resizeAudio('left', 3, null, 3));
+    assert.equal(s.audioData.startTime, 3);
+    assert.equal(s.audioData.offset, 3);
+    assert.equal(s.audioData.endTime, 10, 'the far edge is untouched');
+});
+
+test('resizeAudio: the right edge is a plain trim', () => {
+    const s = mediaReducer(withAudio(clip(0, 10, 2)), resizeAudio('right', null, 6, null));
+    assert.equal(s.audioData.endTime, 6);
+    assert.deepEqual([s.audioData.startTime, s.audioData.offset], [0, 2], 'start and offset unchanged');
+});
+
+test('resizeAudio: the offset never goes negative', () => {
+    // Dragging the left edge back past the beginning of the source.
+    const s = mediaReducer(withAudio(clip(5, 10, 0)), resizeAudio('left', 0, null, -5));
+    assert.equal(s.audioData.offset, 0);
+});
+
+test('resizeAudio: with no audio loaded there is nothing to resize', () => {
+    assert.equal(mediaReducer(EMPTY_MEDIA, resizeAudio('left', 1, null, 0)).audioData, null);
+});
+
+// ── video ──────────────────────────────────────────────────────────────────
+test('setVideoCuts: scene markers are attached to the loaded video', () => {
+    const s = mediaReducer(withVideo(), setVideoCuts([1, 2, 3], 0, 0.5));
+    assert.deepEqual(s.videoOverlay.cuts, [1, 2, 3]);
+    assert.deepEqual([s.videoOverlay.cutStart, s.videoOverlay.cutOffset], [0, 0.5]);
+    assert.equal(s.videoOverlay.name, 'clip.mp4', 'the rest of the overlay survives');
+});
+
+test('setVideoCuts: markers arriving after the video was removed are dropped', () => {
+    // Detection runs in the background and can finish late.
+    const s = mediaReducer(EMPTY_MEDIA, setVideoCuts([1, 2], 0, 0));
+    assert.equal(s.videoOverlay, null, 'no overlay is invented to hold them');
+});
+
+test('clearVideo: leaves the audio alone', () => {
+    const both = mediaReducer(withAudio(), loadVideo({ name: 'v', startTime: 0, endTime: 5 }));
+    const s = mediaReducer(both, clearVideo());
+    assert.equal(s.videoOverlay, null);
+    assert.ok(s.audioData, 'audio still loaded');
+});
+
+// ── whole-state actions ────────────────────────────────────────────────────
+test('restoreMedia: opening a project fills in anything the file did not carry', () => {
+    const s = mediaReducer(withAudio(), restoreMedia({ videoOverlay: { name: 'v', startTime: 0, endTime: 2 } }));
+    assert.equal(s.videoOverlay.name, 'v');
+    assert.equal(s.audioUrl, null, 'the previous project audio is gone, not left behind');
+    assert.equal(s.audioDuration, 30, 'back to the default');
+});
+
+test('clearMedia: a new project starts empty', () => {
+    assert.deepEqual(mediaReducer(withAudio(), clearMedia()), EMPTY_MEDIA);
+});
+
+test('an unknown action changes nothing, and no state is mutated', () => {
+    const before = withAudio(clip(1, 9, 2));
+    const snapshot = JSON.stringify(before);
+    // @ts-ignore - deliberately not a real action
+    assert.equal(mediaReducer(before, { type: 'nonsense' }), before);
+    for (const a of [loadAudio('x', 'y'), setAudioClip(clip(0, 1)), clearAudio(), moveTrack('audio', 4),
+        resizeAudio('left', 1, null, 1), loadVideo({ startTime: 0, endTime: 1 }), clearVideo(), clearMedia()]) {
+        mediaReducer(before, a);
+    }
+    assert.equal(JSON.stringify(before), snapshot, 'the input was mutated');
+});
+
+test('a missing state falls back to empty rather than throwing', () => {
+    assert.deepEqual(mediaReducer(undefined, clearAudio()).audioFile, null);
+    assert.deepEqual(mediaReducer(null, setAudioDuration(60)).audioDuration, 60);
+});


### PR DESCRIPTION
## What / why

First step of #3.

The audio and video tracks were five pieces of state that only ever moved together: loading a
piece of audio set four of them, clearing it set three. Forgetting one leaves a combination the
app has no name for — a URL with no clip range, or a clip range describing audio that is gone.
That is the same argument that moved `cuts` to a reducer, on a smaller scale.

Reads keep the names they always had, because the state is destructured straight back out:

```js
const [media, dispatchMedia] = useReducer(mediaReducer, EMPTY_MEDIA);
const { audioFile, audioUrl, audioDuration, audioData, videoOverlay } = media;
```

So only the nineteen write sites changed. What deliberately stays outside are the audio element,
the video element and the blobs behind them — browser objects with their own lifetime, so refs
remain right for those; this only describes where the tracks sit on the timeline.

**Two rules that were implicit are now stated and tested.** Replacing the audio drops the
previous clip range, or the new track is placed using the old one's bounds until the element
reports back. Clearing the audio keeps the duration, because resetting it would shrink the
timeline under the user mid-edit.

**One impurity fixed.** The drag and resize handlers read the previous value inside the updater,
which React invokes twice under StrictMode — the same class of thing found in the cut drag
earlier. Both compute from where the drag began plus the delta, so they pass absolute values now
and the reducer stays pure.

## Verified

- [x] `npm run check` passes — 267 tests, hook baseline within limit, build clean
- [x] 20 new tests, including the cases only reachable now: scene markers arriving after the
      video was removed are dropped rather than inventing an overlay to hold them; a track
      dragged before zero stops at zero and keeps its length rather than being squashed; the
      audio offset never goes negative when the left edge is dragged past the start of the source

## Needs looking at

The reducer cannot tell whether the wiring is right, so this needs the audio and video tracks
exercised by hand:

1. Load audio — track appears, right length, plays
2. **Drag** the audio track along the timeline; **trim both edges**. The left edge should scrub
   into the source (the audio under the playhead stays the same sound), the right edge should
   just shorten
3. Load a video overlay, drag it, let scene detection finish — markers should appear
4. Remove the audio, then the video; the other should be unaffected each time
5. Save a project with both, reopen it — both tracks should come back where they were
6. New project — both gone

## Left out

Extracting project I/O and media import, which is the rest of #3. This was the prerequisite:
those blocks need these setters, and threading five of them by hand was the thing making the
extraction pointless.
