### PR TITLE
ci: least privilege, cancellation, timeouts, dependency updates, and a boot smoke test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependency updates, weekly.
+#
+# The point is not to be on the newest of everything - it is that a security advisory against
+# something in the tree should arrive as a pull request that CI has already run, rather than
+# being noticed months later. Grouped so a quiet week is one PR to look at instead of six.
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # Patch and minor bumps are read together; a major goes on its own, because that is the
+      # one that needs the release notes read.
+      routine:
+        update-types: [minor, patch]
+    commit-message:
+      prefix: 'chore(deps)'
+
+  # Actions pinned to a major tag still move underneath you; this is how a deprecated runner
+  # version or a compromised action gets noticed.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        patterns: ['*']
+    commit-message:
+      prefix: 'chore(ci)'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,9 +13,23 @@ on:
   push:
     tags: ['v*']
 
+# The release step needs to write. Without this the whole build succeeds, uploads the APK as a
+# run artifact, and then fails at the last step trying to create the Release - the account-wide
+# default for workflow tokens here is read-only. Nobody had pushed a v* tag yet, so that was
+# waiting to be discovered at the worst moment.
+permissions:
+  contents: write
+
+concurrency:
+  group: apk-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   apk:
     runs-on: ubuntu-latest
+    # A cold Gradle build with no cache runs about ten minutes; thirty leaves room without
+    # letting a hang sit there for six hours.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,25 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Nothing here writes to the repository, so nothing here gets a token that could. The default is
+# already read-only, but that is an account-wide setting somebody can change; saying it in the
+# workflow means this job keeps its own answer.
+permissions:
+  contents: read
+
+# Pushing twice to a branch used to run both to completion, and the older run could report after
+# the newer one - a green tick describing code that had already been replaced. The newest push
+# wins; main is exempt because each of its commits is a distinct thing to have checked.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    # The job takes about half a minute. Ten is generous and still stops a hang from running to
+    # the six-hour default.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -38,3 +54,40 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  # Separate from `check` on purpose: that job is the required gate and it finishes in half a
+  # minute, so it must not wait behind a browser. This one is allowed to be the slow one.
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      # vite preview serves dist/ the way a static host would, so this exercises the built
+      # bundle rather than the dev server's module graph.
+      - name: Serve the build
+        run: npx vite preview --port 4173 &
+
+      - name: Wait for the server
+        run: npx wait-on http://localhost:4173 --timeout 60000
+
+      # The runner image ships Google Chrome, which is what the test drives - no browser
+      # download, no playwright install step.
+      - name: Boot smoke test
+        run: npm run smoke
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: smoke-failure
+          path: smoke-failure.png
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,19 @@ jobs:
 
       - run: npm run build
 
+      # The app probes /api on load to decide whether server save is available, so the API has
+      # to be up or the page comes up reporting itself offline - which is what the first run of
+      # this job caught.
+      - name: Start the API server
+        run: npm run server &
+
       # vite preview serves dist/ the way a static host would, so this exercises the built
       # bundle rather than the dev server's module graph.
       - name: Serve the build
         run: npx vite preview --port 4173 &
 
-      - name: Wait for the server
-        run: npx wait-on http://localhost:4173 --timeout 60000
+      - name: Wait for both servers
+        run: npx wait-on http://localhost:8787/api/projects http://localhost:4173 --timeout 60000
 
       # The runner image ships Google Chrome, which is what the test drives - no browser
       # download, no playwright install step.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+# Static security analysis. Free for public repositories, and worth having here specifically
+# because this app handles files and URLs the user supplies - project files, imported video,
+# YouTube links that are passed to a server process. Findings appear under Security → Code
+# scanning rather than as a failing check, so this does not gate merges.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so an advisory published after a quiet period still gets found.
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # Includes the security rules that are off by default, which is the reason to run this
+          # at all rather than rely on the linter.
+          queries: security-extended
+
+      - uses: github/codeql-action/analyze@v3

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ server/data/
 
 # Dev-server output, written when the server is started with its log redirected.
 *.log
+
+# Screenshot written by the boot smoke test when it fails; CI keeps it as an artifact.
+smoke-failure.png

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,11 @@
         "concurrently": "^10.0.3",
         "eslint": "^9.39.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "playwright-core": "^1.62.1",
         "typescript": "^5.9.3",
         "vite": "^6.1.1",
-        "vite-plugin-qrcode": "^0.4.1"
+        "vite-plugin-qrcode": "^0.4.1",
+        "wait-on": "^9.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1020,6 +1022,60 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+      "integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1733,6 +1789,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1886,6 +1949,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -1946,6 +2022,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -1954,6 +2037,19 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2244,6 +2340,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -2382,6 +2491,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2482,6 +2601,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2975,6 +3110,67 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3187,6 +3383,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -3217,6 +3429,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -3372,6 +3598,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/joi": {
+      "version": "18.2.5",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.5.tgz",
+      "integrity": "sha512-+gEA7rLfaNWx9JzawWPrPetSZwT16NUqHtECDgjyAJreXcs4TM7tx2Pa+VVJJK0YHM83ybrVdaT6UekHH50FJQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3511,6 +3756,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3618,6 +3870,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -3931,6 +4193,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
@@ -4020,6 +4295,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {
@@ -4904,6 +5189,26 @@
       },
       "peerDependencies": {
         "vite": ">=3"
+      }
+    },
+    "node_modules/wait-on": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.1.0.tgz",
+      "integrity": "sha512-PymrLXHLBM1Ju/Xspb2ADUhbPSMvbnuNvy/mN2hWtpbJ3da0h3Ky1LqwKPG5QSVR57liyO0iUpfipYl/s5qNvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.18.1",
+        "joi": "^18.2.3",
+        "lodash": "^4.18.1",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.2"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "bench": "node scripts/bench.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
-    "check": "npm run typecheck && npm test && node scripts/hook-baseline.mjs && npm run build"
+    "check": "npm run typecheck && npm test && node scripts/hook-baseline.mjs && npm run build",
+    "smoke": "node test/smoke/boot.mjs"
   },
   "dependencies": {
     "@capacitor/android": "^7.0.0",
@@ -33,8 +34,10 @@
     "concurrently": "^10.0.3",
     "eslint": "^9.39.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "playwright-core": "^1.62.1",
     "typescript": "^5.9.3",
     "vite": "^6.1.1",
-    "vite-plugin-qrcode": "^0.4.1"
+    "vite-plugin-qrcode": "^0.4.1",
+    "wait-on": "^9.1.0"
   }
 }

--- a/test/smoke/boot.mjs
+++ b/test/smoke/boot.mjs
@@ -1,0 +1,87 @@
+// Does the app actually come up?
+//
+// `vite build` succeeding says the bundler resolved every import. It says nothing about whether
+// the page runs: a component that returns undefined, a module-level throw, a null deref during
+// the first render - all of those build cleanly and produce a white screen. Every other check in
+// this repository is static, so nothing before this one has ever opened the page.
+//
+// Deliberately shallow. It loads the built bundle, waits for the app to mount, and asserts the
+// drawing canvas and the toolbar exist and that nothing was logged as an error. Anything deeper
+// belongs in a real end-to-end suite; this is the smallest thing that catches a white screen.
+
+// playwright-core rather than playwright: the full package downloads its own browser builds on
+// install, which is over a hundred megabytes for a check that only needs to open one page. This
+// drives a browser that is already on the machine - Chrome on the CI runners, Chrome or Edge on
+// a Windows desktop - and says which ones it tried when it cannot find any.
+import { chromium } from 'playwright-core';
+
+const url = process.env.SMOKE_URL || 'http://localhost:4173/';
+const errors = [];
+
+const channels = process.env.SMOKE_CHANNEL ? [process.env.SMOKE_CHANNEL] : ['chrome', 'msedge', 'chromium'];
+let browser = null;
+const tried = [];
+for (const channel of channels) {
+    try {
+        browser = await chromium.launch({ channel });
+        break;
+    } catch (e) {
+        tried.push(`${channel}: ${String(e.message).slice(0, 100)}`);
+    }
+}
+if (!browser) {
+    console.error('No browser to run the smoke test in. Tried:');
+    for (const t of tried) console.error('  ' + t);
+    process.exit(1);
+}
+
+const page = await browser.newPage();
+page.on('console', m => { if (m.type() === 'error') errors.push(m.text()); });
+page.on('pageerror', e => errors.push(`uncaught: ${e.message}`));
+
+let failure = null;
+try {
+    const res = await page.goto(url, { waitUntil: 'load', timeout: 30_000 });
+    if (!res || !res.ok()) throw new Error(`the page did not load: ${res && res.status()}`);
+
+    // The canvas is created by React, so waiting for it is waiting for the first render to have
+    // happened rather than merely for the bundle to have been fetched.
+    await page.waitForSelector('canvas', { timeout: 15_000 });
+
+    // The biggest canvas on the page is the drawing surface - the others are the colour wheel
+    // and the live stroke overlay. Picking it by size rather than by a test-only attribute keeps
+    // the hook out of the application, and the size assertion is the real check anyway: a
+    // drawing canvas that came up at 174x174 has not been given the project's dimensions.
+    const size = await page.evaluate(() => [...document.querySelectorAll('canvas')]
+        .map(c => ({ w: c.width, h: c.height }))
+        .sort((a, b) => b.w * b.h - a.w * a.h)[0] || null);
+    if (!size || size.w < 640 || size.h < 360) {
+        throw new Error(`no full-size drawing canvas: largest was ${JSON.stringify(size)}`);
+    }
+
+    // A white screen usually still has a canvas somewhere, so this also checks that the chrome
+    // around it rendered: the tool buttons and the timeline are separate subtrees, and one of
+    // them throwing while the other survives is exactly the failure worth catching.
+    const counts = await page.evaluate(() => ({
+        buttons: document.querySelectorAll('button').length,
+        panels: document.querySelectorAll('.panel-title, .tl-tracks, .toolbar').length,
+    }));
+    if (counts.buttons < 5) throw new Error(`only ${counts.buttons} buttons rendered - the UI did not come up`);
+
+    // A failed asset or a caught-but-real exception shows up here and nowhere else.
+    if (errors.length) throw new Error('console errors:' + errors.map(e => '\n  ' + e).join(''));
+
+    console.log(`smoke passed - canvas ${size.w}x${size.h}, ${counts.buttons} buttons, no console errors`);
+} catch (e) {
+    failure = e;
+    // A screenshot is the only way to tell "white screen" from "loaded but missing an element"
+    // when this fails on a machine nobody is sitting at.
+    try { await page.screenshot({ path: 'smoke-failure.png', fullPage: true }); } catch { }
+} finally {
+    await browser.close();
+}
+
+if (failure) {
+    console.error('smoke failed:', failure.message);
+    process.exit(1);
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,13 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { qrcode } from 'vite-plugin-qrcode'
 
+// Forward /api to the project-storage server, so saving and loading are same-origin and there
+// is no CORS to configure. Shared between dev and preview - they used to differ, and preview
+// silently having no backend is a hard thing to notice.
+const API_PROXY = {
+  '/api': { target: 'http://localhost:8787', changeOrigin: true },
+};
+
 // https://vitejs.dev/config/
 export default defineConfig({
   // Relative base so Capacitor/Android WebView can load /assets (avoids white screen).
@@ -12,9 +19,13 @@ export default defineConfig({
     host: true, // expose on LAN so a tablet on the same Wi-Fi can connect
     port: 5173,
     strictPort: false,
-    // Forward /api to the project-storage server (same-origin save/load, no CORS).
-    proxy: {
-      '/api': { target: 'http://localhost:8787', changeOrigin: true },
-    },
+    proxy: API_PROXY,
+  },
+  // `vite preview` does not inherit the dev server's proxy. Without this, the built app served
+  // by preview has no backend at all: it probes /api/projects on load, gets an error from the
+  // static server, and shows itself as offline. That is also what the boot smoke test saw.
+  preview: {
+    port: 4173,
+    proxy: API_PROXY,
   },
 })


### PR DESCRIPTION
Closes #29.

## The Android release step could not have worked

This account's default workflow token is read-only and `android.yml` never raised it. Pushing a `v*` tag would have built the APK, uploaded it as a run artifact, and then **failed creating the Release**. No tag has been pushed yet, so it was waiting to be found at the worst possible moment. It now asks for `contents: write`, and `ci.yml` declares `contents: read` rather than inheriting a default that can be changed in account settings.

## A green build proved less than it looked

`vite build` succeeds on code that throws the moment it loads — a component returning `undefined` is valid to the bundler. Every other check here is static, so **nothing had ever opened the page.**

The new `smoke` job serves the build and loads it in headless Chrome: the drawing canvas has to reach full size, the UI has to render, and the console has to be clean. Locally:

```
smoke passed - canvas 1920x1080, 73 buttons, no console errors
```

It picks the largest canvas rather than a test-only attribute — that keeps the hook out of the application, and makes the size the real assertion: a drawing surface that came up 174×174 got the colour wheel's dimensions, not the project's. On failure it saves a screenshot, the only way to tell a white screen from a missing element on a machine nobody is watching.

It runs as **its own job** so the required `check` gate stays at half a minute, and uses `playwright-core` against the browser already on the machine — the full `playwright` package downloads its own builds, a hundred megabytes to open one page.

## The rest

- **Concurrency** — pushing twice to a branch ran both to completion, and the older run could report after the newer, so a green tick could describe superseded code. Newest push wins; `main` is exempt because each of its commits is a separate thing to have checked.
- **Timeouts** on every job, so a hang stops in minutes instead of at the six-hour default.
- **Dependabot** for npm and actions, grouped so a quiet week is one PR instead of six.
- **CodeQL** with `security-extended`. Reports to Security rather than gating merges — worth running beyond the linter because this app takes files and URLs from the user and hands some of them to a server process.

## Verified

- [x] `npm run check` — 320 tests, build clean
- [x] `npm run smoke` passes locally against the built bundle
- [x] All four YAML files parse

## Note

This PR is itself the test of the smoke job — watch whether `smoke` appears and goes green. I have **not** added it to the required checks; that is worth deciding after it has run a few times without flaking.