### PR TITLE
feat: add a switch to draw without pen pressure

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -290,6 +290,12 @@ export default function App() {
         else setPickingColor(true);
     };
     const [brushSize, setBrushSize] = useState(5);
+    // Pen pressure. Off means an even line however hard the pen is pressed - wanted for lineart,
+    // and for pens that report pressure unevenly.
+    const [pressureOn, setPressureOn] = useState(() => {
+        try { return localStorage.getItem('mv_pressure') !== 'off'; } catch { return true; }
+    });
+    useEffect(() => { try { localStorage.setItem('mv_pressure', pressureOn ? 'on' : 'off'); } catch { } }, [pressureOn]);
     const [eraserSize, setEraserSize] = useState(20);
     const [opacity, setOpacity] = useState(1.0);
     const [expandedCuts, setExpandedCuts] = useState(new Set());
@@ -1831,7 +1837,15 @@ export default function App() {
     };
     const onLayerDragEnd = () => { setDragLayerInfo(null); setDropInfo(null); };
 
-    const getPos = (e) => { const c = canvasRef.current, r = c.getBoundingClientRect(); return { x: (e.clientX - r.left) * (c.width / r.width), y: (e.clientY - r.top) * (c.height / r.height), pressure: e.pressure > 0 ? e.pressure : 0.5 }; };
+    // Pressure is flattened here rather than at render time, so it is baked into the stroke and
+    // the drawing keeps the shape it had when it was made. Turning the preference off later does
+    // not go back and change work that is already on the canvas.
+    // 0.5 is the neutral value the renderer treats as "no pressure information".
+    const getPos = (e) => {
+        const c = canvasRef.current, r = c.getBoundingClientRect();
+        const pressure = pressureOn && e.pressure > 0 ? e.pressure : 0.5;
+        return { x: (e.clientX - r.left) * (c.width / r.width), y: (e.clientY - r.top) * (c.height / r.height), pressure };
+    };
     // Render only the in-progress stroke on the overlay canvas — one stroke, no full-layer rebuild.
     // Live preview while drawing. This used to re-smooth and redraw the entire stroke on every
     // pointer move: the cost of one redraw grew with the length of the line and the total grew
@@ -2451,14 +2465,14 @@ export default function App() {
             case 'rough':
             case 'calligraphy': {
                 // Draw on the live overlay only — no layer-state writes per move (that was the lag).
-                liveStrokeRef.current = { id: Date.now(), tool: etool, color, opacity, size: brushSize, points: [pos], pen: e.pointerType === 'pen' };
+                liveStrokeRef.current = { id: Date.now(), tool: etool, color, opacity, size: brushSize, points: [pos], pen: pressureOn && e.pointerType === 'pen' };
                 liveDrawnRef.current = 0; renderLiveStroke(true);
                 break;
             }
             case 'line': {
                 // Line ruler: the start is pinned and only the end follows, giving a two-point line.
                 lineStartRef.current = pos;
-                liveStrokeRef.current = { id: Date.now(), tool: 'brush', color, opacity, size: brushSize, points: [pos, { ...pos }], pen: e.pointerType === 'pen' };
+                liveStrokeRef.current = { id: Date.now(), tool: 'brush', color, opacity, size: brushSize, points: [pos, { ...pos }], pen: pressureOn && e.pointerType === 'pen' };
                 liveDrawnRef.current = 0; renderLiveStroke(true);
                 break;
             }
@@ -3732,7 +3746,8 @@ export default function App() {
             rulerMode={rulerMode} setRulerMode={setRulerMode} commitCurve={commitCurve}
             mosaicBlock={mosaicBlock} setMosaicBlock={setMosaicBlock}
             brushSize={brushSize} setBrushSize={setBrushSize}
-            eraserSize={eraserSize} setEraserSize={setEraserSize} />
+            eraserSize={eraserSize} setEraserSize={setEraserSize}
+            pressureOn={pressureOn} setPressureOn={setPressureOn} />
     );
 
     const colorPanelEl = (

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -510,6 +510,8 @@ const EN = {
     '추가': 'Add',
     '끄기': 'Off',
     '켜기': 'On',
+    '필압': 'Pressure',
+    '끄면 세게 눌러도 굵기가 일정합니다. 이미 그린 선은 그대로입니다.': 'Off draws an even line however hard you press. Strokes already drawn are unchanged.',
     '그리는 중…': 'Drawing…',
     '(없음)': '(none)',
     '사용한': 'used',

--- a/src/ui/ToolsPanel.jsx
+++ b/src/ui/ToolsPanel.jsx
@@ -20,6 +20,7 @@ function ToolSettings({
     mosaicBlock = undefined, setMosaicBlock = undefined,
     brushSize = undefined, setBrushSize = undefined,
     eraserSize = undefined, setEraserSize = undefined,
+    pressureOn = true, setPressureOn = undefined,
 }) {
     if (tool === 'soft') {
         return (<>
@@ -75,6 +76,14 @@ function ToolSettings({
             ))}
         </div>
         <input type="range" min="1" max="80" value={Math.min(80, curSize)} onChange={e => setSize(+e.target.value)} className="v-slider" disabled={isSelectionTool} />
+        {/* The eraser takes its size from the same control but does not vary with pressure, so
+            offering the switch there would be a control that does nothing. */}
+        {tool !== 'eraser' && (
+            <label className="te-check" style={{ justifyContent: 'center', marginTop: 2 }}
+                title={tr('끄면 세게 눌러도 굵기가 일정합니다. 이미 그린 선은 그대로입니다.')}>
+                <input type="checkbox" checked={!!pressureOn} onChange={e => setPressureOn(e.target.checked)} /> {tr('필압')}
+            </label>
+        )}
     </>);
 }
 
@@ -84,6 +93,7 @@ export function ToolsPanel({
     globalUndo, globalRedo, handleClearCut, doTween,
     hasLassoClip, pasteLassoSelection, pickingColor, pickColor, isSelectionTool,
     color, applyColor, opacity, setOpacity,
+    pressureOn = true, setPressureOn = undefined,
     ...settings
 }) {
     return (
@@ -111,7 +121,7 @@ export function ToolsPanel({
             <div className="tool-divider" />
             <input type="color" className="color-picker" value={color} onChange={e => applyColor(e.target.value)} title={tr('색상')} disabled={isSelectionTool} />
             <div className="slider-wrap">
-                <ToolSettings tool={tool} isSelectionTool={isSelectionTool} {...settings} />
+                <ToolSettings tool={tool} isSelectionTool={isSelectionTool} pressureOn={pressureOn} setPressureOn={setPressureOn} {...settings} />
             </div>
             <div className="slider-wrap">
                 <span className="slider-label">Opacity</span>

--- a/src/ui/ToolsPanel.jsx
+++ b/src/ui/ToolsPanel.jsx
@@ -76,14 +76,13 @@ function ToolSettings({
             ))}
         </div>
         <input type="range" min="1" max="80" value={Math.min(80, curSize)} onChange={e => setSize(+e.target.value)} className="v-slider" disabled={isSelectionTool} />
-        {/* The eraser takes its size from the same control but does not vary with pressure, so
-            offering the switch there would be a control that does nothing. */}
-        {tool !== 'eraser' && (
-            <label className="te-check" style={{ justifyContent: 'center', marginTop: 2 }}
-                title={tr('끄면 세게 눌러도 굵기가 일정합니다. 이미 그린 선은 그대로입니다.')}>
-                <input type="checkbox" checked={!!pressureOn} onChange={e => setPressureOn(e.target.checked)} /> {tr('필압')}
-            </label>
-        )}
+        {/* The eraser is included: its width goes through the same pressure term as a brush
+            (canvasUtils, `s.size * (hasPressure ? pr * 2 : 1)`), so an even eraser is exactly as
+            useful as an even line. */}
+        <label className="te-check" style={{ justifyContent: 'center', marginTop: 2 }}
+            title={tr('끄면 세게 눌러도 굵기가 일정합니다. 이미 그린 선은 그대로입니다.')}>
+            <input type="checkbox" checked={!!pressureOn} onChange={e => setPressureOn(e.target.checked)} /> {tr('필압')}
+        </label>
     </>);
 }
 


### PR DESCRIPTION
## What / why

Closes #9

A `필압 / Pressure` checkbox in the TOOLS panel, under the size control. Remembered between
sessions like the other drawing preferences.

**Where the flattening happens matters.** It is done in `getPos`, where the pressure is read,
rather than at render time — so it is baked into the stroke and the drawing keeps the shape it
had when it was made. Turning the preference off later does not reach back and change work
already on the canvas, which is not what a preference should do. `0.5` is the value the renderer
already treats as "no pressure information", so nothing downstream needed changing.

**The `pen` flag had to follow too.** A stroke with `s.pen === true` is trusted to carry pressure
regardless of its values (`canvasUtils.js:704`), so leaving it set would have kept pressure on
for the one device the switch exists for.

The switch is hidden for the eraser: it takes its size from the same control but does not vary
with pressure, and a control that does nothing is worse than no control.

## Verified

- [x] `npm run check` passes — 247 tests, hook baseline within limit, build clean
- [ ] Needs a pen — I cannot generate real pressure values

No unit test here: the change is one conditional at the point of capture, and extracting it to
test `a && b > 0 ? b : 0.5` would be ceremony. The behaviour worth checking needs a real pen.

## Needs looking at

**On the tablet, with the S Pen:**

1. Pressure **on** (default) — draw hard and soft, the line should still thin and swell as before
2. Pressure **off** — the same stroke should come out one even width
3. Reload the page — the setting should still be off
4. The strokes drawn in step 1 should look exactly as they did; turning the switch off must not
   change existing artwork
5. Switch to the eraser — the checkbox should not be there

## Note

Branched from `main` while #8 is still open. Both touch `App.jsx` but in different places
(state declarations vs `getPos`), so no conflict is expected — whichever merges second may still
want a glance.
