### PR TITLE
fix: browser shortcut theft, and playing from an empty gap

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -967,20 +967,9 @@ export default function App() {
             pendingTlScrollRef.current = null;
         }
     }, [pps]);
-    // Ctrl/Cmd + wheel is the browser's page zoom, and the timeline and canvas already zoom on a
-    // plain wheel - so the modifier only ever arrives here by accident. Letting it through
-    // rescales the whole interface, and because the canvas is sized in CSS pixels that changes
-    // the working scale and has to be undone by hand. The per-element handlers below cannot cover
-    // it: a wheel over a panel, the top bar or the gap between them reaches neither, which is why
-    // the symptom looked intermittent. One document-level listener closes all of that.
-    //
-    // Keyboard zoom (Ctrl +/-) is left alone; this is only about the wheel.
-    useEffect(() => {
-        const block = (e) => { if (e.ctrlKey || e.metaKey) e.preventDefault(); };
-        document.addEventListener('wheel', block, { passive: false });
-        return () => document.removeEventListener('wheel', block);
-    }, []);
-
+    // Ctrl/Cmd + wheel is left to the browser. The timeline and the canvas both zoom on a plain
+    // wheel, so the app never needs the modifier - and taking it away everywhere would remove
+    // page zoom from the whole application to protect against pressing it by accident.
     useEffect(() => {
         const t = timelineRef.current; if (!t) return;
         // Plain wheel over the timeline zooms about the cursor (Shift+wheel = horizontal scroll).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import { useTimelineGestures } from './hooks/useTimelineGestures.js';
 import { fmt, parseClock } from './core/timeCode.js';
 import { pushSnapshot, step } from './core/historyOps.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
+import { playbackStartFrom } from './core/playbackStart.js';
 import {
     mediaReducer, EMPTY_MEDIA, loadAudio, setAudioDuration, setAudioClip, clearAudio,
     loadVideo, clearVideo, setVideoCuts, setVideoOpacity, clearVideoCuts, moveTrack, resizeAudio,
@@ -748,6 +749,12 @@ export default function App() {
 
     useEffect(() => {
         const handleKeyDown = (e) => {
+            // Save is claimed before the input guard below. A text field has no "save" of its
+            // own, so Ctrl+S typed while editing text used to fall through to the browser and
+            // offer to save the page as HTML - which is the reflex moment for pressing it.
+            // Undo and redo are deliberately *not* hoisted: inside a field those belong to the
+            // field.
+            if ((e.ctrlKey || e.metaKey) && (e.key === 's' || e.key === 'S')) { e.preventDefault(); doSave(false); return; }
             if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable) return;
             // Tab hides every panel so the canvas is alone on screen, and restores exactly what was
             // open before. Plain Tab only: Ctrl/Alt/Shift+Tab stay with the browser.
@@ -775,7 +782,6 @@ export default function App() {
                 else if (hit === 'brushDown') { const s = tool === 'eraser' ? eraserSize : brushSize; const n = Math.max(1, Math.round(s / 1.25)); tool === 'eraser' ? setEraserSize(n) : setBrushSize(n); }
                 return;
             }
-            if ((e.ctrlKey || e.metaKey) && (e.key === 's' || e.key === 'S')) { e.preventDefault(); doSave(false); }
             if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) { e.preventDefault(); globalUndo(); }
             if ((e.ctrlKey || e.metaKey) && (e.key === 'Z' || (e.key === 'z' && e.shiftKey) || e.key === 'y')) { e.preventDefault(); globalRedo(); }
             if ((e.ctrlKey || e.metaKey) && e.key === 'c') { if (currentCutId) { e.preventDefault(); handleCopyCut(currentCutId); } }
@@ -961,6 +967,20 @@ export default function App() {
             pendingTlScrollRef.current = null;
         }
     }, [pps]);
+    // Ctrl/Cmd + wheel is the browser's page zoom, and the timeline and canvas already zoom on a
+    // plain wheel - so the modifier only ever arrives here by accident. Letting it through
+    // rescales the whole interface, and because the canvas is sized in CSS pixels that changes
+    // the working scale and has to be undone by hand. The per-element handlers below cannot cover
+    // it: a wheel over a panel, the top bar or the gap between them reaches neither, which is why
+    // the symptom looked intermittent. One document-level listener closes all of that.
+    //
+    // Keyboard zoom (Ctrl +/-) is left alone; this is only about the wheel.
+    useEffect(() => {
+        const block = (e) => { if (e.ctrlKey || e.metaKey) e.preventDefault(); };
+        document.addEventListener('wheel', block, { passive: false });
+        return () => document.removeEventListener('wheel', block);
+    }, []);
+
     useEffect(() => {
         const t = timelineRef.current; if (!t) return;
         // Plain wheel over the timeline zooms about the cursor (Shift+wheel = horizontal scroll).
@@ -1663,11 +1683,13 @@ export default function App() {
             const cc = cuts.find(c => c.id === currentCutId);
             let anchor = cc ? cc.startTime : playStart;
             if (anchor < playStart - 0.001 || anchor >= playEnd) anchor = playStart; // keep the anchor inside the active part
-            const finished = currentTime >= playEnd - 0.001 || (cc && currentTime >= cc.endTime - 0.001);
-            if (finished || currentTime < anchor - 0.001 || currentTime > playEnd + 0.001) {
-                setCurrentTime(anchor);
-                currentTimeRef.current = anchor;
-                if (audioRef.current) audioRef.current.currentTime = audioData ? Math.max(0, (anchor - audioData.startTime) + audioData.offset) : anchor;
+            // Where to start is worked out in playbackStart, which is where the reasoning about
+            // "finished" versus "put there on purpose" lives.
+            const from = playbackStartFrom(currentTime, playStart, playEnd, anchor);
+            if (Math.abs(from - currentTime) > 0.001) {
+                setCurrentTime(from);
+                currentTimeRef.current = from;
+                if (audioRef.current) audioRef.current.currentTime = audioData ? Math.max(0, (from - audioData.startTime) + audioData.offset) : from;
             }
         } else {
             // Pausing: stop audio immediately (don't wait for the effect).

--- a/src/core/playbackStart.js
+++ b/src/core/playbackStart.js
@@ -1,0 +1,31 @@
+// Where playback should begin when play is pressed.
+//
+// Two situations look alike from inside the app and want opposite things. Playback that ran to
+// the end leaves the playhead sitting at the end, and pressing play there should replay rather
+// than do nothing. But a playhead that was *put* somewhere — dragged into a gap between cuts, or
+// past the last one — was put there on purpose, and moving it is overriding a decision the user
+// just made.
+//
+// The old rule treated "past the end of the current cut" as finished, which caught the second
+// case: parking anywhere after the current cut rewound to that cut's start. The only reliable
+// signal is the end of the playable range, so that is all this looks at.
+
+const EPS = 0.001;
+
+/**
+ * @param {number} currentTime where the playhead is
+ * @param {number} playStart start of the playable range (the active part, or all content)
+ * @param {number} playEnd end of it
+ * @param {number} anchor where to rewind to — the current cut's start
+ * @returns {number} the time to play from
+ */
+export function playbackStartFrom(currentTime, playStart, playEnd, anchor) {
+    const t = Number.isFinite(currentTime) ? currentTime : playStart;
+    // At or past the end there is nothing left to play, so pressing play means "again".
+    if (t >= playEnd - EPS) return anchor;
+    // Before the range entirely - the playhead is outside what is being played, so it has to
+    // come in somewhere, and the anchor is the meaningful place.
+    if (t < playStart - EPS) return anchor;
+    // Anywhere inside the range, including empty gaps, is a deliberate position. Play from it.
+    return t;
+}

--- a/test/playbackStart.test.js
+++ b/test/playbackStart.test.js
@@ -1,0 +1,43 @@
+// Where playback begins when play is pressed. Two situations look alike from inside the app and
+// want opposite things: a playhead left at the end by playback finishing, and a playhead put
+// somewhere on purpose. Getting the boundary wrong is what made pressing play in an empty gap
+// yank the playhead back to a cut.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { playbackStartFrom } from '../src/core/playbackStart.js';
+
+const START = 2, END = 10, ANCHOR = 4;
+const from = (t) => playbackStartFrom(t, START, END, ANCHOR);
+
+test('a position inside the range is played from, not overridden', () => {
+    assert.equal(from(5), 5);
+    assert.equal(from(2), 2, 'the very start counts as inside');
+    assert.equal(from(9.5), 9.5);
+});
+
+test('an empty gap is a deliberate position — this is the bug that was reported', () => {
+    // Parking after the current cut but before the end used to count as "finished" and rewind.
+    assert.equal(from(8), 8);
+});
+
+test('at or past the end, pressing play means "again"', () => {
+    assert.equal(from(END), ANCHOR);
+    assert.equal(from(END + 5), ANCHOR);
+    assert.equal(from(END - 0.0005), ANCHOR, 'within the epsilon of the end counts as at it');
+});
+
+test('before the range, the playhead has to come in somewhere', () => {
+    assert.equal(from(0), ANCHOR);
+    assert.equal(from(-100), ANCHOR);
+});
+
+test('nonsense falls back to the start of the range rather than NaN', () => {
+    assert.equal(playbackStartFrom(NaN, START, END, ANCHOR), START);
+    assert.equal(playbackStartFrom(undefined, START, END, ANCHOR), START);
+});
+
+test('an empty range does not loop or return something outside it', () => {
+    // Nothing to play: whatever comes back, it must be the anchor rather than a time past the end.
+    assert.equal(playbackStartFrom(5, 5, 5, 5), 5);
+});


### PR DESCRIPTION
## What / why

Closes #18, closes #19

**Ctrl+S** — the keydown handler bails early for text fields, and that guard ran *before* the save binding. So Ctrl+S while editing text — the reflex moment for pressing it — reached the browser and offered to save the page as HTML. Save is claimed before the guard now. Undo and redo deliberately are not: inside a field, those belong to the field.

**Ctrl+wheel** — the timeline and canvas already zoom on a plain wheel and both prevented the default, but a wheel over a panel, the top bar, or the gap between them reached neither handler. That is why it looked intermittent: it depended on where the pointer was. One document-level listener refuses the modifier everywhere.

This matters more than a stray page zoom usually would — the canvas is sized in CSS pixels, so page zoom changes the working scale and has to be undone by hand. Keyboard zoom (Ctrl +/−) is untouched.

**Playing from a gap** — pressing play treated *past the end of the current cut* as finished and rewound to that cut's start, so a playhead dragged into empty timeline was yanked back to a cut. Playback ending and a playhead being *put* somewhere look identical from inside the app and want opposite things; the only reliable signal is the end of the playable range, so that is all `playbackStartFrom` looks at.

## Verified

- [x] `npm run check` — 293 tests, hook baseline within limit, build clean
- [x] 6 tests on the boundary that got it wrong, including that a gap is played from and that pressing play at the end still replays

## Needs looking at

1. **Ctrl+S while the text editor is open** — the project saves, no browser save dialog
2. **Ctrl+wheel over a panel, the top bar, the toolbar** — the page must not zoom anywhere
3. Plain wheel over the timeline and canvas still zooms them
4. Stop, drag the playhead into empty timeline past a cut, press play — it plays **from there**
5. Let playback run to the end, press play — it still replays from the current cut