### PR TITLE
fix: layer merge, project-scoped video import, and a misdiagnosed YouTube 403

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -256,6 +256,14 @@ const friendlyYtError = (err) => {
     if (e.includes('geo') || e.includes('country')) return '지역 제한 영상입니다.';
     if (e.includes('live')) return '라이브 스트림은 지원하지 않습니다.';
     if (e.includes('requested format') || e.includes('no video formats')) return '받을 수 있는 단일 파일 포맷이 없습니다 (ffmpeg 없이 병합 불가).';
+    // YouTube signs its media URLs with a challenge that yt-dlp solves in JavaScript. When the
+    // installed yt-dlp is too old to solve the current one it fetches an unsigned URL and the
+    // download comes back 403 - extraction having succeeded moments earlier, which is what makes
+    // this look like a network fault. It is not: it is a version problem, and saying "network
+    // error" sends people to check their connection instead of running one command.
+    if (e.includes('403') || e.includes('signature solving failed') || e.includes('n challenge')) {
+        return 'yt-dlp가 최신이 아니라 유튜브가 다운로드를 거부했습니다 (403). 서버에서 yt-dlp를 업데이트하세요: python -m pip install -U yt-dlp';
+    }
     if (e.includes('unable to download') || e.includes('network') || e.includes('timed out')) return '네트워크 오류로 받지 못했습니다.';
     return '영상 받기 실패: ' + err.slice(-300);
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useLayoutEffect } from 'react';
-import { Plus, Trash2, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, ClipboardPaste, GitBranch, Move, Type, Cloud, Film, Repeat, Minus, Waves, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw } from 'lucide-react';
+import { Plus, Trash2, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, ClipboardPaste, GitBranch, Move, Type, Cloud, Film, Repeat, Minus, Waves, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw, ArrowDownToLine } from 'lucide-react';
 import './App.css';
 import { saveAutosave, loadAutosave, saveProject, loadProject, listProjects, deleteProject, autosaveKey } from './db';
 import { CutAnimPanel, LayerAnimPanel, JitterPanel } from './ui/AnimPanels';
@@ -30,7 +30,7 @@ import {
     cutsReducer, replaceCuts, addCuts, updateCut, setCutAnim, clearCut,
     updateLayer, setLayerAnim, moveLayers, upsertText, moveText, deleteText, toggleTextVisible as toggleTextVisibleAction,
     assignPartTo, renamePart as renamePartAction, ungroupPart as ungroupPartAction, removeBatch,
-    insertCutsShifting, deleteTrack, moveCutGroup, replaceBatchCuts, patchCut, patchCuts,
+    insertCutsShifting, deleteTrack, moveCutGroup, replaceBatchCuts, mergeLayerDown, patchCut, patchCuts,
 } from './core/cutsReducer.js';
 import { measureTextBox as measureTextBoxPure, textNeedsBox, drawTextObject } from './canvas/textRender.js';
 import { migrateCuts, projectSettings, makeLoadProgress } from './core/projectFormat.js';
@@ -3720,6 +3720,12 @@ export default function App() {
                                 title={layer.roughen ? tr('자글자글 모션 (강도 {0}) — 클릭: 설정 열기', layer.roughen) : tr('자글자글 모션 설정 (이미 그린 선이 제자리에서 부글거림)')}
                                 onClick={e => toggleJitterPanel(e, cut.id, layer.id)}>
                                 <Waves size={11} />
+                            </button>
+                        )}
+                        {!isFolder && (
+                            <button className="icon-btn" title={tr('아래 레이어와 병합')}
+                                onClick={e => { e.stopPropagation(); dispatchCuts(mergeLayerDown(cut.id, layer.id, flattenLayersInUiOrder)); }}>
+                                <ArrowDownToLine size={11} />
                             </button>
                         )}
                         {!isFolder && (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3579,7 +3579,7 @@ export default function App() {
             openVideoImport(file, 'YT ' + (url.match(/(?:v=|youtu\.be\/|shorts\/)([\w-]{6,})/)?.[1] || tr('영상')), { url, key: 'yt:' + url });
         } catch (e) {
             console.error('[import]', e);
-            setAppError(tr('영상 가져오기 실패: ') + e.message + '\n' + tr('(서버에 yt-dlp 설치 필요)'));
+            setAppError(tr('영상 가져오기 실패: ') + e.message);
         } finally { setVideoBusy(null); }
     };
 
@@ -3682,7 +3682,7 @@ export default function App() {
             if (!res.ok) { const j = await res.json().catch(() => ({})); throw new Error(j.error || ('HTTP ' + res.status)); }
             const blob = await res.blob();
             loadAudioUrl(URL.createObjectURL(blob), tr('유튜브 음원'));
-        } catch (e) { alert(tr('음원 추출 실패: ') + e.message + '\n' + tr('(서버에 yt-dlp + ffmpeg 설치 필요)')); }
+        } catch (e) { alert(tr('음원 추출 실패: ') + e.message); }
     };
     const handleExport = () => {
         const canvas = canvasRef.current;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -408,6 +408,14 @@ export default function App() {
     const [localProjects, setLocalProjects] = useState(null); // IndexedDB project picker
     const localIdRef = useRef(null);
     const localNameRef = useRef('');
+    // Which document is loaded, as a number that changes whenever the whole thing is replaced.
+    //
+    // Long jobs - extracting frames from a video, detecting scenes - can be sent to the
+    // background and finish minutes later, by which time another project may be open. They
+    // captured no notion of *which* project they were started for, so the result landed in
+    // whatever was on screen: frames from project 1 appearing in project 2. Each job takes a copy
+    // of this when it starts and drops its result if it no longer matches.
+    const docEpochRef = useRef(0);
     const serverIdRef = useRef(null);
     const serverNameRef = useRef('');
     const cutDragMovedRef = useRef(false); // distinguishes a click (select) from a real drag (move)
@@ -1238,6 +1246,7 @@ export default function App() {
         }
         // Older files are brought up to the current shape in projectFormat, where the renames and
         // added fields are written down and tested.
+        docEpochRef.current++;   // opening a project: anything still running belongs to the old one
         dispatchCuts(replaceCuts(migrateCuts(data.cuts)));
         setActivePartId(null);
         const s = projectSettings(data);
@@ -1327,6 +1336,7 @@ export default function App() {
     const resetToEmpty = () => {
         fileHandleRef.current = null;
         bitmapStoreRef.current.clear();
+        docEpochRef.current++;   // starting over
         dispatchCuts(replaceCuts([{ id: 1, name: 'Cut 1', startTime: 0, endTime: 1, track: 0, layers: [mkLayer(1)], activeLayerId: 1, texts: [] }]));
         setNumTracks(2); setCurrentCutId(1); setCurrentTime(0); setExpandedCuts(new Set());
         setCopiedCut(null); setSelectedCutIds(new Set()); setActivePartId(null);
@@ -3457,6 +3467,7 @@ export default function App() {
         // detectSceneCuts polls shouldStop between frames, so cancelling takes effect within one
         // seek rather than running the scan to the end and throwing the answer away.
         sceneStopRef.current = false;
+        const startedFor = docEpochRef.current;
         setSceneDetect({ done: 0, total: 0 });
         detectSceneCuts(blob, {
             start: rStart, end: rEnd, threshold,
@@ -3465,7 +3476,9 @@ export default function App() {
         })
             // A cancelled scan returns what it found so far; keeping a partial set of markers
             // would look like a finished detection that missed most of the cuts.
-            .then(cuts => { if (!sceneStopRef.current) dispatchMedia(setVideoCuts(cuts, cs, co)); })
+            // Same reasoning as the frame import: a scan of a long video outlives a project
+            // switch, and its markers describe a video that is no longer loaded.
+            .then(cuts => { if (!sceneStopRef.current && docEpochRef.current === startedFor) dispatchMedia(setVideoCuts(cuts, cs, co)); })
             .catch(() => { })
             .finally(() => { setSceneDetect(null); sceneStopRef.current = false; });
     };
@@ -3574,6 +3587,7 @@ export default function App() {
     const runVideoImport = async () => {
         const cfg = videoImport;
         if (!cfg?.file) return;
+        const startedFor = docEpochRef.current;
         setVideoBusy({ done: 0, total: 0 });
         try {
             const rStart = cfg.rangeOn ? parseClock(cfg.startText) : 0;
@@ -3596,6 +3610,14 @@ export default function App() {
                 shouldStop: () => videoStopRef.current,
             });
             if (!frames.length) { alert(tr('추출된 프레임이 없습니다.')); return; }
+            // Extraction can take minutes and can be left running in the background, so the
+            // project may have been swapped underneath it. Dropping the frames is the only safe
+            // answer: putting them in the project that happens to be open now would be writing
+            // into a document the user never asked to change.
+            if (docEpochRef.current !== startedFor) {
+                setAppError(tr('다른 프로젝트를 여는 동안 영상 프레임 추출이 끝나 결과를 버렸습니다. 프로젝트를 연 뒤 다시 가져오세요.'));
+                return;
+            }
             // Re-importing the same source replaces its old frames instead of piling up duplicates.
             const srcKey = cfg.srcKey;
             const kept = cuts.filter(c => c.videoSrc !== srcKey);

--- a/src/core/cutsReducer.js
+++ b/src/core/cutsReducer.js
@@ -19,7 +19,7 @@
 // `patchCut` remains for the handful of operations that are genuinely one-off. Reach for a named
 // action first; a lambda here is a note that something has not been given a name yet.
 
-import { offsetLayers } from './layerOps.js';
+import { offsetLayers, mergeDown } from './layerOps.js';
 import { assignPart, renamePartIn, ungroupPartIn, removeVideoBatch } from './partOps.js';
 import { ANIM_DEFAULT, LAYER_ANIM_DEFAULT, safeArray } from '../canvas/canvasUtils.js';
 
@@ -40,6 +40,8 @@ export const clearCut = (cutId) => ({ type: 'clearCut', cutId });
 export const updateLayer = (cutId, layerId, patch) => ({ type: 'updateLayer', cutId, layerId, patch });
 /** Merge into a layer's animation, over the defaults. */
 export const setLayerAnim = (cutId, layerId, patch) => ({ type: 'setLayerAnim', cutId, layerId, patch });
+/** Flatten a layer into the one below it. */
+export const mergeLayerDown = (cutId, layerId, flattenVisibleLeaves) => ({ type: 'mergeLayerDown', cutId, layerId, flattenVisibleLeaves });
 /** Shift whole layers (and optionally the cut's texts) by a pixel offset. Bumps rev. */
 export const moveLayers = (cutId, layerIds, dx, dy, withTexts) => ({ type: 'moveLayers', cutId, layerIds, dx, dy, withTexts });
 
@@ -112,6 +114,14 @@ export function cutsReducer(cuts, action) {
             // offsetLayers bumps rev, which is what stops the cached canvas drawing the layer at
             // its old position: only coordinates changed, and the cache signature cannot see that.
             return mapCut(list, action.cutId, c => ({ ...c, ...offsetLayers(c, action.layerIds, action.dx, action.dy, action.withTexts) }));
+
+        case 'mergeLayerDown':
+            return mapCut(list, action.cutId, c => {
+                const merged = mergeDown(c.layers, action.layerId, action.flattenVisibleLeaves);
+                // null means there was nothing underneath to merge into; leaving the cut alone is
+                // better than silently deleting the layer.
+                return merged ? { ...c, ...merged } : c;
+            });
 
         case 'upsertText':
             return mapCut(list, action.cutId, c => mapTexts(c, texts =>

--- a/src/core/layerOps.js
+++ b/src/core/layerOps.js
@@ -167,3 +167,48 @@ export function offsetLayers(cut, layerIds, dx, dy, withTexts) {
         texts: withTexts ? texts.map(t => ({ ...t, x: (t.x || 0) + dx, y: (t.y || 0) + dy })) : texts,
     };
 }
+
+/**
+ * Flatten a layer into the one below it.
+ *
+ * "Below" means the next drawable layer in UI order — folders are containers, not surfaces, so
+ * they are skipped as a target and refused as a source. The upper layer's strokes go after the
+ * lower one's, which is what keeps it looking the same: later strokes draw on top.
+ *
+ * Stroke bitmap ids are carried across unchanged rather than copied. The pixels have one owner
+ * either way, because the layer they came from is being removed in the same move — duplicating
+ * them here would leave the originals unreferenced and the collector would free them.
+ *
+ * @param {Array} layers the cut's layers, in UI order
+ * @param {any} layerId the layer to merge downwards
+ * @param {(layers: Array) => Array} flattenVisibleLeaves ordering helper (flattenLayersInUiOrder)
+ * @returns {{layers: Array, activeLayerId: any} | null} null when there is nothing to merge into
+ */
+export function mergeDown(layers, layerId, flattenVisibleLeaves) {
+    const list = Array.isArray(layers) ? layers : [];
+    const src = list.find(l => l.id === layerId);
+    if (!src || src.type === 'folder') return null;
+
+    // The order the user sees, which is what "the one below" means - not the array order, since
+    // nesting makes those differ.
+    const order = flattenVisibleLeaves(list).filter(l => l.type === 'layer');
+    const at = order.findIndex(l => l.id === layerId);
+    if (at < 0 || at + 1 >= order.length) return null;   // nothing underneath
+    const target = order[at + 1];
+
+    return {
+        layers: list
+            .filter(l => l.id !== layerId)
+            .map(l => l.id !== target.id ? l : ({
+                ...l,
+                // Visible, because merging into a hidden layer would make the work vanish.
+                visible: true,
+                rev: (l.rev || 0) + 1,
+                strokes: [...(l.strokes || []), ...(src.strokes || [])],
+                // Redo belongs to the layers as they were; those steps cannot be replayed onto
+                // the merged result.
+                redoStrokes: [],
+            })),
+        activeLayerId: target.id,
+    };
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -512,6 +512,7 @@ const EN = {
     '필압': 'Pressure',
     '농도': 'Opacity',
     '영상 설정': 'Video settings',
+    '다른 프로젝트를 여는 동안 영상 프레임 추출이 끝나 결과를 버렸습니다. 프로젝트를 연 뒤 다시 가져오세요.': 'The frame extraction finished after a different project was opened, so its frames were discarded rather than added to the wrong project. Import again with the project you want open.',
     '아래 레이어와 병합': 'Merge into the layer below',
     '도구 단축키': 'Tool shortcuts',
     '도구 단축키…': 'Tool shortcuts…',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -512,6 +512,7 @@ const EN = {
     '필압': 'Pressure',
     '농도': 'Opacity',
     '영상 설정': 'Video settings',
+    '아래 레이어와 병합': 'Merge into the layer below',
     '도구 단축키': 'Tool shortcuts',
     '도구 단축키…': 'Tool shortcuts…',
     '도구 기본값': 'Reset tool keys',

--- a/test/layerOps.test.js
+++ b/test/layerOps.test.js
@@ -4,7 +4,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { moveLayer, isDescendantOf, resolveDrawLayer, commitStroke, insertFill, offsetLayers } from '../src/core/layerOps.js';
+import { moveLayer, isDescendantOf, resolveDrawLayer, commitStroke, insertFill, offsetLayers, mergeDown } from '../src/core/layerOps.js';
 import { flattenLayersInUiOrder } from '../src/canvas/canvasUtils.js';
 
 // f1 > a, b   then c at the root
@@ -286,4 +286,85 @@ test('offsetLayers: does not mutate the cut it was given', () => {
 test('offsetLayers: a cut with nothing in it is not a special case for the caller', () => {
     assert.deepEqual(offsetLayers({}, ['a'], 1, 1, true), { layers: [], texts: [] });
     assert.deepEqual(offsetLayers(undefined, undefined, 1, 1, false), { layers: [], texts: [] });
+});
+
+// ── merging a layer down ───────────────────────────────────────────────────
+const stack = () => ([
+    { id: 'top', type: 'layer', parentId: null, visible: true, strokes: [{ id: 't1' }] },
+    { id: 'mid', type: 'layer', parentId: null, visible: true, strokes: [{ id: 'm1' }] },
+    { id: 'bot', type: 'layer', parentId: null, visible: true, strokes: [{ id: 'b1' }] },
+]);
+
+test('mergeDown: the upper layer goes away and its strokes land on top of the lower one', () => {
+    // Order matters: later strokes draw over earlier ones, so appending is what keeps the
+    // merged layer looking like the two did.
+    const out = mergeDown(stack(), 'top', flat);
+    assert.deepEqual(out.layers.map(l => l.id), ['mid', 'bot']);
+    assert.deepEqual(out.layers[0].strokes.map(s => s.id), ['m1', 't1']);
+    assert.equal(out.activeLayerId, 'mid', 'the surviving layer becomes the active one');
+});
+
+test('mergeDown: "below" follows what the user sees, not the array', () => {
+    const out = mergeDown(stack(), 'mid', flat);
+    assert.deepEqual(out.layers.map(l => l.id), ['top', 'bot']);
+    assert.deepEqual(out.layers[1].strokes.map(s => s.id), ['b1', 'm1']);
+});
+
+test('mergeDown: the bottom layer has nothing to merge into', () => {
+    // Returning null rather than deleting it: losing a layer to a misplaced click is expensive.
+    assert.equal(mergeDown(stack(), 'bot', flat), null);
+});
+
+test('mergeDown: a folder is neither a source nor a target', () => {
+    const withFolder = [
+        { id: 'f', type: 'folder', parentId: null, visible: true },
+        { id: 'a', type: 'layer', parentId: 'f', visible: true, strokes: [{ id: 'a1' }] },
+        { id: 'b', type: 'layer', parentId: null, visible: true, strokes: [{ id: 'b1' }] },
+    ];
+    assert.equal(mergeDown(withFolder, 'f', flat), null, 'a folder is a container, not a surface');
+    const out = mergeDown(withFolder, 'a', flat);
+    assert.deepEqual(out.layers.find(l => l.id === 'b').strokes.map(s => s.id), ['b1', 'a1'],
+        'the folder is skipped as a target');
+});
+
+test('mergeDown: merging into a hidden layer reveals it', () => {
+    // Otherwise the work disappears at the moment of merging, which reads as data loss.
+    const s = [
+        { id: 'top', type: 'layer', parentId: null, visible: true, strokes: [{ id: 't' }] },
+        { id: 'bot', type: 'layer', parentId: null, visible: false, strokes: [] },
+    ];
+    assert.equal(mergeDown(s, 'top', flat).layers[0].visible, true);
+});
+
+test('mergeDown: bumps rev and drops redo on the surviving layer', () => {
+    const s = [
+        { id: 'top', type: 'layer', parentId: null, visible: true, strokes: [{ id: 't' }] },
+        { id: 'bot', type: 'layer', parentId: null, visible: true, rev: 3, strokes: [], redoStrokes: [{ id: 'r' }] },
+    ];
+    const merged = mergeDown(s, 'top', flat).layers[0];
+    assert.equal(merged.rev, 4);
+    assert.deepEqual(merged.redoStrokes, [], 'those steps cannot be replayed onto the merged result');
+});
+
+test('mergeDown: bitmap ids are carried across, not copied', () => {
+    // The pixels keep one owner because the source layer is removed in the same move; copying
+    // would leave the originals unreferenced for the collector to free.
+    const s = [
+        { id: 'top', type: 'layer', parentId: null, visible: true, strokes: [{ id: 't', bitmapId: 'bmp' }] },
+        { id: 'bot', type: 'layer', parentId: null, visible: true, strokes: [] },
+    ];
+    assert.equal(mergeDown(s, 'top', flat).layers[0].strokes[0].bitmapId, 'bmp');
+});
+
+test('mergeDown: an unknown layer, or none at all, changes nothing', () => {
+    assert.equal(mergeDown(stack(), 'nope', flat), null);
+    assert.equal(mergeDown([], 'a', flat), null);
+    assert.equal(mergeDown(null, 'a', flat), null);
+});
+
+test('mergeDown: does not mutate the layers it was given', () => {
+    const before = stack();
+    const snapshot = JSON.stringify(before);
+    mergeDown(before, 'top', flat);
+    assert.equal(JSON.stringify(before), snapshot);
 });


### PR DESCRIPTION
Three things. Closes half of #22.

## The YouTube failure

Reported as every import failing with *network error — check yt-dlp and ffmpeg are installed*. Both were installed. Running the server's exact invocation reproduced it:

```
WARNING: Signature solving failed ... Ensure you have a supported JavaScript runtime
ERROR: unable to download video data: HTTP Error 403: Forbidden
```

Extraction succeeds; the **download** is refused. YouTube signs media URLs with a challenge solved in JavaScript, and a yt-dlp too old to solve the current one fetches an unsigned URL. Updating `2026.06.09 → 2026.08.19` fixed it outright — **an environment fix, not a code one.**

But two things in the code pointed the wrong way, and those are fixed here: the server matched `unable to download` and called it a network error, so an authentication refusal read as a connection fault; and the client appended *yt-dlp and ffmpeg must be installed* to every failure regardless of cause. A 403 now says which command to run.

## Video import belongs to its project

Extraction can be sent to the background and finish minutes later. Nothing recorded which project it started in, so the frames went into whatever document was on screen — **frames from project 1 landing in project 2**, as reported. Scene detection has the same shape.

Both capture a document token on start and discard their result if it no longer matches. Discarding is the only safe answer: writing into a document the user never asked to change is not obviously recoverable once it has autosaved.

## Merge a layer down

Clipping is left open — it needs work inside the compositing loop where per-layer animation, sway and masking interleave. Merging is a pure transform with 9 tests; the rules are in the commit.

## Verified

- [x] `npm run check` — 302 tests, build clean
- [x] The 403 reproduced and confirmed fixed by the update (3.27 MiB downloaded)

## Needs looking at

1. **Restart the API server** so it picks up the new yt-dlp, then try a YouTube import
2. Start a long frame extraction, send it to the background, open another project — the frames should be **discarded with a message**, not added
3. Merge two layers (⤓) — the result should look identical to before