### PR TITLE
refactor: single definitions for storage mode, timeline zoom, and the modal shell

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -888,6 +888,8 @@ canvas {
     align-items: center;
 }
 
+/* The width here is also TRACK_GUTTER in core/timelineZoom.js, which every conversion between a
+   screen x and a time subtracts. Change one and the playhead stops landing where it should. */
 .tl-track-label {
     position: sticky;
     left: 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -999,7 +999,10 @@ export default function App() {
         };
         t.addEventListener('wheel', h, { passive: false });
         return () => t.removeEventListener('wheel', h);
-    }, []);
+        // Re-attach when the timeline is shown again. It is inside `showBottom &&`, so hiding it
+        // unmounts the element and showing it mounts a new one - an empty dependency list would
+        // leave these listeners on the detached node and wheel zoom silently dead after a Tab.
+    }, [showBottom]);
 
     // Two-finger pinch-zoom on the timeline, intercepted in the CAPTURE phase so it works
     // even over cut blocks (which stop propagation / capture the pointer for dragging).
@@ -1043,7 +1046,8 @@ export default function App() {
             el.removeEventListener('pointerup', up, opt);
             el.removeEventListener('pointercancel', up, opt);
         };
-    }, []);
+        // As above: the element is replaced whenever the timeline is hidden and shown.
+    }, [showBottom]);
 
     useEffect(() => {
         if (!resizingData && !draggingCutData) return;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ import {
 import { measureTextBox as measureTextBoxPure, textNeedsBox, drawTextObject } from './canvas/textRender.js';
 import { migrateCuts, projectSettings, makeLoadProgress } from './core/projectFormat.js';
 import { frameStorage, frameLoad, imageExt, imageExtFromType, audioExt, videoExt } from './core/projectAssets.js';
+import { xAtTime, timeAtX, zoomAnchored, pinchZoom } from './core/timelineZoom.js';
 import { unusedBitmapIds } from './core/bitmapRefs.js';
 import { dragCut, resizeCut } from './core/cutOps.js';
 import {
@@ -892,7 +893,7 @@ export default function App() {
                 syncVideo(t, true);
                 currentTimeRef.current = t;
                 paintFrameRef.current?.(t, true);
-                if (playheadRef.current) playheadRef.current.style.left = `${t * pps + 60}px`;
+                if (playheadRef.current) playheadRef.current.style.left = `${xAtTime(t, pps)}px`;
                 reqRef.current = requestAnimationFrame(step);
                 return;
             }
@@ -919,7 +920,7 @@ export default function App() {
             }
             currentTimeRef.current = t;
             paintFrameRef.current?.(t, true);                                   // 60fps imperative canvas
-            if (playheadRef.current) playheadRef.current.style.left = `${t * pps + 60}px`; // 60fps imperative playhead
+            if (playheadRef.current) playheadRef.current.style.left = `${xAtTime(t, pps)}px`; // 60fps imperative playhead
             if (now - lastPrefetch > 120) { lastPrefetch = now; prefetchRef.current?.(t, true); } // decode ahead of the REAL playhead
             if (now - lastUiSync > 200) { lastUiSync = now; setCurrentTime(t); } // ~5Hz React sync — keep re-renders off the rAF thread so prefetch keeps up
             reqRef.current = requestAnimationFrame(step);
@@ -973,16 +974,15 @@ export default function App() {
         const el = timelineRef.current; if (!el) return;
         const localX = clientX - el.getBoundingClientRect().left;
         setPps(prev => {
-            const next = Math.max(10, Math.min(300, prev * factor));
-            if (next === prev) return prev;
-            const time = (el.scrollLeft + localX - 60) / prev;
-            pendingTlScrollRef.current = time * next + 60 - localX;
-            return next;
+            const r = zoomAnchored(prev, factor, el.scrollLeft, localX);
+            if (!r) return prev; // already at the limit - leave the scroll where it is
+            pendingTlScrollRef.current = r.scrollLeft;
+            return r.pps;
         });
     };
     useLayoutEffect(() => {
         if (pendingTlScrollRef.current != null && timelineRef.current) {
-            timelineRef.current.scrollLeft = Math.max(0, pendingTlScrollRef.current);
+            timelineRef.current.scrollLeft = pendingTlScrollRef.current;
             pendingTlScrollRef.current = null;
         }
     }, [pps]);
@@ -1014,8 +1014,8 @@ export default function App() {
             if (pts.size === 2) {
                 const [a, b] = [...pts.values()];
                 const rect = el.getBoundingClientRect();
-                const contentX = (a.x + b.x) / 2 - rect.left + el.scrollLeft - 60;
-                pinch = { startDist: Math.hypot(a.x - b.x, a.y - b.y) || 1, startPps: ppsRef.current, anchorTime: Math.max(0, contentX / ppsRef.current) };
+                const midX = (a.x + b.x) / 2 - rect.left;
+                pinch = { startDist: Math.hypot(a.x - b.x, a.y - b.y) || 1, startPps: ppsRef.current, anchorTime: Math.max(0, timeAtX(el.scrollLeft, midX, ppsRef.current)) };
                 e.preventDefault(); e.stopPropagation();
             }
         };
@@ -1024,10 +1024,10 @@ export default function App() {
             pts.set(e.pointerId, { x: e.clientX, y: e.clientY });
             if (pts.size >= 2 && pinch) {
                 const [a, b] = [...pts.values()];
-                const np = Math.max(10, Math.min(300, pinch.startPps * (Math.hypot(a.x - b.x, a.y - b.y) / pinch.startDist)));
-                setPps(np);
                 const rect = el.getBoundingClientRect();
-                el.scrollLeft = Math.max(0, pinch.anchorTime * np + 60 - ((a.x + b.x) / 2 - rect.left));
+                const r = pinchZoom(pinch, Math.hypot(a.x - b.x, a.y - b.y), (a.x + b.x) / 2 - rect.left);
+                setPps(r.pps);
+                el.scrollLeft = r.scrollLeft;
                 e.preventDefault(); e.stopPropagation();
             }
         };
@@ -1072,7 +1072,7 @@ export default function App() {
                 // works from the edges the drag started at plus the delta, so reading the
                 // document from liveRef gives the same answer as the updater's argument would.
                 const r = resizeCut(liveRef.current.cuts, { cutId: resizingData.cutId, edge: resizingData.edge, initialStart: i0, initialEnd: i1 }, dt, pps);
-                setSnapLinePos(r.snapAt == null ? null : r.snapAt * pps + 60);
+                setSnapLinePos(r.snapAt == null ? null : xAtTime(r.snapAt, pps));
                 dispatchCuts(replaceCuts(r.cuts));
             } else if (draggingCutData) {
                 // A cut only moves once the press is "armed" (long-press on touch, immediate
@@ -1104,7 +1104,7 @@ export default function App() {
                 // stays pure. dragCut places the cut at initialStart + dt, reading the others
                 // only to snap against them, and they do not move during the drag.
                 const r = dragCut(liveRef.current.cuts, draggingCutData, dt, trackOff, numTracks, pps);
-                setSnapLinePos(r.snapAt == null ? null : r.snapAt * pps + 60);
+                setSnapLinePos(r.snapAt == null ? null : xAtTime(r.snapAt, pps));
                 dispatchCuts(replaceCuts(r.cuts));
             }
         };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ import {
 } from './core/cutsReducer.js';
 import { measureTextBox as measureTextBoxPure, textNeedsBox, drawTextObject } from './canvas/textRender.js';
 import { migrateCuts, projectSettings, makeLoadProgress } from './core/projectFormat.js';
+import { frameStorage, frameLoad, imageExt, imageExtFromType, audioExt, videoExt } from './core/projectAssets.js';
 import { unusedBitmapIds } from './core/bitmapRefs.js';
 import { dragCut, resizeCut } from './core/cutOps.js';
 import {
@@ -1164,9 +1165,10 @@ export default function App() {
             if (!entry) continue;
             // Video frames are held as a Blob (preferred) or legacy dataURL.
             if (entry.blob || entry.url) {
-                const ext = entry.ext || (entry.url?.match(/^data:image\/(\w+)/)?.[1]) || 'webp';
-                if (assetSink) { assets.push({ id, ext, w: entry.w || 0, h: entry.h || 0 }); assetSink.push({ id, blob: entry.blob, url: entry.url, ext }); }
-                else if (blobsOk && entry.blob) { bitmaps[id] = entry.blob; compressed.push(id); }
+                const ext = imageExt(entry);
+                const where = frameStorage(entry, { assetSink, blobsOk });
+                if (where === 'asset') { assets.push({ id, ext, w: entry.w || 0, h: entry.h || 0 }); assetSink.push({ id, blob: entry.blob, url: entry.url, ext }); }
+                else if (where === 'blob') { bitmaps[id] = entry.blob; compressed.push(id); }
                 else { bitmaps[id] = entry.blob ? await blobToDataURL(entry.blob) : entry.url; compressed.push(id); }
                 continue;
             }
@@ -1189,7 +1191,7 @@ export default function App() {
         if (includeAudio && audioB64Ref.current && audioData) {
             const meta = { name: audioFile?.name || tr('오디오'), startTime: audioData.startTime, endTime: audioData.endTime, offset: audioData.offset, duration: audioDuration };
             if (assetSink) {
-                const ext = (audioB64Ref.current.match(/^data:audio\/([\w.-]+)/)?.[1] || 'mp3').replace('mpeg', 'mp3').replace('x-m4a', 'm4a');
+                const ext = audioExt(audioB64Ref.current);
                 assetSink.push({ id: '__audio__', url: audioB64Ref.current, ext });
                 out.audio = { ...meta, asset: true, ext };
             } else {
@@ -1200,7 +1202,7 @@ export default function App() {
         // Blob directly for IndexedDB; embed as dataURL only for a self-contained .emv file.
         if (videoOverlay && videoBlobRef.current) {
             const meta = { name: videoOverlay.name, startTime: videoOverlay.startTime, endTime: videoOverlay.endTime, offset: videoOverlay.offset, duration: videoOverlay.duration, w: videoOverlay.w, h: videoOverlay.h, opacity: videoOverlay.opacity ?? 1, cuts: videoOverlay.cuts, cutStart: videoOverlay.cutStart, cutOffset: videoOverlay.cutOffset };
-            const ext = (videoBlobRef.current.type.match(/video\/([\w.-]+)/)?.[1] || 'mp4').replace('x-matroska', 'mkv').replace('quicktime', 'mov');
+            const ext = videoExt(videoBlobRef.current.type);
             if (assetSink) { assetSink.push({ id: '__video__', blob: videoBlobRef.current, ext }); out.video = { ...meta, asset: true, ext }; }
             else if (blobsOk) { out.video = { ...meta, blob: videoBlobRef.current }; }
             else { out.video = { ...meta, dataUrl: await blobToDataURL(videoBlobRef.current) }; }
@@ -1239,12 +1241,13 @@ export default function App() {
                     // Frames may arrive as a Blob (IndexedDB autosave) or a dataURL (embedded .emv).
                     // Keep them as a Blob (off-heap) and decode lazily. Drawing layers (small PNG
                     // dataURLs, not flagged compressed) become editable ImageData up front.
-                    if (val instanceof Blob) {
-                        return [id, { imageData: null, imageBitmap: null, blob: val, ext: (val.type.match(/image\/(\w+)/)?.[1]) || 'webp' }];
+                    const how = frameLoad(val, compressedSet, id);
+                    if (how === 'blob') {
+                        return [id, { imageData: null, imageBitmap: null, blob: val, ext: imageExtFromType(val.type) }];
                     }
-                    if (compressedSet.has(id) || /^data:image\/(webp|jpeg)/.test(val)) {
+                    if (how === 'compressed') {
                         const blob = await (await fetch(val)).blob();
-                        return [id, { imageData: null, imageBitmap: null, blob, ext: (blob.type.match(/image\/(\w+)/)?.[1]) || 'webp' }];
+                        return [id, { imageData: null, imageBitmap: null, blob, ext: imageExtFromType(blob.type) }];
                     }
                     const imageData = await dataURLToImageData(val);
                     let imageBitmap = null;

--- a/src/core/projectAssets.js
+++ b/src/core/projectAssets.js
@@ -1,0 +1,104 @@
+// Deciding how each piece of a project is stored, and how a stored one comes back.
+//
+// A project is written three different ways and the difference is not cosmetic:
+//
+//   - a local .emv file must open on a machine that has nothing else, so every frame, the audio
+//     and the video are embedded as base64 dataURLs and the file stands alone
+//   - an IndexedDB autosave runs every few seconds, so it stores Blobs directly - IDB persists
+//     them natively, and base64 costs a third more bytes plus a full copy on the JS heap, which
+//     is what used to make autosaving a big import run the tab out of memory
+//   - a server save uploads frames and media as separate binary assets, so the JSON stays small
+//     instead of becoming one enormous base64 string
+//
+// Which of the three applies was decided inline at each of the three call sites, with the
+// fallbacks written out again each time. They did not agree: a frame with only a legacy dataURL
+// fell back to embedding under a Blob-preferring autosave, which is correct, but nothing said so.
+// The rules live here now, and the extension maps below are the reason - they are pure lookup
+// with no way to notice a wrong answer until a file will not open.
+
+/** A frame or media item goes out as a separate binary asset alongside a small JSON. */
+export const STORE_ASSET = 'asset';
+/** Stored as a Blob in the object itself - only IndexedDB can persist that. */
+export const STORE_BLOB = 'blob';
+/** Embedded as a base64 dataURL, so the JSON is self-contained. */
+export const STORE_DATAURL = 'dataurl';
+
+/**
+ * Where one whole-image frame bitmap goes.
+ *
+ * Blob storage is preferred when it is available and allowed, but an entry that only ever had a
+ * dataURL (written by an older version) has no Blob to store, so it embeds instead of vanishing.
+ *
+ * @param {{blob?: Blob|null, url?: string|null}} entry a bitmap store entry
+ * @param {{assetSink?: unknown, blobsOk?: boolean}} mode how this project is being written
+ * @returns {'asset'|'blob'|'dataurl'}
+ */
+export function frameStorage(entry, { assetSink = null, blobsOk = false } = {}) {
+    if (assetSink) return STORE_ASSET;
+    if (blobsOk && entry?.blob) return STORE_BLOB;
+    return STORE_DATAURL;
+}
+
+/**
+ * How a bitmap read back from a saved project has to be loaded.
+ *
+ * Only drawing layers are decoded to ImageData up front, because those are the ones the user can
+ * still edit pixel by pixel. Video frames stay compressed and decode lazily when displayed -
+ * decoding a whole import at once is several gigabytes of ImageData and takes the tab down.
+ *
+ * @param {unknown} val the saved value: a Blob, or a dataURL string
+ * @param {Set<string>} compressedSet ids the file marked as whole encoded images
+ * @param {string} id
+ * @returns {'blob'|'compressed'|'decode'}
+ */
+export function frameLoad(val, compressedSet, id) {
+    if (typeof Blob !== 'undefined' && val instanceof Blob) return 'blob';
+    // The regex is not redundant with the manifest: files written before compressedBitmaps
+    // existed have no manifest at all, and decoding their video frames would be the memory
+    // blowup above. Format sniffing is what keeps those openable.
+    if (compressedSet?.has(id) || (typeof val === 'string' && /^data:image\/(webp|jpeg)/.test(val))) return 'compressed';
+    return 'decode';
+}
+
+/**
+ * The file extension for a frame bitmap.
+ * @param {{ext?: string, url?: string|null}} entry
+ * @returns {string}
+ */
+export function imageExt(entry) {
+    return entry?.ext || entry?.url?.match(/^data:image\/(\w+)/)?.[1] || 'webp';
+}
+
+/**
+ * The file extension for an image, from a Blob MIME type.
+ * @param {string|null|undefined} mime
+ * @returns {string}
+ */
+export function imageExtFromType(mime) {
+    return (typeof mime === 'string' && mime.match(/^image\/(\w+)/)?.[1]) || 'webp';
+}
+
+// Browsers report container formats under names nobody wants on the end of a filename, and the
+// two lists differ, so they are written out rather than guessed at.
+const AUDIO_EXT = { mpeg: 'mp3', 'x-m4a': 'm4a' };
+const VIDEO_EXT = { 'x-matroska': 'mkv', quicktime: 'mov' };
+
+/**
+ * The file extension for the audio track, from its dataURL.
+ * @param {string|null|undefined} dataUrl
+ * @returns {string}
+ */
+export function audioExt(dataUrl) {
+    const raw = (typeof dataUrl === 'string' && dataUrl.match(/^data:audio\/([\w.-]+)/)?.[1]) || 'mp3';
+    return AUDIO_EXT[raw] || raw;
+}
+
+/**
+ * The file extension for the video overlay, from its Blob MIME type.
+ * @param {string|null|undefined} mime
+ * @returns {string}
+ */
+export function videoExt(mime) {
+    const raw = (typeof mime === 'string' && mime.match(/^video\/([\w.-]+)/)?.[1]) || 'mp4';
+    return VIDEO_EXT[raw] || raw;
+}

--- a/src/core/timelineZoom.js
+++ b/src/core/timelineZoom.js
@@ -1,0 +1,93 @@
+// Turning timeline pixels into time, and zooming without the content sliding out from under the
+// cursor.
+//
+// The timeline scrolls horizontally behind a sticky column of track labels, so the pixel where
+// time zero sits is not the left edge of the element - it is the left edge plus the width of that
+// column. Every conversion between a screen x and a time has to account for it, and the width was
+// written as a bare 60 in six places, none of which mentioned where the number came from. The one
+// place it is actually defined is `.tl-track-label` in App.css; TRACK_GUTTER below is the same
+// number, said once, and the two have to be changed together.
+//
+// Zooming about a point is the same three lines twice - once for the wheel, once for a two-finger
+// pinch - and getting it subtly wrong does not look like a bug, it looks like the timeline
+// drifting slightly whenever you zoom. Both go through zoomAnchored now.
+
+/** Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */
+export const TRACK_GUTTER = 60;
+
+// Below ten pixels a second the cuts are too small to grab; above three hundred a few seconds
+// fill the screen and scrolling becomes the only way to see anything.
+export const PPS_MIN = 10;
+export const PPS_MAX = 300;
+
+/** @param {number} pps @returns {number} */
+export function clampPps(pps) {
+    if (!Number.isFinite(pps)) return PPS_MIN;
+    return Math.max(PPS_MIN, Math.min(PPS_MAX, pps));
+}
+
+/**
+ * The time under a point, given where the timeline is scrolled to.
+ * @param {number} scrollLeft
+ * @param {number} localX x within the timeline element, from its left edge
+ * @param {number} pps pixels per second
+ * @returns {number}
+ */
+export function timeAtX(scrollLeft, localX, pps) {
+    return (scrollLeft + localX - TRACK_GUTTER) / pps;
+}
+
+/**
+ * Where a time sits, as a content x - what the playhead's `left` is set to.
+ * @param {number} time
+ * @param {number} pps
+ * @returns {number}
+ */
+export function xAtTime(time, pps) {
+    return time * pps + TRACK_GUTTER;
+}
+
+/**
+ * Scroll position that puts a time back under a point on screen.
+ *
+ * Never negative: scrolling before the start is not a place the timeline can be, and asking for
+ * it once left the first track label overlapping the ruler.
+ *
+ * @param {number} time the time to pin
+ * @param {number} pps the new scale
+ * @param {number} localX where on screen it should stay
+ * @returns {number}
+ */
+export function scrollToHold(time, pps, localX) {
+    return Math.max(0, xAtTime(time, pps) - localX);
+}
+
+/**
+ * Zoom by a factor while keeping whatever is under `localX` under `localX`.
+ *
+ * @param {number} prevPps
+ * @param {number} factor >1 zooms in
+ * @param {number} scrollLeft current scroll
+ * @param {number} localX the point to hold still
+ * @returns {{pps: number, scrollLeft: number} | null} null when already at the limit, so the
+ *   caller can leave the scroll position alone rather than recomputing it from an unchanged scale
+ */
+export function zoomAnchored(prevPps, factor, scrollLeft, localX) {
+    const pps = clampPps(prevPps * factor);
+    if (pps === prevPps) return null;
+    return { pps, scrollLeft: scrollToHold(timeAtX(scrollLeft, localX, prevPps), pps, localX) };
+}
+
+/**
+ * The same thing for a pinch, which scales from where the fingers started rather than from the
+ * current value - accumulating a factor per move event would drift.
+ *
+ * @param {{startPps: number, startDist: number, anchorTime: number}} pinch captured on the second finger down
+ * @param {number} dist current distance between the fingers
+ * @param {number} localX midpoint between them, within the element
+ * @returns {{pps: number, scrollLeft: number}}
+ */
+export function pinchZoom(pinch, dist, localX) {
+    const pps = clampPps(pinch.startPps * (dist / (pinch.startDist || 1)));
+    return { pps, scrollLeft: scrollToHold(pinch.anchorTime, pps, localX) };
+}

--- a/src/hooks/useTimelineGestures.js
+++ b/src/hooks/useTimelineGestures.js
@@ -15,10 +15,10 @@
 // The drags listen on the window rather than the element, so a gesture that leaves the timeline
 // keeps working and still ends when the button comes up somewhere else.
 
+import { timeAtX, pinchZoom } from '../core/timelineZoom.js';
+
 const DRAG_SLOP = 5;   // mouse travel before a click becomes a marquee drag
 const TAP_SLOP = 4;    // finger travel before a tap becomes a pan
-const RULER_OFFSET = 60; // the track labels occupy the left edge; time starts after them
-const MIN_PPS = 10, MAX_PPS = 300;
 
 export function useTimelineGestures({
     timelineRef, tlTouchRef, tlPinchRef,
@@ -50,7 +50,7 @@ export function useTimelineGestures({
         const el = timelineRef.current;
         if (!el) return null;
         const rect = el.getBoundingClientRect();
-        return (clientX - rect.left + el.scrollLeft - RULER_OFFSET) / pps;
+        return timeAtX(el.scrollLeft, clientX - rect.left, pps);
     };
     const seekToClientX = (clientX) => {
         const t = timeAtClientX(clientX);
@@ -169,14 +169,13 @@ export function useTimelineGestures({
         tlTouchRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
         if (tlTouchRef.current.size === 2) {
             const [a, b] = [...tlTouchRef.current.values()];
-            const midX = (a.x + b.x) / 2;
-            const contentX = midX - el.getBoundingClientRect().left + el.scrollLeft - RULER_OFFSET;
+            const midX = (a.x + b.x) / 2 - el.getBoundingClientRect().left;
             // The time under the midpoint is remembered so the zoom can hold it in place.
             tlPinchRef.current = {
                 mode: 'pinch',
                 startDist: Math.hypot(a.x - b.x, a.y - b.y) || 1,
                 startPps: pps,
-                anchorTime: Math.max(0, contentX / pps),
+                anchorTime: Math.max(0, timeAtX(el.scrollLeft, midX, pps)),
             };
         } else if (tlTouchRef.current.size === 1) {
             tlPinchRef.current = { mode: 'pan', startClientX: e.clientX, startClientY: e.clientY, startScroll: el ? el.scrollLeft : 0, moved: false };
@@ -192,12 +191,12 @@ export function useTimelineGestures({
         if (tlTouchRef.current.size >= 2 && p?.mode === 'pinch') {
             const [a, b] = [...tlTouchRef.current.values()];
             const dist = Math.hypot(a.x - b.x, a.y - b.y);
-            const np = Math.max(MIN_PPS, Math.min(MAX_PPS, p.startPps * (dist / p.startDist)));
-            setPps(np);
             // Scroll so the anchor time stays under the midpoint; without this the timeline slides
             // away from the fingers as it zooms.
-            const midX = (a.x + b.x) / 2;
-            el.scrollLeft = Math.max(0, p.anchorTime * np + RULER_OFFSET - (midX - el.getBoundingClientRect().left));
+            const midX = (a.x + b.x) / 2 - el.getBoundingClientRect().left;
+            const r = pinchZoom(p, dist, midX);
+            setPps(r.pps);
+            el.scrollLeft = r.scrollLeft;
             e.preventDefault();
         } else if (tlTouchRef.current.size === 1 && p?.mode === 'pan') {
             const dx = e.clientX - p.startClientX;

--- a/src/ui/Modal.jsx
+++ b/src/ui/Modal.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { X } from 'lucide-react';
+
+// The shell every dialog in the app sits in.
+//
+// It was written out by hand seven times: a fixed backdrop, a panel that stops the click from
+// reaching the backdrop, and a header row with a title and a close button. Seven copies drifted -
+// three different border colours, two different close glyphs - and none of them closed on Escape,
+// because adding that is seven edits and nobody made all seven.
+//
+// Escape is why this is a component rather than a style guide. A dialog that traps you until you
+// find the small x is the kind of thing that is only ever fixed everywhere at once.
+
+/**
+ * @param {object} props
+ * @param {React.ReactNode} [props.title] header text; omit for a dialog with no header
+ * @param {() => void} props.onClose
+ * @param {number} props.width panel width in px
+ * @param {string} [props.maxHeight] set when the content can outgrow the screen
+ * @param {number} [props.z] stacking order, for a dialog opened from another one
+ * @param {string} [props.className]
+ * @param {boolean} [props.closable] false while something is running that must not be interrupted
+ * @param {boolean} [props.closeOnEscape] false when the dialog uses Escape for its own purpose
+ * @param {React.CSSProperties} [props.panelStyle] extra panel styling
+ * @param {React.ReactNode} props.children
+ */
+export function Modal({
+    title, onClose, width, maxHeight, z = 1000, className,
+    closable = true, closeOnEscape = true, panelStyle, children,
+}) {
+    React.useEffect(() => {
+        if (!closable || !closeOnEscape) return;
+        const h = (e) => {
+            if (e.key !== 'Escape') return;
+            // Stop here rather than letting it reach the canvas, where Escape clears the
+            // selection - closing a dialog should not also undo what was selected behind it.
+            e.stopPropagation();
+            onClose();
+        };
+        window.addEventListener('keydown', h, true);
+        return () => window.removeEventListener('keydown', h, true);
+    }, [closable, closeOnEscape, onClose]);
+
+    return (
+        <div onClick={() => { if (closable) onClose(); }}
+            style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: z, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <div className={className} onClick={e => e.stopPropagation()} role="dialog" aria-modal="true"
+                style={{
+                    width, maxHeight, overflow: maxHeight ? 'auto' : undefined,
+                    background: 'hsl(var(--ui-h) var(--ui-s) 15%)',
+                    border: '1px solid hsl(var(--ui-h) var(--ui-s) 24%)',
+                    borderRadius: 8, padding: 18, ...panelStyle,
+                }}>
+                {title != null && (
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+                        <span className="panel-title">{title}</span>
+                        {closable && <button className="icon-btn" onClick={onClose} aria-label="close"><X size={14} /></button>}
+                    </div>
+                )}
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/src/ui/Modals.jsx
+++ b/src/ui/Modals.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Trash2, AlertTriangle, X } from 'lucide-react';
+import { Trash2, AlertTriangle } from 'lucide-react';
 import { tr } from '../i18n';
 import { TOOL_PREFIX } from '../core/shortcuts.js';
 import { targetCanvasFor } from '../canvas/canvasUtils';
+import { Modal } from './Modal.jsx';
 
 // Overlays and dialogs split out of App.jsx. All state arrives as props; these only display.
 // (App.jsx had grown to 4,800 lines, so the screens moved into files you can actually read.)
@@ -10,25 +11,19 @@ import { targetCanvasFor } from '../canvas/canvasUtils';
 // Picker for the saved project and backup lists.
 export function ProjectPicker({ title, items, onOpen, onDelete, onClose }) {
     return (
-        <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <div onClick={e => e.stopPropagation()} style={{ width: 420, maxHeight: '70vh', overflow: 'auto', background: 'hsl(var(--ui-h) var(--ui-s) 15%)', border: '1px solid hsl(var(--ui-h) var(--ui-s) 24%)', borderRadius: 8, padding: 16 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
-                    <span className="panel-title">{title}</span>
-                    <button className="icon-btn" onClick={onClose}>✕</button>
-                </div>
-                {items.length === 0 && <div style={{ fontSize: 12, color: '#888', padding: '12px 2px' }}>{tr('저장된 프로젝트가 없습니다.')}</div>}
-                {items.map(p => (
-                    <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 6px', borderBottom: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)' }}>
-                        <div style={{ flex: 1, minWidth: 0, cursor: 'pointer' }} onClick={() => onOpen(p.id, p.name)}>
-                            <div style={{ fontSize: 13, color: '#ddd', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</div>
-                            <div style={{ fontSize: 10, color: '#777' }}>{p.savedAt ? new Date(p.savedAt).toLocaleString() : ''}</div>
-                        </div>
-                        <button className="button" style={{ height: 28, padding: '0 10px' }} onClick={() => onOpen(p.id, p.name)}>{tr('열기')}</button>
-                        <button className="icon-btn del-btn" onClick={() => onDelete(p.id)}><Trash2 size={13} /></button>
+        <Modal title={title} onClose={onClose} width={420} maxHeight="70vh" panelStyle={{ padding: 16 }}>
+            {items.length === 0 && <div style={{ fontSize: 12, color: '#888', padding: '12px 2px' }}>{tr('저장된 프로젝트가 없습니다.')}</div>}
+            {items.map(p => (
+                <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 6px', borderBottom: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)' }}>
+                    <div style={{ flex: 1, minWidth: 0, cursor: 'pointer' }} onClick={() => onOpen(p.id, p.name)}>
+                        <div style={{ fontSize: 13, color: '#ddd', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</div>
+                        <div style={{ fontSize: 10, color: '#777' }}>{p.savedAt ? new Date(p.savedAt).toLocaleString() : ''}</div>
                     </div>
-                ))}
-            </div>
-        </div>
+                    <button className="button" style={{ height: 28, padding: '0 10px' }} onClick={() => onOpen(p.id, p.name)}>{tr('열기')}</button>
+                    <button className="icon-btn del-btn" onClick={() => onDelete(p.id)}><Trash2 size={13} /></button>
+                </div>
+            ))}
+        </Modal>
     );
 }
 
@@ -66,135 +61,125 @@ export function SettingsModal({
 }) {
     const saveKeymap = (next) => { setKeymap(next); try { localStorage.setItem('mv_keymap', JSON.stringify(next)); } catch { } };
     return (
-        <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <div className="settings-modal" onClick={e => e.stopPropagation()} style={{ width: 520, maxHeight: '80vh', overflow: 'auto', background: 'hsl(var(--ui-h) var(--ui-s) 15%)', border: '1px solid hsl(var(--ui-h) var(--ui-s) 26%)', borderRadius: 10, padding: 20 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
-                    <span className="panel-title">{tr('설정')}</span>
-                    <button className="icon-btn" onClick={onClose}>✕</button>
-                </div>
-                <div className="pal-tabs" style={{ marginBottom: 10 }}>
-                    <button className={`pal-tab${tab === 'theme' ? ' active' : ''}`} onClick={() => { setTab('theme'); setRebinding(null); }}>{tr('테마')}</button>
-                    <button className={`pal-tab${tab === 'keys' ? ' active' : ''}`} onClick={() => setTab('keys')}>{tr('단축키')}</button>
-                </div>
+        <Modal title={tr('설정')} onClose={onClose} width={520} maxHeight="80vh" className="settings-modal"
+            closeOnEscape={!rebinding} panelStyle={{ borderRadius: 10, padding: 20 }}>
+            <div className="pal-tabs" style={{ marginBottom: 10 }}>
+                <button className={`pal-tab${tab === 'theme' ? ' active' : ''}`} onClick={() => { setTab('theme'); setRebinding(null); }}>{tr('테마')}</button>
+                <button className={`pal-tab${tab === 'keys' ? ' active' : ''}`} onClick={() => setTab('keys')}>{tr('단축키')}</button>
+            </div>
 
-                {tab === 'theme' ? (
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-                        <div>
-                            <div className="color-section-label" style={{ marginBottom: 6 }}>{tr('언어')}</div>
-                            <div className="pal-tabs">
-                                <button className={`pal-tab${lang === 'en' ? ' active' : ''}`} onClick={() => changeLang('en')}>English</button>
-                                <button className={`pal-tab${lang === 'ko' ? ' active' : ''}`} onClick={() => changeLang('ko')}>한국어</button>
-                            </div>
-                        </div>
-                        <div>
-                            <div className="color-section-label" style={{ marginBottom: 6 }}>{tr('테마색')}</div>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                                <input type="color" className="color-swatch-lg" style={{ width: 46, height: 34 }} value={themeColor} onChange={e => setThemeColor(e.target.value)} title={tr('테마색 직접 선택')} />
-                                <span style={{ fontSize: 12, color: '#aaa', flex: 1 }}>{themeColor}</span>
-                                <button className="button" style={{ height: 30, padding: '0 12px' }} onClick={() => setThemeColor(defaultTheme)}>{tr('기본')}</button>
-                            </div>
-                            {/* Recent theme colours: ten fixed slots, empty to begin with. */}
-                            <div className="color-section-label" style={{ margin: '10px 0 6px' }}>{tr('최근 사용한 테마색')}</div>
-                            <div className="slot-grid" style={{ gridTemplateColumns: 'repeat(10, 1fr)', maxWidth: 320 }}>
-                                {Array.from({ length: 10 }, (_, i) => {
-                                    const c = themeRecent[i];
-                                    return c
-                                        ? <button key={i} className={`slot filled${c.toLowerCase() === String(themeColor).toLowerCase() ? ' sel' : ''}`}
-                                            style={{ background: c }} title={c} onClick={() => setThemeColor(c)} />
-                                        : <span key={i} className="slot empty" />;
-                                })}
-                            </div>
-                        </div>
-                        <div>
-                            <div className="color-section-label" style={{ marginBottom: 6 }}>{tr('UI 채도 — 패널·버튼 배경에 테마색이 섞이는 정도')}</div>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                                <input type="range" min="0" max="60" step="1" value={uiSat} onChange={e => setUiSat(+e.target.value)} style={{ flex: 1 }} />
-                                <input type="number" className="time-input" style={{ width: 60 }} min="0" max="60" value={uiSat}
-                                    onChange={e => setUiSat(Math.max(0, Math.min(60, +e.target.value || 0)))} />
-                                <span style={{ fontSize: 11, color: '#888' }}>%</span>
-                            </div>
-                            <div style={{ fontSize: 10, color: '#777', marginTop: 4 }}>{tr('0%로 두면 완전한 무채색 회색 UI가 됩니다.')}</div>
-                        </div>
-                        {/* Also on the video track itself; here as well because settings are
-                            where someone looks, and the track row can be folded away. */}
-                        <div>
-                            <div className="color-section-label" style={{ marginBottom: 6 }}>{tr('영상 농도')}</div>
-                            {videoOpacity == null
-                                ? <div style={{ fontSize: 11, color: '#777' }}>{tr('영상이 없습니다')}</div>
-                                : (
-                                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                                        <input type="range" min="0" max="100" step="1" style={{ flex: 1 }}
-                                            value={Math.round(videoOpacity * 100)}
-                                            onChange={e => setVideoOpacity(+e.target.value / 100)} />
-                                        <input type="number" className="time-input" style={{ width: 60 }} min="0" max="100"
-                                            value={Math.round(videoOpacity * 100)}
-                                            onChange={e => setVideoOpacity(Math.max(0, Math.min(100, +e.target.value || 0)) / 100)} />
-                                        <span style={{ fontSize: 11, color: '#888' }}>%</span>
-                                    </div>
-                                )}
+            {tab === 'theme' ? (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                    <div>
+                        <div className="color-section-label" style={{ marginBottom: 6 }}>{tr('언어')}</div>
+                        <div className="pal-tabs">
+                            <button className={`pal-tab${lang === 'en' ? ' active' : ''}`} onClick={() => changeLang('en')}>English</button>
+                            <button className={`pal-tab${lang === 'ko' ? ' active' : ''}`} onClick={() => changeLang('ko')}>한국어</button>
                         </div>
                     </div>
-                ) : (
-                    <>
-                        <div style={{ fontSize: 11, color: '#888', marginBottom: 10 }}>
-                            {rebinding ? tr('원하는 키를 누르세요 (Esc = 취소)') : tr('바꿀 항목을 누른 뒤 새 키를 누르세요.')}
+                    <div>
+                        <div className="color-section-label" style={{ marginBottom: 6 }}>{tr('테마색')}</div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                            <input type="color" className="color-swatch-lg" style={{ width: 46, height: 34 }} value={themeColor} onChange={e => setThemeColor(e.target.value)} title={tr('테마색 직접 선택')} />
+                            <span style={{ fontSize: 12, color: '#aaa', flex: 1 }}>{themeColor}</span>
+                            <button className="button" style={{ height: 30, padding: '0 12px' }} onClick={() => setThemeColor(defaultTheme)}>{tr('기본')}</button>
                         </div>
-                        {Object.entries(conflicts || {}).map(([key, actions]) => (
-                            <div key={key} style={{ fontSize: 11, color: '#e0a84e', padding: '4px 0' }}>
-                                <AlertTriangle size={11} style={{ verticalAlign: '-1px' }} /> {tr('{0} 키가 겹칩니다: {1} — 하나만 동작합니다.', key, actions.map(a => tr(keyLabels[a] || a)).join(', '))}
-                            </div>
-                        ))}
-                        {Object.keys(defaultKeys).filter(id => !id.startsWith(TOOL_PREFIX)).map(id => (
-                            <div key={id} className="key-row" style={{ display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)' }}>
-                                <span style={{ flex: 1, color: '#ddd' }}>{tr(keyLabels[id])}</span>
-                                <button className="button" style={{ height: 30, minWidth: 110, justifyContent: 'center', background: rebinding === id ? 'var(--accent)' : undefined }}
-                                    onClick={() => setRebinding(rebinding === id ? null : id)}>
-                                    {rebinding === id ? tr('키 입력 대기…') : (keymap[id] || tr('(없음)'))}
-                                </button>
-                                {keymap[id] !== defaultKeys[id] && (
-                                    <button className="small-btn" title={tr('기본값으로')} onClick={() => saveKeymap({ ...keymap, [id]: defaultKeys[id] })}>{tr('되돌리기')}</button>
-                                )}
-                            </div>
-                        ))}
-                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 12 }}>
-                            <span style={{ fontSize: 10, color: '#777' }}>{tr('Ctrl+S 저장 · Ctrl+Z/Y 등 기본 조합은 항상 동작합니다')}</span>
-                            <button className="button" onClick={() => setShowToolKeys(true)}>{tr('도구 단축키…')}</button>
-                            <button className="button" onClick={() => saveKeymap({ ...defaultKeys })}>{tr('전체 기본값')}</button>
+                        {/* Recent theme colours: ten fixed slots, empty to begin with. */}
+                        <div className="color-section-label" style={{ margin: '10px 0 6px' }}>{tr('최근 사용한 테마색')}</div>
+                        <div className="slot-grid" style={{ gridTemplateColumns: 'repeat(10, 1fr)', maxWidth: 320 }}>
+                            {Array.from({ length: 10 }, (_, i) => {
+                                const c = themeRecent[i];
+                                return c
+                                    ? <button key={i} className={`slot filled${c.toLowerCase() === String(themeColor).toLowerCase() ? ' sel' : ''}`}
+                                        style={{ background: c }} title={c} onClick={() => setThemeColor(c)} />
+                                    : <span key={i} className="slot empty" />;
+                            })}
                         </div>
-                    </>
-                )}
-            </div>
-        </div>
+                    </div>
+                    <div>
+                        <div className="color-section-label" style={{ marginBottom: 6 }}>{tr('UI 채도 — 패널·버튼 배경에 테마색이 섞이는 정도')}</div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <input type="range" min="0" max="60" step="1" value={uiSat} onChange={e => setUiSat(+e.target.value)} style={{ flex: 1 }} />
+                            <input type="number" className="time-input" style={{ width: 60 }} min="0" max="60" value={uiSat}
+                                onChange={e => setUiSat(Math.max(0, Math.min(60, +e.target.value || 0)))} />
+                            <span style={{ fontSize: 11, color: '#888' }}>%</span>
+                        </div>
+                        <div style={{ fontSize: 10, color: '#777', marginTop: 4 }}>{tr('0%로 두면 완전한 무채색 회색 UI가 됩니다.')}</div>
+                    </div>
+                    {/* Also on the video track itself; here as well because settings are
+                        where someone looks, and the track row can be folded away. */}
+                    <div>
+                        <div className="color-section-label" style={{ marginBottom: 6 }}>{tr('영상 농도')}</div>
+                        {videoOpacity == null
+                            ? <div style={{ fontSize: 11, color: '#777' }}>{tr('영상이 없습니다')}</div>
+                            : (
+                                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                                    <input type="range" min="0" max="100" step="1" style={{ flex: 1 }}
+                                        value={Math.round(videoOpacity * 100)}
+                                        onChange={e => setVideoOpacity(+e.target.value / 100)} />
+                                    <input type="number" className="time-input" style={{ width: 60 }} min="0" max="100"
+                                        value={Math.round(videoOpacity * 100)}
+                                        onChange={e => setVideoOpacity(Math.max(0, Math.min(100, +e.target.value || 0)) / 100)} />
+                                    <span style={{ fontSize: 11, color: '#888' }}>%</span>
+                                </div>
+                            )}
+                    </div>
+                </div>
+            ) : (
+                <>
+                    <div style={{ fontSize: 11, color: '#888', marginBottom: 10 }}>
+                        {rebinding ? tr('원하는 키를 누르세요 (Esc = 취소)') : tr('바꿀 항목을 누른 뒤 새 키를 누르세요.')}
+                    </div>
+                    {Object.entries(conflicts || {}).map(([key, actions]) => (
+                        <div key={key} style={{ fontSize: 11, color: '#e0a84e', padding: '4px 0' }}>
+                            <AlertTriangle size={11} style={{ verticalAlign: '-1px' }} /> {tr('{0} 키가 겹칩니다: {1} — 하나만 동작합니다.', key, actions.map(a => tr(keyLabels[a] || a)).join(', '))}
+                        </div>
+                    ))}
+                    {Object.keys(defaultKeys).filter(id => !id.startsWith(TOOL_PREFIX)).map(id => (
+                        <div key={id} className="key-row" style={{ display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)' }}>
+                            <span style={{ flex: 1, color: '#ddd' }}>{tr(keyLabels[id])}</span>
+                            <button className="button" style={{ height: 30, minWidth: 110, justifyContent: 'center', background: rebinding === id ? 'var(--accent)' : undefined }}
+                                onClick={() => setRebinding(rebinding === id ? null : id)}>
+                                {rebinding === id ? tr('키 입력 대기…') : (keymap[id] || tr('(없음)'))}
+                            </button>
+                            {keymap[id] !== defaultKeys[id] && (
+                                <button className="small-btn" title={tr('기본값으로')} onClick={() => saveKeymap({ ...keymap, [id]: defaultKeys[id] })}>{tr('되돌리기')}</button>
+                            )}
+                        </div>
+                    ))}
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 12 }}>
+                        <span style={{ fontSize: 10, color: '#777' }}>{tr('Ctrl+S 저장 · Ctrl+Z/Y 등 기본 조합은 항상 동작합니다')}</span>
+                        <button className="button" onClick={() => setShowToolKeys(true)}>{tr('도구 단축키…')}</button>
+                        <button className="button" onClick={() => saveKeymap({ ...defaultKeys })}>{tr('전체 기본값')}</button>
+                    </div>
+                </>
+            )}
+        </Modal>
     );
 }
 
 // Shortcut and gesture help.
 export function HelpModal({ keymap, onClose }) {
     return (
-        <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <div onClick={e => e.stopPropagation()} style={{ width: 460, maxHeight: '80vh', overflow: 'auto', background: 'hsl(var(--ui-h) var(--ui-s) 15%)', border: '1px solid hsl(var(--ui-h) var(--ui-s) 24%)', borderRadius: 8, padding: 18, fontSize: 12.5, color: '#ccc', lineHeight: 1.7 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
-                    <span className="panel-title">{tr('단축키 · 제스처')}</span>
-                    <button className="icon-btn" onClick={onClose}>✕</button>
-                </div>
-                <b style={{ color: '#9aa' }}>{tr('키보드')}</b>
-                <div>{tr('Ctrl+Z 실행취소 · Ctrl+Shift+Z / Ctrl+Y 다시실행')}</div>
-                <div>{tr('Ctrl+C 컷 복사 · Ctrl+V 붙여넣기 · Ctrl+D 다음 프레임 복제')}</div>
-                <div>{tr('Ctrl+S 저장 · Esc 선택 취소 · Enter 선택 적용')}</div>
-                <div><b>{keymap.undo}</b> {tr('실행취소 ·')} <b>{keymap.redo}</b> {tr('다시실행 ·')} <b>{keymap.brushDown}</b>/<b>{keymap.brushUp}</b> {tr('브러시 크기 ·')} <b>{keymap.zoomOut}</b>/<b>{keymap.zoomIn}</b> {tr('캔버스 축소/확대 (설정에서 변경)')}</div>
-                <div>{tr('move 도구: 빈 곳을 끌면')} <b>{tr('그림 전체가 이동')}</b>{tr('합니다(선택 범위 불필요).')} <b>{tr('Alt+드래그')}</b> {tr('= 활성 레이어만')}</div>
-                <div style={{ marginTop: 8 }}><b style={{ color: '#9aa' }}>{tr('펜 / 손가락')}</b></div>
-                <div>{tr('펜(S펜)·마우스 = 그리기 / 손가락은 그려지지 않음(팜 리젝션)')}</div>
-                <div>{tr('캔버스: 손가락 1개 = 이동, 2개 = 핀치 줌 (우상단 ⟲ 초기화)')}</div>
-                <div>PC: <b>{tr('스페이스바 + 드래그 = 화면 이동')}</b> {tr('· 휠 클릭 드래그도 이동 · 휠 = 줌')}</div>
-                <div style={{ marginTop: 8 }}><b style={{ color: '#9aa' }}>{tr('타임라인')}</b></div>
-                <div>{tr('1손가락 드래그 = 이동, 탭 = 재생위치 / 2손가락 = 확대·축소')}</div>
-                <div>PC: <b>{tr('휠(가운데) 클릭 드래그 = 타임라인 이동')}</b></div>
-                <div>{tr('컷: 길게 눌러 이동 · 가장자리 드래그로 길이조절 · 더블클릭 이름변경 · Ctrl/Shift+클릭 다중선택')}</div>
-                <div style={{ marginTop: 8 }}><b style={{ color: '#9aa' }}>{tr('팁')}</b></div>
-                <div>{tr('애니메이션(컷·파츠)은 ▶ 재생 시에만 보입니다. 올가미 → "파츠로 분리"로 부분 애니메이션.')}</div>
-            </div>
-        </div>
+        <Modal title={tr('단축키 · 제스처')} onClose={onClose} width={460} maxHeight="80vh"
+            panelStyle={{ fontSize: 12.5, color: '#ccc', lineHeight: 1.7 }}>
+            <b style={{ color: '#9aa' }}>{tr('키보드')}</b>
+            <div>{tr('Ctrl+Z 실행취소 · Ctrl+Shift+Z / Ctrl+Y 다시실행')}</div>
+            <div>{tr('Ctrl+C 컷 복사 · Ctrl+V 붙여넣기 · Ctrl+D 다음 프레임 복제')}</div>
+            <div>{tr('Ctrl+S 저장 · Esc 선택 취소 · Enter 선택 적용')}</div>
+            <div><b>{keymap.undo}</b> {tr('실행취소 ·')} <b>{keymap.redo}</b> {tr('다시실행 ·')} <b>{keymap.brushDown}</b>/<b>{keymap.brushUp}</b> {tr('브러시 크기 ·')} <b>{keymap.zoomOut}</b>/<b>{keymap.zoomIn}</b> {tr('캔버스 축소/확대 (설정에서 변경)')}</div>
+            <div>{tr('move 도구: 빈 곳을 끌면')} <b>{tr('그림 전체가 이동')}</b>{tr('합니다(선택 범위 불필요).')} <b>{tr('Alt+드래그')}</b> {tr('= 활성 레이어만')}</div>
+            <div style={{ marginTop: 8 }}><b style={{ color: '#9aa' }}>{tr('펜 / 손가락')}</b></div>
+            <div>{tr('펜(S펜)·마우스 = 그리기 / 손가락은 그려지지 않음(팜 리젝션)')}</div>
+            <div>{tr('캔버스: 손가락 1개 = 이동, 2개 = 핀치 줌 (우상단 ⟲ 초기화)')}</div>
+            <div>PC: <b>{tr('스페이스바 + 드래그 = 화면 이동')}</b> {tr('· 휠 클릭 드래그도 이동 · 휠 = 줌')}</div>
+            <div style={{ marginTop: 8 }}><b style={{ color: '#9aa' }}>{tr('타임라인')}</b></div>
+            <div>{tr('1손가락 드래그 = 이동, 탭 = 재생위치 / 2손가락 = 확대·축소')}</div>
+            <div>PC: <b>{tr('휠(가운데) 클릭 드래그 = 타임라인 이동')}</b></div>
+            <div>{tr('컷: 길게 눌러 이동 · 가장자리 드래그로 길이조절 · 더블클릭 이름변경 · Ctrl/Shift+클릭 다중선택')}</div>
+            <div style={{ marginTop: 8 }}><b style={{ color: '#9aa' }}>{tr('팁')}</b></div>
+            <div>{tr('애니메이션(컷·파츠)은 ▶ 재생 시에만 보입니다. 올가미 → "파츠로 분리"로 부분 애니메이션.')}</div>
+        </Modal>
     );
 }
 
@@ -205,198 +190,188 @@ export function VideoImportModal({
     runVideoImport, loadVideoOverlay, loadAudioUrl, parseClock, setShowHelp, canvasW, canvasH, setCanvasSize,
 }) {
     return (
-        <div onClick={() => { if (!videoBusy) setVideoImport(null); }} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <div onClick={e => e.stopPropagation()} style={{ width: 420, background: 'hsl(var(--ui-h) var(--ui-s) 15%)', border: '1px solid #333', borderRadius: 8, padding: 18, color: '#ccc', fontSize: 12.5 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-                    <span className="panel-title">{tr('영상 → 프레임 컷')}</span>
-                    {!videoBusy && <button className="icon-btn" onClick={() => setVideoImport(null)}>✕</button>}
-                </div>
-                <div style={{ marginBottom: 10, color: '#9aa', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{videoImport.file.name}</div>
-                {videoBusy ? (
-                    <>
-                        <div style={{ marginBottom: 8 }}>{tr('프레임 추출 중…')} {videoBusy.done}/{videoBusy.total || '?'}{videoBusy.skipped ? ' ' + tr('(중복 {0}컷 통합)', videoBusy.skipped) : ''}</div>
-                        <div style={{ height: 8, background: 'hsl(var(--ui-h) var(--ui-s) 20%)', borderRadius: 4, overflow: 'hidden' }}>
-                            <div style={{ height: '100%', width: `${videoBusy.total ? (videoBusy.done / videoBusy.total * 100) : 0}%`, background: 'var(--accent-soft)' }} />
-                        </div>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 12 }}>
-                            <span style={{ color: '#888', fontSize: 11 }}>{tr('백그라운드로 두고 다른 작업을 계속할 수 있어요.')}</span>
-                            <span style={{ display: 'flex', gap: 6 }}>
-                                <button className="button" onClick={() => setVideoBusyBg(true)}>{tr('백그라운드로')}</button>
-                                <button className="button" onClick={() => { videoStopRef.current = true; }}>{tr('중지')}</button>
+        <Modal title={tr('영상 → 프레임 컷')} onClose={() => setVideoImport(null)} width={420}
+            closable={!videoBusy} panelStyle={{ color: '#ccc', fontSize: 12.5 }}>
+            <div style={{ marginBottom: 10, color: '#9aa', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{videoImport.file.name}</div>
+            {videoBusy ? (
+                <>
+                    <div style={{ marginBottom: 8 }}>{tr('프레임 추출 중…')} {videoBusy.done}/{videoBusy.total || '?'}{videoBusy.skipped ? ' ' + tr('(중복 {0}컷 통합)', videoBusy.skipped) : ''}</div>
+                    <div style={{ height: 8, background: 'hsl(var(--ui-h) var(--ui-s) 20%)', borderRadius: 4, overflow: 'hidden' }}>
+                        <div style={{ height: '100%', width: `${videoBusy.total ? (videoBusy.done / videoBusy.total * 100) : 0}%`, background: 'var(--accent-soft)' }} />
+                    </div>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 12 }}>
+                        <span style={{ color: '#888', fontSize: 11 }}>{tr('백그라운드로 두고 다른 작업을 계속할 수 있어요.')}</span>
+                        <span style={{ display: 'flex', gap: 6 }}>
+                            <button className="button" onClick={() => setVideoBusyBg(true)}>{tr('백그라운드로')}</button>
+                            <button className="button" onClick={() => { videoStopRef.current = true; }}>{tr('중지')}</button>
+                        </span>
+                    </div>
+                </>
+            ) : (
+                <>
+                    <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
+                        <span style={{ width: 76 }}>{tr('초당 프레임')}</span>
+                        <select className="time-input" style={{ width: 80 }} value={videoImport.fps} onChange={e => setVideoImport(v => ({ ...v, fps: +e.target.value }))}>
+                            {[1, 2, 3, 4, 6, 8, 12, 15, 24].map(v => <option key={v} value={v}>{v} fps</option>)}
+                        </select>
+                        {videoImport.quality === 'compressed' && <>
+                            <span style={{ width: 50, marginLeft: 6 }}>{tr('배율')}</span>
+                            <select className="time-input" style={{ width: 80 }} value={videoImport.scale} onChange={e => setVideoImport(v => ({ ...v, scale: +e.target.value }))}>
+                                {[[1, '100%'], [0.75, '75%'], [0.5, '50%'], [0.35, '35%'], [0.25, '25%']].map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+                            </select>
+                        </>}
+                    </div>
+                    <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 8, flexWrap: 'wrap' }}>
+                        <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                            <input type="checkbox" checked={videoImport.whole} onChange={e => setVideoImport(v => ({ ...v, whole: e.target.checked }))} /> {tr('영상 전체')}
+                        </label>
+                        {!videoImport.whole && (
+                            <label style={{ display: 'flex', alignItems: 'center', gap: 4 }} title={tr('가져올 컷 개수 (중복 병합분은 제외한 실제 컷 수)')}>
+                                <input type="number" className="time-input" style={{ width: 70 }} min={1} max={5000} value={videoImport.maxFrames}
+                                    onChange={e => setVideoImport(v => ({ ...v, maxFrames: Math.max(1, Math.min(5000, Math.floor(+e.target.value) || 1)) }))} />
+                                <span style={{ color: '#888' }}>{tr('컷')}</span>
+                            </label>
+                        )}
+                        <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                            <input type="checkbox" checked={videoImport.withAudio} onChange={e => setVideoImport(v => ({ ...v, withAudio: e.target.checked }))} /> {tr('음원도 같이')}
+                        </label>
+                        <label style={{ display: 'flex', alignItems: 'center', gap: 4 }} title={tr('영상의 일부 구간만 가져오기 (mm:ss)')}>
+                            <input type="checkbox" checked={videoImport.rangeOn} onChange={e => setVideoImport(v => ({ ...v, rangeOn: e.target.checked }))} /> {tr('구간만')}
+                        </label>
+                        {videoImport.rangeOn && (
+                            <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+                                <input className="time-input" style={{ width: 60 }} placeholder="0:00" value={videoImport.startText} onChange={e => setVideoImport(v => ({ ...v, startText: e.target.value }))} />
+                                <span style={{ color: '#888' }}>~</span>
+                                <input className="time-input" style={{ width: 60 }} placeholder={tr('끝')} value={videoImport.endText} onChange={e => setVideoImport(v => ({ ...v, endText: e.target.value }))} />
                             </span>
-                        </div>
-                    </>
-                ) : (
-                    <>
-                        <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
-                            <span style={{ width: 76 }}>{tr('초당 프레임')}</span>
-                            <select className="time-input" style={{ width: 80 }} value={videoImport.fps} onChange={e => setVideoImport(v => ({ ...v, fps: +e.target.value }))}>
-                                {[1, 2, 3, 4, 6, 8, 12, 15, 24].map(v => <option key={v} value={v}>{v} fps</option>)}
+                        )}
+                        <label style={{ display: 'flex', alignItems: 'center', gap: 4 }} title={tr('화질/용량 선택. 고화질=원본 해상도 WebP(거의 무손실, 용량 적당) / 무손실=PNG(픽셀 완전 보존, 용량 큼)')}>
+                            <span style={{ color: '#888' }}>{tr('화질')}</span>
+                            <select className="time-input" style={{ width: 118 }} value={videoImport.quality} onChange={e => setVideoImport(v => ({ ...v, quality: e.target.value }))}>
+                                <option value="compressed">{tr('압축(작음)')}</option>
+                                <option value="high">{tr('고화질 WebP')}</option>
+                                <option value="lossless">{tr('무손실 PNG')}</option>
                             </select>
-                            {videoImport.quality === 'compressed' && <>
-                                <span style={{ width: 50, marginLeft: 6 }}>{tr('배율')}</span>
-                                <select className="time-input" style={{ width: 80 }} value={videoImport.scale} onChange={e => setVideoImport(v => ({ ...v, scale: +e.target.value }))}>
-                                    {[[1, '100%'], [0.75, '75%'], [0.5, '50%'], [0.35, '35%'], [0.25, '25%']].map(([v, l]) => <option key={v} value={v}>{l}</option>)}
-                                </select>
-                            </>}
-                        </div>
-                        <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 8, flexWrap: 'wrap' }}>
-                            <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                                <input type="checkbox" checked={videoImport.whole} onChange={e => setVideoImport(v => ({ ...v, whole: e.target.checked }))} /> {tr('영상 전체')}
-                            </label>
-                            {!videoImport.whole && (
-                                <label style={{ display: 'flex', alignItems: 'center', gap: 4 }} title={tr('가져올 컷 개수 (중복 병합분은 제외한 실제 컷 수)')}>
-                                    <input type="number" className="time-input" style={{ width: 70 }} min={1} max={5000} value={videoImport.maxFrames}
-                                        onChange={e => setVideoImport(v => ({ ...v, maxFrames: Math.max(1, Math.min(5000, Math.floor(+e.target.value) || 1)) }))} />
-                                    <span style={{ color: '#888' }}>{tr('컷')}</span>
-                                </label>
-                            )}
-                            <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                                <input type="checkbox" checked={videoImport.withAudio} onChange={e => setVideoImport(v => ({ ...v, withAudio: e.target.checked }))} /> {tr('음원도 같이')}
-                            </label>
-                            <label style={{ display: 'flex', alignItems: 'center', gap: 4 }} title={tr('영상의 일부 구간만 가져오기 (mm:ss)')}>
-                                <input type="checkbox" checked={videoImport.rangeOn} onChange={e => setVideoImport(v => ({ ...v, rangeOn: e.target.checked }))} /> {tr('구간만')}
-                            </label>
-                            {videoImport.rangeOn && (
-                                <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-                                    <input className="time-input" style={{ width: 60 }} placeholder="0:00" value={videoImport.startText} onChange={e => setVideoImport(v => ({ ...v, startText: e.target.value }))} />
-                                    <span style={{ color: '#888' }}>~</span>
-                                    <input className="time-input" style={{ width: 60 }} placeholder={tr('끝')} value={videoImport.endText} onChange={e => setVideoImport(v => ({ ...v, endText: e.target.value }))} />
-                                </span>
-                            )}
-                            <label style={{ display: 'flex', alignItems: 'center', gap: 4 }} title={tr('화질/용량 선택. 고화질=원본 해상도 WebP(거의 무손실, 용량 적당) / 무손실=PNG(픽셀 완전 보존, 용량 큼)')}>
-                                <span style={{ color: '#888' }}>{tr('화질')}</span>
-                                <select className="time-input" style={{ width: 118 }} value={videoImport.quality} onChange={e => setVideoImport(v => ({ ...v, quality: e.target.value }))}>
-                                    <option value="compressed">{tr('압축(작음)')}</option>
-                                    <option value="high">{tr('고화질 WebP')}</option>
-                                    <option value="lossless">{tr('무손실 PNG')}</option>
-                                </select>
-                            </label>
-                            <label style={{ display: 'flex', alignItems: 'center', gap: 4 }} title={tr('긴 영상을 여러 파트로 나눠서 가져오기 (재생 시 파트별/전체 선택 가능)')}>
-                                <input type="number" className="time-input" style={{ width: 46 }} min={1} max={50} value={videoImport.parts}
-                                    onChange={e => setVideoImport(v => ({ ...v, parts: Math.max(1, Math.min(50, Math.floor(+e.target.value) || 1)) }))} />
-                                <span style={{ color: 'var(--accent-soft)' }}>{tr('파트로 나누기')}</span>
-                            </label>
-                            <label style={{ display: 'flex', alignItems: 'center', gap: 4 }} title={tr('세로 영상(쇼츠)을 가로 캔버스에 넣으면 대부분이 여백이 됩니다. 영상에 맞추거나 직접 고르세요.')}>
-                                <span style={{ color: '#888' }}>{tr('캔버스 크기')}</span>
-                                <select className="time-input" style={{ width: 150 }} value={videoImport.canvasMode || 'source'}
-                                    onChange={e => setVideoImport(v => ({ ...v, canvasMode: e.target.value }))}>
-                                    <option value="source">{tr('영상 크기대로')}</option>
-                                    <option value="landscape">{tr('일반 (가로 1920×1080)')}</option>
-                                    <option value="portrait">{tr('쇼츠 (세로 1080×1920)')}</option>
-                                    <option value="keep">{tr('현재 캔버스 유지')}</option>
-                                </select>
-                            </label>
-                            <span style={{ marginLeft: 'auto' }}>{tr('중복 통합')}</span>
-                            <select className="time-input" style={{ width: 100 }} value={videoImport.dedupe} onChange={e => setVideoImport(v => ({ ...v, dedupe: e.target.value === 'exact' ? 'exact' : +e.target.value }))}>
-                                {[['0', tr('끄기')], ['exact', tr('완전 동일')], ['3', tr('거의 같음')], ['8', tr('느슨')]].map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+                        </label>
+                        <label style={{ display: 'flex', alignItems: 'center', gap: 4 }} title={tr('긴 영상을 여러 파트로 나눠서 가져오기 (재생 시 파트별/전체 선택 가능)')}>
+                            <input type="number" className="time-input" style={{ width: 46 }} min={1} max={50} value={videoImport.parts}
+                                onChange={e => setVideoImport(v => ({ ...v, parts: Math.max(1, Math.min(50, Math.floor(+e.target.value) || 1)) }))} />
+                            <span style={{ color: 'var(--accent-soft)' }}>{tr('파트로 나누기')}</span>
+                        </label>
+                        <label style={{ display: 'flex', alignItems: 'center', gap: 4 }} title={tr('세로 영상(쇼츠)을 가로 캔버스에 넣으면 대부분이 여백이 됩니다. 영상에 맞추거나 직접 고르세요.')}>
+                            <span style={{ color: '#888' }}>{tr('캔버스 크기')}</span>
+                            <select className="time-input" style={{ width: 150 }} value={videoImport.canvasMode || 'source'}
+                                onChange={e => setVideoImport(v => ({ ...v, canvasMode: e.target.value }))}>
+                                <option value="source">{tr('영상 크기대로')}</option>
+                                <option value="landscape">{tr('일반 (가로 1920×1080)')}</option>
+                                <option value="portrait">{tr('쇼츠 (세로 1080×1920)')}</option>
+                                <option value="keep">{tr('현재 캔버스 유지')}</option>
                             </select>
-                        </div>
-                        <div style={{ color: '#888', lineHeight: 1.6, marginBottom: 12 }}>
-                            {(() => {
-                                const t = targetCanvasFor(videoImport, canvasW, canvasH);
-                                const changes = t.w !== canvasW || t.h !== canvasH;
-                                return <>
-                                    {tr('캔버스({0}×{1})에 비율 유지로 넣고, 현재 트랙 뒤에 이어서 생성됩니다.', t.w, t.h)}
-                                    {changes && <> <b style={{ color: 'var(--accent-soft)' }}>{tr('가져오면 캔버스가 {0}×{1}로 바뀝니다.', t.w, t.h)}</b></>}
-                                </>;
-                            })()}<br />
-                            {videoImport.quality === 'lossless'
-                                ? <><b style={{ color: 'var(--accent-soft)' }}>{tr('무손실 PNG')}</b> {tr('— 픽셀 완전 보존, 장당 용량이 큽니다(수 MB). 긴 영상은')} <b>{tr('고화질 WebP')}</b>{tr('를 권장.')}</>
-                                : videoImport.quality === 'high'
-                                    ? <>{tr('원본 해상도')} <b style={{ color: 'var(--accent-soft)' }}>{tr('고화질 WebP(거의 무손실)')}</b> {tr('— 무손실 대비 용량 약 1/5~1/8, 화질 차이는 거의 없음.')}</>
-                                    : <>{tr('프레임은')} <b style={{ color: '#9b9' }}>{tr('WebP로 압축 저장')}</b>{tr('되어 원본 대비 용량이 크게 줄어듭니다')}{videoImport.scale < 1 ? ' ' + tr('(배율 {0}%로 추가 절감)', Math.round(videoImport.scale * 100)) : ''}.</>}
-                            {videoImport.dedupe === 'exact'
-                                ? <><br /><b style={{ color: '#9b9' }}>{tr('완전히 똑같은 프레임만')}</b> {tr('한 컷으로 합칩니다 (픽셀 단위 비교).')}</>
-                                : videoImport.dedupe > 0 && <><br />{tr('이어지는')} <b style={{ color: '#9b9' }}>{tr('비슷한 화면을 한 컷으로 합칩니다')}</b> {tr('— 정지 구간이 길수록 컷 수·용량이 줄어듭니다.')}</>}
-                            {!videoImport.whole && <><br />{tr('지정한 {0}컷은 중복 병합을 제외한 실제 컷 수입니다 (합쳐진 프레임은 개수에 안 셉니다).', videoImport.maxFrames)}</>}
-                            {videoImport.rangeOn && <><br /><b style={{ color: 'var(--accent-soft)' }}>{videoImport.startText || '0:00'} ~ {videoImport.endText || tr('끝')}</b> {tr('구간만 가져옵니다 (mm:ss).')}</>}
-                            {videoImport.parts > 1 && <><br /><b style={{ color: 'var(--accent-soft)' }}>{tr('{0}개 파트', videoImport.parts)}</b>{' '}{tr('로 나눠 가져옵니다 — 재생 시 파트별 또는 전체로 볼 수 있습니다.')}</>}
-                            {videoImport.whole && <><br /><span style={{ color: '#c99' }}>{tr('전체 추출: 길이가 길면 컷이 매우 많아집니다. fps를 낮게(1~4) 두는 것을 권장합니다.')}</span></>}
-                        </div>
-                        {/* The text must be allowed to shrink and the button not to: without flex:1 and
-                            min-width:0 the longer English copy collapses into a one-word column. */}
-                        <div style={{ background: 'hsl(var(--ui-h) var(--ui-s) 12%)', border: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)', borderRadius: 6, padding: '8px 10px', marginBottom: 10, color: 'var(--accent-pale)', fontSize: 11.5, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
-                            <span style={{ flex: '1 1 240px', minWidth: 0 }}><b style={{ color: '#8de' }}>{tr('영상 위에 덧그리기')}</b> {tr('— 프레임으로 쪼개지 않고 원본 영상을 트랙으로 깔고 그 위에 그림·텍스트. 24fps 장편도 매끄럽게 재생.')} <b style={{ color: '#8de' }}>{tr('음원도 함께')}</b> {tr('들어갑니다.')}</span>
-                            <button className="button" style={{ whiteSpace: 'nowrap', flex: '0 0 auto' }} onClick={() => {
-                                const useRange = videoImport.rangeOn && parseClock(videoImport.endText) > parseClock(videoImport.startText);
-                                const off = useRange ? parseClock(videoImport.startText) : 0;
-                                const clip = useRange ? (parseClock(videoImport.endText) - parseClock(videoImport.startText)) : null;
-                                // The canvas-size choice above applies here too. Without it a
-                                // portrait clip laid down as-is is letterboxed into a landscape
-                                // canvas - the same thing the frame importer does with it.
-                                const tgt = targetCanvasFor(videoImport, canvasW, canvasH);
-                                if (tgt.w !== canvasW || tgt.h !== canvasH) setCanvasSize({ w: tgt.w, h: tgt.h });
-                                loadVideoOverlay(videoImport.file, videoImport.label || videoImport.file.name, 0, off, clip);
-                                // The overlay <video> is muted; always bring the audio via a synced audio track.
-                                loadAudioUrl(URL.createObjectURL(videoImport.file), (videoImport.label || tr('영상')) + tr(' (음원)'), 0, off, clip);
-                                setVideoImport(null);
-                            }}>{tr('영상 그대로 깔기(+음원)')}</button>
-                        </div>
-                        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6 }}>
-                            <button className="button" onClick={() => setVideoImport(null)}>{tr('취소')}</button>
-                            <button className="button button-primary" onClick={runVideoImport}>{tr('프레임으로 가져오기')}</button>
-                        </div>
-                    </>
-                )}
-            </div>
-        </div>
+                        </label>
+                        <span style={{ marginLeft: 'auto' }}>{tr('중복 통합')}</span>
+                        <select className="time-input" style={{ width: 100 }} value={videoImport.dedupe} onChange={e => setVideoImport(v => ({ ...v, dedupe: e.target.value === 'exact' ? 'exact' : +e.target.value }))}>
+                            {[['0', tr('끄기')], ['exact', tr('완전 동일')], ['3', tr('거의 같음')], ['8', tr('느슨')]].map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+                        </select>
+                    </div>
+                    <div style={{ color: '#888', lineHeight: 1.6, marginBottom: 12 }}>
+                        {(() => {
+                            const t = targetCanvasFor(videoImport, canvasW, canvasH);
+                            const changes = t.w !== canvasW || t.h !== canvasH;
+                            return <>
+                                {tr('캔버스({0}×{1})에 비율 유지로 넣고, 현재 트랙 뒤에 이어서 생성됩니다.', t.w, t.h)}
+                                {changes && <> <b style={{ color: 'var(--accent-soft)' }}>{tr('가져오면 캔버스가 {0}×{1}로 바뀝니다.', t.w, t.h)}</b></>}
+                            </>;
+                        })()}<br />
+                        {videoImport.quality === 'lossless'
+                            ? <><b style={{ color: 'var(--accent-soft)' }}>{tr('무손실 PNG')}</b> {tr('— 픽셀 완전 보존, 장당 용량이 큽니다(수 MB). 긴 영상은')} <b>{tr('고화질 WebP')}</b>{tr('를 권장.')}</>
+                            : videoImport.quality === 'high'
+                                ? <>{tr('원본 해상도')} <b style={{ color: 'var(--accent-soft)' }}>{tr('고화질 WebP(거의 무손실)')}</b> {tr('— 무손실 대비 용량 약 1/5~1/8, 화질 차이는 거의 없음.')}</>
+                                : <>{tr('프레임은')} <b style={{ color: '#9b9' }}>{tr('WebP로 압축 저장')}</b>{tr('되어 원본 대비 용량이 크게 줄어듭니다')}{videoImport.scale < 1 ? ' ' + tr('(배율 {0}%로 추가 절감)', Math.round(videoImport.scale * 100)) : ''}.</>}
+                        {videoImport.dedupe === 'exact'
+                            ? <><br /><b style={{ color: '#9b9' }}>{tr('완전히 똑같은 프레임만')}</b> {tr('한 컷으로 합칩니다 (픽셀 단위 비교).')}</>
+                            : videoImport.dedupe > 0 && <><br />{tr('이어지는')} <b style={{ color: '#9b9' }}>{tr('비슷한 화면을 한 컷으로 합칩니다')}</b> {tr('— 정지 구간이 길수록 컷 수·용량이 줄어듭니다.')}</>}
+                        {!videoImport.whole && <><br />{tr('지정한 {0}컷은 중복 병합을 제외한 실제 컷 수입니다 (합쳐진 프레임은 개수에 안 셉니다).', videoImport.maxFrames)}</>}
+                        {videoImport.rangeOn && <><br /><b style={{ color: 'var(--accent-soft)' }}>{videoImport.startText || '0:00'} ~ {videoImport.endText || tr('끝')}</b> {tr('구간만 가져옵니다 (mm:ss).')}</>}
+                        {videoImport.parts > 1 && <><br /><b style={{ color: 'var(--accent-soft)' }}>{tr('{0}개 파트', videoImport.parts)}</b>{' '}{tr('로 나눠 가져옵니다 — 재생 시 파트별 또는 전체로 볼 수 있습니다.')}</>}
+                        {videoImport.whole && <><br /><span style={{ color: '#c99' }}>{tr('전체 추출: 길이가 길면 컷이 매우 많아집니다. fps를 낮게(1~4) 두는 것을 권장합니다.')}</span></>}
+                    </div>
+                    {/* The text must be allowed to shrink and the button not to: without flex:1 and
+                        min-width:0 the longer English copy collapses into a one-word column. */}
+                    <div style={{ background: 'hsl(var(--ui-h) var(--ui-s) 12%)', border: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)', borderRadius: 6, padding: '8px 10px', marginBottom: 10, color: 'var(--accent-pale)', fontSize: 11.5, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+                        <span style={{ flex: '1 1 240px', minWidth: 0 }}><b style={{ color: '#8de' }}>{tr('영상 위에 덧그리기')}</b> {tr('— 프레임으로 쪼개지 않고 원본 영상을 트랙으로 깔고 그 위에 그림·텍스트. 24fps 장편도 매끄럽게 재생.')} <b style={{ color: '#8de' }}>{tr('음원도 함께')}</b> {tr('들어갑니다.')}</span>
+                        <button className="button" style={{ whiteSpace: 'nowrap', flex: '0 0 auto' }} onClick={() => {
+                            const useRange = videoImport.rangeOn && parseClock(videoImport.endText) > parseClock(videoImport.startText);
+                            const off = useRange ? parseClock(videoImport.startText) : 0;
+                            const clip = useRange ? (parseClock(videoImport.endText) - parseClock(videoImport.startText)) : null;
+                            // The canvas-size choice above applies here too. Without it a
+                            // portrait clip laid down as-is is letterboxed into a landscape
+                            // canvas - the same thing the frame importer does with it.
+                            const tgt = targetCanvasFor(videoImport, canvasW, canvasH);
+                            if (tgt.w !== canvasW || tgt.h !== canvasH) setCanvasSize({ w: tgt.w, h: tgt.h });
+                            loadVideoOverlay(videoImport.file, videoImport.label || videoImport.file.name, 0, off, clip);
+                            // The overlay <video> is muted; always bring the audio via a synced audio track.
+                            loadAudioUrl(URL.createObjectURL(videoImport.file), (videoImport.label || tr('영상')) + tr(' (음원)'), 0, off, clip);
+                            setVideoImport(null);
+                        }}>{tr('영상 그대로 깔기(+음원)')}</button>
+                    </div>
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6 }}>
+                        <button className="button" onClick={() => setVideoImport(null)}>{tr('취소')}</button>
+                        <button className="button button-primary" onClick={runVideoImport}>{tr('프레임으로 가져오기')}</button>
+                    </div>
+                </>
+            )}
+        </Modal>
     );
 }
 
 // Scene-change detection settings. Only opens when there is a video overlay.
 export function SceneDetectModal({ sceneCfg, setSceneCfg, sceneDetect, runSceneDetect, videoOpacity, setVideoOpacity, cancelSceneDetect, autoSceneDetect, setAutoSceneDetect, clearVideoCuts, hasCuts }) {
     return (
-        <div onClick={() => setSceneCfg(null)} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <div onClick={e => e.stopPropagation()} style={{ width: 360, background: 'hsl(var(--ui-h) var(--ui-s) 15%)', border: '1px solid #333', borderRadius: 8, padding: 18, color: '#ccc', fontSize: 12.5 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-                    <span className="panel-title">{tr('영상 설정')}</span>
-                    <button className="icon-btn" onClick={() => setSceneCfg(null)}>✕</button>
-                </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-                    <span style={{ width: 56 }}>{tr('농도')}</span>
-                    <input type="range" min={0} max={100} step={1} style={{ flex: 1 }}
-                        value={Math.round((videoOpacity ?? 1) * 100)}
-                        onChange={e => setVideoOpacity(+e.target.value / 100)} />
-                    <span style={{ width: 40, color: '#888', textAlign: 'right' }}>{Math.round((videoOpacity ?? 1) * 100)}%</span>
-                </div>
-                <div style={{ color: '#888', marginBottom: 12 }}>{tr('영상 투명도 — 위에 그린 그림이 잘 보이도록 흐리게 할 수 있습니다.')}</div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
-                    <span style={{ width: 56 }}>{tr('민감도')}</span>
-                    <input type="range" min={6} max={30} step={1} value={30 - sceneCfg.threshold + 6} onChange={e => setSceneCfg(v => ({ ...v, threshold: 30 - (+e.target.value) + 6 }))} style={{ flex: 1 }} />
-                    <span style={{ width: 60, color: '#888', textAlign: 'right' }}>{sceneCfg.threshold <= 10 ? tr('민감') : sceneCfg.threshold >= 20 ? tr('둔감') : tr('보통')}</span>
-                </div>
-                <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
-                    <input type="checkbox" checked={sceneCfg.rangeOn} onChange={e => setSceneCfg(v => ({ ...v, rangeOn: e.target.checked }))} /> {tr('구간만 감지 (전체보다 빠름)')}
-                </label>
-                {sceneCfg.rangeOn && (
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8, paddingLeft: 22 }}>
-                        <input className="time-input" style={{ width: 70 }} placeholder="0:00" value={sceneCfg.startText} onChange={e => setSceneCfg(v => ({ ...v, startText: e.target.value }))} />
-                        <span style={{ color: '#888' }}>~</span>
-                        <input className="time-input" style={{ width: 70 }} placeholder={tr('끝(mm:ss)')} value={sceneCfg.endText} onChange={e => setSceneCfg(v => ({ ...v, endText: e.target.value }))} />
-                    </div>
-                )}
-                <div style={{ color: '#888', lineHeight: 1.6, marginBottom: 12 }}>
-                    {tr('장면이 바뀌는 지점을 정밀하게 찾아')} <b style={{ color: '#fde047' }}>{tr('노란 표시')}</b>{tr('로 타임라인에 찍습니다. 민감도를 올리면 미세한 전환도 잡습니다.')}
-                    {sceneDetect && <><br /><b style={{ color: 'var(--accent-soft)' }}>{tr('감지 중…')} {sceneDetect.total ? Math.round(sceneDetect.done / sceneDetect.total * 100) : 0}%</b></>}
-                </div>
-                {/* Detection is a scan of the whole video: worth it for a cut-heavy clip, pure
-                    cost for a single continuous take. Hence a choice rather than something that
-                    always happens on load. */}
-                <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 12 }}
-                    title={tr('영상을 불러올 때 장면 전환을 자동으로 찾습니다. 긴 영상에서는 시간이 걸립니다.')}>
-                    <input type="checkbox" checked={!!autoSceneDetect} onChange={e => setAutoSceneDetect(e.target.checked)} />
-                    {tr('자동 컷 감지')}
-                </label>
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6 }}>
-                    {hasCuts && <button className="button" onClick={clearVideoCuts}>{tr('컷 표시 지우기')}</button>}
-                    <button className="button" onClick={() => setSceneCfg(null)}>{tr('닫기')}</button>
-                    {sceneDetect
-                        ? <button className="button" onClick={cancelSceneDetect}>{tr('감지 취소')}</button>
-                        : <button className="button button-primary" onClick={() => runSceneDetect(sceneCfg)}>{tr('감지')}</button>}
-                </div>
+        <Modal title={tr('영상 설정')} onClose={() => setSceneCfg(null)} width={360}
+            panelStyle={{ color: '#ccc', fontSize: 12.5 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+                <span style={{ width: 56 }}>{tr('농도')}</span>
+                <input type="range" min={0} max={100} step={1} style={{ flex: 1 }}
+                    value={Math.round((videoOpacity ?? 1) * 100)}
+                    onChange={e => setVideoOpacity(+e.target.value / 100)} />
+                <span style={{ width: 40, color: '#888', textAlign: 'right' }}>{Math.round((videoOpacity ?? 1) * 100)}%</span>
             </div>
-        </div>
+            <div style={{ color: '#888', marginBottom: 12 }}>{tr('영상 투명도 — 위에 그린 그림이 잘 보이도록 흐리게 할 수 있습니다.')}</div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+                <span style={{ width: 56 }}>{tr('민감도')}</span>
+                <input type="range" min={6} max={30} step={1} value={30 - sceneCfg.threshold + 6} onChange={e => setSceneCfg(v => ({ ...v, threshold: 30 - (+e.target.value) + 6 }))} style={{ flex: 1 }} />
+                <span style={{ width: 60, color: '#888', textAlign: 'right' }}>{sceneCfg.threshold <= 10 ? tr('민감') : sceneCfg.threshold >= 20 ? tr('둔감') : tr('보통')}</span>
+            </div>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+                <input type="checkbox" checked={sceneCfg.rangeOn} onChange={e => setSceneCfg(v => ({ ...v, rangeOn: e.target.checked }))} /> {tr('구간만 감지 (전체보다 빠름)')}
+            </label>
+            {sceneCfg.rangeOn && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8, paddingLeft: 22 }}>
+                    <input className="time-input" style={{ width: 70 }} placeholder="0:00" value={sceneCfg.startText} onChange={e => setSceneCfg(v => ({ ...v, startText: e.target.value }))} />
+                    <span style={{ color: '#888' }}>~</span>
+                    <input className="time-input" style={{ width: 70 }} placeholder={tr('끝(mm:ss)')} value={sceneCfg.endText} onChange={e => setSceneCfg(v => ({ ...v, endText: e.target.value }))} />
+                </div>
+            )}
+            <div style={{ color: '#888', lineHeight: 1.6, marginBottom: 12 }}>
+                {tr('장면이 바뀌는 지점을 정밀하게 찾아')} <b style={{ color: '#fde047' }}>{tr('노란 표시')}</b>{tr('로 타임라인에 찍습니다. 민감도를 올리면 미세한 전환도 잡습니다.')}
+                {sceneDetect && <><br /><b style={{ color: 'var(--accent-soft)' }}>{tr('감지 중…')} {sceneDetect.total ? Math.round(sceneDetect.done / sceneDetect.total * 100) : 0}%</b></>}
+            </div>
+            {/* Detection is a scan of the whole video: worth it for a cut-heavy clip, pure
+                cost for a single continuous take. Hence a choice rather than something that
+                always happens on load. */}
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 12 }}
+                title={tr('영상을 불러올 때 장면 전환을 자동으로 찾습니다. 긴 영상에서는 시간이 걸립니다.')}>
+                <input type="checkbox" checked={!!autoSceneDetect} onChange={e => setAutoSceneDetect(e.target.checked)} />
+                {tr('자동 컷 감지')}
+            </label>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6 }}>
+                {hasCuts && <button className="button" onClick={clearVideoCuts}>{tr('컷 표시 지우기')}</button>}
+                <button className="button" onClick={() => setSceneCfg(null)}>{tr('닫기')}</button>
+                {sceneDetect
+                    ? <button className="button" onClick={cancelSceneDetect}>{tr('감지 취소')}</button>
+                    : <button className="button button-primary" onClick={() => runSceneDetect(sceneCfg)}>{tr('감지')}</button>}
+            </div>
+        </Modal>
     );
 }
 
@@ -409,24 +384,18 @@ export function LinkPromptModal({ title, placeholder, onSubmit, onClose }) {
     React.useEffect(() => { inputRef.current?.focus(); }, []);
     const submit = () => { const v = url.trim(); if (v) onSubmit(v); };
     return (
-        <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1200, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <div onClick={e => e.stopPropagation()} style={{ width: 460, background: 'hsl(var(--ui-h) var(--ui-s) 15%)', border: '1px solid hsl(var(--ui-h) var(--ui-s) 26%)', borderRadius: 10, padding: 18 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
-                    <span className="panel-title">{title}</span>
-                    <button className="icon-btn" onClick={onClose}>✕</button>
-                </div>
-                <input ref={inputRef} className="time-input" style={{ width: '100%', height: 34 }}
-                    placeholder={placeholder} value={url}
-                    onChange={e => setUrl(e.target.value)}
-                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); submit(); } if (e.key === 'Escape') onClose(); }} />
-                <div style={{ fontSize: 11, color: '#888', marginTop: 8 }}>{tr('유튜브 주소를 붙여넣고 Enter를 누르세요.')}</div>
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6, marginTop: 12 }}>
-                    <button className="button" onClick={onClose}>{tr('취소')}</button>
-                    <button className="button button-primary" style={{ background: 'var(--accent)', borderColor: 'var(--accent-hi)', color: '#fff' }}
-                        disabled={!url.trim()} onClick={submit}>{tr('가져오기')}</button>
-                </div>
+        <Modal title={title} onClose={onClose} width={460} z={1200} panelStyle={{ borderRadius: 10 }}>
+            <input ref={inputRef} className="time-input" style={{ width: '100%', height: 34 }}
+                placeholder={placeholder} value={url}
+                onChange={e => setUrl(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); submit(); } if (e.key === 'Escape') onClose(); }} />
+            <div style={{ fontSize: 11, color: '#888', marginTop: 8 }}>{tr('유튜브 주소를 붙여넣고 Enter를 누르세요.')}</div>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6, marginTop: 12 }}>
+                <button className="button" onClick={onClose}>{tr('취소')}</button>
+                <button className="button button-primary" style={{ background: 'var(--accent)', borderColor: 'var(--accent-hi)', color: '#fff' }}
+                    disabled={!url.trim()} onClick={submit}>{tr('가져오기')}</button>
             </div>
-        </div>
+        </Modal>
     );
 }
 
@@ -445,37 +414,32 @@ export function ToolKeysModal({ keymap, setKeymap, defaultKeys, keyLabels, confl
     };
     const ids = Object.keys(defaultKeys).filter(id => id.startsWith(TOOL_PREFIX));
     return (
-        <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1001, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <div onClick={e => e.stopPropagation()} style={{ width: 400, maxHeight: '80vh', overflow: 'auto', background: 'hsl(var(--ui-h) var(--ui-s) 15%)', border: '1px solid #333', borderRadius: 8, padding: 18, color: '#ccc', fontSize: 12.5 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
-                    <span className="panel-title">{tr('도구 단축키')}</span>
-                    <button className="icon-btn" onClick={onClose}><X size={14} /></button>
-                </div>
-                <div style={{ fontSize: 11, color: '#888', marginBottom: 10 }}>
-                    {rebinding ? tr('원하는 키를 누르세요 (Esc = 취소)') : tr('바꿀 항목을 누르세요')}
-                </div>
-                {Object.entries(conflicts || {}).map(([key, actions]) => (
-                    <div key={key} style={{ fontSize: 11, color: '#e0a84e', padding: '4px 0' }}>
-                        <AlertTriangle size={11} style={{ verticalAlign: '-1px' }} /> {tr('{0} 키가 겹칩니다: {1} — 하나만 동작합니다.', key, actions.map(a => tr(keyLabels[a] || a)).join(', '))}
-                    </div>
-                ))}
-                {ids.map(id => (
-                    <div key={id} className="key-row" style={{ display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)', padding: '6px 0' }}>
-                        <span style={{ flex: 1, color: '#ddd' }}>{tr(keyLabels[id])}</span>
-                        <button className="button" style={{ height: 30, minWidth: 110, justifyContent: 'center', fontFamily: 'monospace' }}
-                            onClick={() => setRebinding(rebinding === id ? null : id)}>
-                            {rebinding === id ? tr('키 입력 대기…') : (keymap[id] || tr('(없음)'))}
-                        </button>
-                        {keymap[id] !== defaultKeys[id] && (
-                            <button className="small-btn" title={tr('기본값으로')} onClick={() => saveKeymap({ ...keymap, [id]: defaultKeys[id] })}>{tr('되돌리기')}</button>
-                        )}
-                    </div>
-                ))}
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6, marginTop: 12 }}>
-                    <button className="button" onClick={() => saveKeymap({ ...keymap, ...Object.fromEntries(ids.map(id => [id, defaultKeys[id]])) })}>{tr('도구 기본값')}</button>
-                    <button className="button button-primary" onClick={onClose}>{tr('닫기')}</button>
-                </div>
+        <Modal title={tr('도구 단축키')} onClose={onClose} width={400} maxHeight="80vh" z={1001}
+            closeOnEscape={!rebinding} panelStyle={{ color: '#ccc', fontSize: 12.5 }}>
+            <div style={{ fontSize: 11, color: '#888', marginBottom: 10 }}>
+                {rebinding ? tr('원하는 키를 누르세요 (Esc = 취소)') : tr('바꿀 항목을 누르세요')}
             </div>
-        </div>
+            {Object.entries(conflicts || {}).map(([key, actions]) => (
+                <div key={key} style={{ fontSize: 11, color: '#e0a84e', padding: '4px 0' }}>
+                    <AlertTriangle size={11} style={{ verticalAlign: '-1px' }} /> {tr('{0} 키가 겹칩니다: {1} — 하나만 동작합니다.', key, actions.map(a => tr(keyLabels[a] || a)).join(', '))}
+                </div>
+            ))}
+            {ids.map(id => (
+                <div key={id} className="key-row" style={{ display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)', padding: '6px 0' }}>
+                    <span style={{ flex: 1, color: '#ddd' }}>{tr(keyLabels[id])}</span>
+                    <button className="button" style={{ height: 30, minWidth: 110, justifyContent: 'center', fontFamily: 'monospace' }}
+                        onClick={() => setRebinding(rebinding === id ? null : id)}>
+                        {rebinding === id ? tr('키 입력 대기…') : (keymap[id] || tr('(없음)'))}
+                    </button>
+                    {keymap[id] !== defaultKeys[id] && (
+                        <button className="small-btn" title={tr('기본값으로')} onClick={() => saveKeymap({ ...keymap, [id]: defaultKeys[id] })}>{tr('되돌리기')}</button>
+                    )}
+                </div>
+            ))}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6, marginTop: 12 }}>
+                <button className="button" onClick={() => saveKeymap({ ...keymap, ...Object.fromEntries(ids.map(id => [id, defaultKeys[id]])) })}>{tr('도구 기본값')}</button>
+                <button className="button button-primary" onClick={onClose}>{tr('닫기')}</button>
+            </div>
+        </Modal>
     );
 }

--- a/test/projectAssets.test.js
+++ b/test/projectAssets.test.js
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { frameStorage, frameLoad, imageExt, imageExtFromType, audioExt, videoExt } from '../src/core/projectAssets.js';
+
+const blobEntry = () => ({ blob: new Blob(['x']), url: null });
+const urlEntry = () => ({ blob: null, url: 'data:image/webp;base64,AA' });
+
+test('frameStorage: a server save externalizes everything', () => {
+    assert.equal(frameStorage(blobEntry(), { assetSink: [] }), 'asset');
+    assert.equal(frameStorage(urlEntry(), { assetSink: [] }), 'asset');
+    // assetSink wins over blobsOk - a server save never stores Blobs inline.
+    assert.equal(frameStorage(blobEntry(), { assetSink: [], blobsOk: true }), 'asset');
+});
+
+test('frameStorage: an autosave keeps Blobs off the heap', () => {
+    assert.equal(frameStorage(blobEntry(), { blobsOk: true }), 'blob');
+});
+
+test('frameStorage: a legacy entry with no Blob still gets saved', () => {
+    // The whole point: blobsOk is a preference, not a requirement. An older entry that only ever
+    // had a dataURL must embed rather than be dropped from the autosave.
+    assert.equal(frameStorage(urlEntry(), { blobsOk: true }), 'dataurl');
+});
+
+test('frameStorage: a local file embeds everything', () => {
+    assert.equal(frameStorage(blobEntry(), {}), 'dataurl');
+    assert.equal(frameStorage(urlEntry(), {}), 'dataurl');
+    assert.equal(frameStorage({}, undefined), 'dataurl');
+});
+
+test('frameLoad: a Blob from IndexedDB is used as-is', () => {
+    assert.equal(frameLoad(new Blob(['x']), new Set(), 'a'), 'blob');
+});
+
+test('frameLoad: the manifest marks frames that stay compressed', () => {
+    assert.equal(frameLoad('data:image/png;base64,AA', new Set(['a']), 'a'), 'compressed');
+});
+
+test('frameLoad: video frames in a file with no manifest are recognised by format', () => {
+    // Files written before compressedBitmaps existed have no manifest. Decoding their frames to
+    // ImageData is the memory blowup lazy decoding exists to avoid, so the format has to say so.
+    assert.equal(frameLoad('data:image/webp;base64,AA', new Set(), 'a'), 'compressed');
+    assert.equal(frameLoad('data:image/jpeg;base64,AA', new Set(), 'a'), 'compressed');
+});
+
+test('frameLoad: a drawing layer decodes to editable pixels', () => {
+    assert.equal(frameLoad('data:image/png;base64,AA', new Set(), 'a'), 'decode');
+    assert.equal(frameLoad('data:image/png;base64,AA', new Set(['other']), 'a'), 'decode');
+});
+
+test('frameLoad: survives a missing manifest object', () => {
+    assert.equal(frameLoad('data:image/png;base64,AA', undefined, 'a'), 'decode');
+});
+
+test('imageExt: the recorded extension wins over the dataURL', () => {
+    assert.equal(imageExt({ ext: 'png', url: 'data:image/webp;base64,AA' }), 'png');
+    assert.equal(imageExt({ url: 'data:image/jpeg;base64,AA' }), 'jpeg');
+    assert.equal(imageExt({}), 'webp');
+    assert.equal(imageExt(null), 'webp');
+});
+
+test('audioExt: container names browsers report are renamed to usable ones', () => {
+    assert.equal(audioExt('data:audio/mpeg;base64,AA'), 'mp3');
+    assert.equal(audioExt('data:audio/x-m4a;base64,AA'), 'm4a');
+});
+
+test('audioExt: anything else is kept, and a missing one defaults to mp3', () => {
+    assert.equal(audioExt('data:audio/ogg;base64,AA'), 'ogg');
+    assert.equal(audioExt('data:audio/webm;base64,AA'), 'webm');
+    assert.equal(audioExt(null), 'mp3');
+    assert.equal(audioExt('data:image/png;base64,AA'), 'mp3');
+});
+
+test('videoExt: container names browsers report are renamed to usable ones', () => {
+    assert.equal(videoExt('video/x-matroska'), 'mkv');
+    assert.equal(videoExt('video/quicktime'), 'mov');
+});
+
+test('videoExt: anything else is kept, and a missing one defaults to mp4', () => {
+    assert.equal(videoExt('video/mp4'), 'mp4');
+    assert.equal(videoExt('video/webm'), 'webm');
+    assert.equal(videoExt(''), 'mp4');
+    assert.equal(videoExt(undefined), 'mp4');
+});
+
+test('the audio and video rename maps stay separate', () => {
+    // quicktime is a video container; nothing should rename it on the audio side, and vice versa.
+    assert.equal(audioExt('data:audio/quicktime;base64,AA'), 'quicktime');
+    assert.equal(videoExt('video/mpeg'), 'mpeg');
+});
+
+test('imageExtFromType: a Blob MIME type, with webp as the fallback', () => {
+    assert.equal(imageExtFromType('image/png'), 'png');
+    assert.equal(imageExtFromType('image/webp'), 'webp');
+    assert.equal(imageExtFromType(''), 'webp');
+    assert.equal(imageExtFromType(undefined), 'webp');
+    // A Blob with no recorded type reads as empty, not as some other image format.
+    assert.equal(imageExtFromType('application/octet-stream'), 'webp');
+});

--- a/test/timelineZoom.test.js
+++ b/test/timelineZoom.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    TRACK_GUTTER, PPS_MIN, PPS_MAX, clampPps, timeAtX, xAtTime, scrollToHold, zoomAnchored, pinchZoom,
+} from '../src/core/timelineZoom.js';
+
+test('clampPps holds the scale inside its usable range', () => {
+    assert.equal(clampPps(50), 50);
+    assert.equal(clampPps(1), PPS_MIN);
+    assert.equal(clampPps(9999), PPS_MAX);
+    assert.equal(clampPps(NaN), PPS_MIN);
+});
+
+test('timeAtX and xAtTime account for the sticky label column', () => {
+    // Time zero is not the left edge of the element - it is one gutter in.
+    assert.equal(timeAtX(0, TRACK_GUTTER, 50), 0);
+    assert.equal(xAtTime(0, 50), TRACK_GUTTER);
+    assert.equal(timeAtX(0, TRACK_GUTTER + 100, 50), 2);
+    assert.equal(xAtTime(2, 50), TRACK_GUTTER + 100);
+});
+
+test('timeAtX and xAtTime are inverses through a scroll', () => {
+    for (const [scroll, x, pps] of [[0, 300, 50], [740, 12, 120], [1200, 640, 17]]) {
+        const t = timeAtX(scroll, x, pps);
+        assert.equal(xAtTime(t, pps) - scroll, x);
+    }
+});
+
+test('zooming keeps the time under the cursor under the cursor', () => {
+    const scrollLeft = 400, localX = 250, prev = 50;
+    const held = timeAtX(scrollLeft, localX, prev);
+    for (const factor of [1.1, 0.9, 2, 0.5]) {
+        const r = zoomAnchored(prev, factor, scrollLeft, localX);
+        assert.ok(r, 'should have zoomed');
+        // The whole point: the same instant is still under the same pixel afterwards.
+        assert.ok(Math.abs(timeAtX(r.scrollLeft, localX, r.pps) - held) < 1e-9);
+    }
+});
+
+test('zooming at the very start does not scroll to a negative position', () => {
+    // Zooming out at the left edge wants a negative scrollLeft, which is not a place the
+    // timeline can be; asking for it once left the first label overlapping the ruler.
+    const r = zoomAnchored(50, 0.5, 0, 10);
+    assert.ok(r);
+    assert.ok(r.scrollLeft >= 0, `scrollLeft was ${r.scrollLeft}`);
+});
+
+test('zoomAnchored reports no change at the limits', () => {
+    // Returning null rather than an unchanged pair is what lets the caller leave the scroll
+    // alone, instead of recomputing it from a scale that did not move.
+    assert.equal(zoomAnchored(PPS_MAX, 1.1, 0, 100), null);
+    assert.equal(zoomAnchored(PPS_MIN, 0.9, 0, 100), null);
+    assert.notEqual(zoomAnchored(PPS_MAX, 0.9, 0, 100), null);
+    assert.notEqual(zoomAnchored(PPS_MIN, 1.1, 0, 100), null);
+});
+
+test('zoomAnchored clamps rather than overshooting', () => {
+    assert.equal(zoomAnchored(PPS_MAX - 1, 4, 0, 100).pps, PPS_MAX);
+    assert.equal(zoomAnchored(PPS_MIN + 1, 0.1, 0, 100).pps, PPS_MIN);
+});
+
+test('a pinch scales from where the fingers started, not from the current value', () => {
+    const pinch = { startPps: 50, startDist: 100, anchorTime: 4 };
+    assert.equal(pinchZoom(pinch, 200, 300).pps, 100);
+    assert.equal(pinchZoom(pinch, 50, 300).pps, 25);
+    // Going out and back returns to exactly the starting scale - accumulating a factor per move
+    // event would have drifted away from it.
+    assert.equal(pinchZoom(pinch, 100, 300).pps, 50);
+});
+
+test('a pinch holds the time between the fingers', () => {
+    const pinch = { startPps: 50, startDist: 100, anchorTime: 4 };
+    const r = pinchZoom(pinch, 180, 300);
+    assert.ok(Math.abs(timeAtX(r.scrollLeft, 300, r.pps) - 4) < 1e-9);
+});
+
+test('a pinch that starts with the fingers together does not divide by zero', () => {
+    const r = pinchZoom({ startPps: 50, startDist: 0, anchorTime: 1 }, 100, 200);
+    assert.ok(Number.isFinite(r.pps) && Number.isFinite(r.scrollLeft));
+});
+
+test('scrollToHold never goes negative', () => {
+    assert.equal(scrollToHold(0, 50, 500), 0);
+    assert.equal(scrollToHold(10, 50, 100), 10 * 50 + TRACK_GUTTER - 100);
+});


### PR DESCRIPTION
Four commits, each removing a set of copies that had drifted apart. Part of #3.

## Project storage mode

A project is written three ways and the difference is not cosmetic — a local `.emv` embeds everything so the file stands alone; an autosave stores Blobs, because base64 costs a third more bytes plus a heap copy every few seconds and that is what used to run a big import out of memory; a server save uploads assets separately so the JSON stays small.

Which one applied was decided inline at each call site with the fallbacks rewritten each time, and the extension maps likewise — three copies, no tests, no way to notice a wrong answer until a file will not open. Now one module, 16 tests, including the two cases the copies got right only by accident: a legacy entry with a dataURL and no Blob still embeds under a Blob-preferring autosave instead of being dropped, and a video frame from a file predating the `compressedBitmaps` manifest is recognised by format so it is not decoded to ImageData.

## Timeline gutter and anchored zoom

The pixel where time zero sits is one sticky-label-column in from the left edge. That width was a bare `60` in six places in App.jsx and a seventh under another name in the gestures hook. It is defined by `.tl-track-label` in App.css and nothing said so — editing the CSS would have left the playhead landing off the beat, with no compile error and nothing to grep for.

Zoom-about-a-point was the same arithmetic four times. 12 tests now cover it, including that a zoom is exactly reversible and that a pinch scales from the distance the fingers started at, so going out and back returns to the original scale instead of accumulating drift.

## A bug this surfaced

Two pinch implementations on one element made that element's lifetime worth looking at: `.tl-tracks` lives inside `showBottom &&`, but the wheel and pinch listeners are attached in an effect with an empty dependency list. **After hiding and showing the timeline once, wheel zoom does nothing** — the listeners are still on the detached node. Same root cause as the scroll position resetting on Tab.

## Modal shell

Seven hand-written copies of backdrop + panel + header, drifted into three border colours and two close glyphs. The reason to make it a component is Escape: **not one of the seven closed on it**, because that is seven edits and nobody made all seven. The two that use Escape themselves (rebinding a shortcut) opt out rather than being special-cased inside the shell.

## Verified

- [x] `npm run check` — 320 tests (up from 302), typecheck and build clean
- [x] No behaviour change intended except Escape-to-close and the wheel-zoom fix

## Worth trying

1. Hide the timeline (Tab), show it again, **wheel over it** — it should zoom
2. **Escape** in any dialog — settings, help, project list, video import, the YouTube link prompt
3. Settings → Shortcuts → click an entry → **Escape should cancel the rebind, not close settings**
4. Zoom the timeline in and out with the wheel — the cut under the cursor should stay put
5. Save and reopen a project, locally and to the server