### PR TITLE
feat: camera moves along a drawn path or a preset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ import { cloneCutContents as cloneCutContentsPure } from './core/cutClone.js';
 import { DEFAULT_KEYS, KEY_LABELS, keyOf, matchShortcut, loadKeymap, toolFromAction, findConflicts } from './core/shortcuts.js';
 import { derivePartsFrom, deriveVideoBatches } from './core/partOps.js';
 import {
-    cutsReducer, replaceCuts, addCuts, updateCut, setCutAnim, clearCut,
+    cutsReducer, replaceCuts, addCuts, updateCut, setCutAnim, setCutCamera, clearCut,
     updateLayer, setLayerAnim, moveLayers, upsertText, moveText, deleteText, toggleTextVisible as toggleTextVisibleAction,
     assignPartTo, renamePart as renamePartAction, ungroupPart as ungroupPartAction, removeBatch,
     insertCutsShifting, deleteTrack, moveCutGroup, replaceBatchCuts, mergeLayerDown, patchCut, patchCuts,
@@ -37,6 +37,11 @@ import { migrateCuts, projectSettings, makeLoadProgress } from './core/projectFo
 import { frameStorage, frameLoad, imageExt, imageExtFromType, audioExt, videoExt } from './core/projectAssets.js';
 import { xAtTime, timeAtX, zoomAnchored, pinchZoom } from './core/timelineZoom.js';
 import { preparePath } from './core/pathMotion.js';
+// Recording a camera path reuses the pen the way a part's motion path does; the two cannot be
+// active at once, and startDraw checks this one first because a camera is a property of the cut
+// rather than of whichever layer happens to be selected.
+
+import { computeCamera, applyCamera } from './core/camera.js';
 import { unusedBitmapIds } from './core/bitmapRefs.js';
 import { dragCut, resizeCut } from './core/cutOps.js';
 import {
@@ -504,6 +509,7 @@ export default function App() {
     const lastInteractRef = useRef(0); // time of the last zoom or pan, used to briefly yield the boiling preview
     const [pathCapture, setPathCapture] = useState(null); // {cutId, layerId} while recording a motion path
     const pathPtsRef = useRef(null);
+    const [cameraCapture, setCameraCapture] = useState(null); // {cutId} while drawing a camera path
 
     const storeBitmap = (imageData) => {
         const id = Date.now().toString(36) + Math.random().toString(36).slice(2);
@@ -1762,6 +1768,7 @@ export default function App() {
     const toggleCutCollapse = (id) => setCollapsedCutIds(p => { const s = new Set(p); s.has(id) ? s.delete(id) : s.add(id); return s; });
     const renameCut = (id, name) => dispatchCuts(updateCut(id, { name }));
     const updCutAnim = (id, patch) => dispatchCuts(setCutAnim(id, patch));
+    const updCutCamera = (id, patch) => dispatchCuts(setCutCamera(id, patch));
     const updLayerAnim = (cutId, layerId, patch) => dispatchCuts(setLayerAnim(cutId, layerId, patch));
     const handleAddTrack = () => setNumTracks(p => p + 1);
     const handleDeleteTrack = (i) => { if (numTracks <= 1) return; if (!window.confirm(tr('Track {0} 삭제?', i))) return; dispatchCuts(deleteTrack(i)); setNumTracks(p => p - 1); };
@@ -2464,6 +2471,15 @@ export default function App() {
             try { const d = canvasRef.current.getContext('2d').getImageData(Math.round(pos.x), Math.round(pos.y), 1, 1).data; if (d[3] > 0) applyColor('#' + [d[0], d[1], d[2]].map(v => v.toString(16).padStart(2, '0')).join('')); } catch { }
             setPickingColor(false); return;
         }
+        // Recording a camera path. Checked before the part path because a camera belongs to the
+        // cut, not to whichever layer is selected - and before the layer is resolved at all, so
+        // it works on a cut whose active layer is a folder or hidden.
+        if (cameraCapture) {
+            beginGesture(e);
+            pathPtsRef.current = [pos];
+            e.preventDefault();
+            return;
+        }
         // Recording a motion path for a part animation: capture the stroke as a path.
         if (pathCapture) {
             beginGesture(e);
@@ -2720,6 +2736,16 @@ export default function App() {
             const pts = pathPtsRef.current;
             pathPtsRef.current = null;
             endGesture();
+            if (cameraCapture) {
+                // Evened out the same way a part path is, and for the same reason: the camera
+                // walks it by index, so uneven points would replay the drawing speed. A camera
+                // doing that is far more obvious than a part doing it, because the whole frame
+                // lurches rather than one drawing.
+                const path = preparePath(pts);
+                if (path.length > 1) dispatchCuts(setCutCamera(cameraCapture.cutId, { path }));
+                setCameraCapture(null);
+                return;
+            }
             if (pathCapture && pts.length > 1) {
                 if (pathCapture.mode === 'sway') {
                     // Sway from a drawn curve: the curve is stored as a waveform, and how far it
@@ -3145,6 +3171,22 @@ export default function App() {
         }
         ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, canvas.width, canvas.height);
         paintedOnceRef.current = true;
+        // The camera is a window onto the frame, so it wraps everything drawn into it - the video
+        // reference, the artwork and the text move together, which is the whole point of it being
+        // a camera rather than another per-layer transform. The white fill above stays outside:
+        // that is the viewport itself, and zooming it would leave the edges unpainted.
+        //
+        // Playback only, like cut and part animation. While editing, a moved canvas would put the
+        // pen somewhere other than where the drawing appears, which is not a trade worth making
+        // for a preview.
+        //
+        // A shot belongs to the cut on the lowest active track: that is the base scene, and the
+        // tracks above it are parts of the same shot rather than shots of their own.
+        const camCut = playing ? activeCuts.find(c => c.camera) : null;
+        const camAt = camCut
+            ? computeCamera(camCut.camera, (t - camCut.startTime) / Math.max(0.0001, camCut.endTime - camCut.startTime), CANVAS_W, CANVAS_H)
+            : null;
+        if (camAt) { ctx.save(); applyCamera(ctx, camAt, CANVAS_W, CANVAS_H); }
         // Video overlay track: drawn underneath everything. The <video> element is kept at time t by
         // the playback loop (playing) or a paused-seek effect.
         if (videoOverlay && t >= videoOverlay.startTime && t < videoOverlay.endTime) {
@@ -3301,6 +3343,7 @@ export default function App() {
             }
             ctx.restore();
         });
+        if (camAt) ctx.restore();
     }, [cuts, currentCutId, onionPrev, onionNext, selection, layerCanvasCache, frameDecodeTick, videoOverlay, boilTick, dragTick]);
 
     const paintFrameRef = useRef(null);
@@ -3897,6 +3940,8 @@ export default function App() {
                     setShowRight={setShowRight} showRight={showRight} toggleCutCollapse={toggleCutCollapse}
                     toggleCutSettings={toggleCutSettings} toggleTextVisible={toggleTextVisible}
                     updCutAnim={updCutAnim} updCutTime={updCutTime} updLayers={updLayers}
+                    updCutCamera={updCutCamera} cameraCapture={cameraCapture} setCameraCapture={setCameraCapture}
+                    canvasW={CANVAS_W} canvasH={CANVAS_H}
                     videoBatches={videoBatches} />
     );
     const panelEls = { color: colorPanelEl, tools: toolsPanelEl, cut: cutPanelEl };
@@ -4070,6 +4115,12 @@ export default function App() {
                     onMouseDown={e => { if (e.button === 1) e.preventDefault(); }} /* suppress middle-click auto-scroll */
                     onAuxClick={e => { if (e.button === 1) e.preventDefault(); }}
                     onPointerDown={onAreaPointerDown} onPointerMove={onAreaPointerMove} onPointerUp={onAreaPointerUp} onPointerCancel={onAreaPointerUp}>
+                    {cameraCapture && (
+                        <div style={{ position: 'absolute', top: 8, left: '50%', transform: 'translateX(-50%)', zIndex: 31, background: 'var(--accent-soft)', color: '#fff', fontSize: 12, padding: '6px 12px', borderRadius: 6, display: 'flex', gap: 8, alignItems: 'center' }}>
+                            {tr('카메라가 지나갈 길을 그리세요 — 재생하면 그 길을 따라갑니다')}
+                            <button className="button" style={{ height: 24, padding: '0 8px' }} onClick={() => setCameraCapture(null)}>{tr('취소')}</button>
+                        </div>
+                    )}
                     {pathCapture && (
                         <div style={{ position: 'absolute', top: 8, left: '50%', transform: 'translateX(-50%)', zIndex: 31, background: 'var(--accent-soft)', color: '#fff', fontSize: 12, padding: '6px 12px', borderRadius: 6, display: 'flex', gap: 8, alignItems: 'center' }}>
                             {pathCapture.mode === 'sway' ? tr('물결치듯 곡선을 그리세요 — 그 모양·크기대로 흔들립니다') : tr('펜으로 이동 경로를 그리세요')}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,7 @@ import { measureTextBox as measureTextBoxPure, textNeedsBox, drawTextObject } fr
 import { migrateCuts, projectSettings, makeLoadProgress } from './core/projectFormat.js';
 import { frameStorage, frameLoad, imageExt, imageExtFromType, audioExt, videoExt } from './core/projectAssets.js';
 import { xAtTime, timeAtX, zoomAnchored, pinchZoom } from './core/timelineZoom.js';
+import { preparePath } from './core/pathMotion.js';
 import { unusedBitmapIds } from './core/bitmapRefs.js';
 import { dragCut, resizeCut } from './core/cutOps.js';
 import {
@@ -2727,7 +2728,11 @@ export default function App() {
                     if (w) updLayerAnim(pathCapture.cutId, pathCapture.layerId, { swayCurve: w.wave, swayAmount: Math.max(1, Math.round(w.amp / 4)) });
                     else alert(tr('거의 직선이라 흔들림을 만들 수 없습니다. 물결치듯 그려보세요.'));
                 } else {
-                    updLayerAnim(pathCapture.cutId, pathCapture.layerId, { path: pts.map(p => ({ x: Math.round(p.x), y: Math.round(p.y) })) });
+                    // Evened out before it is stored, not while it is played. The renderer walks
+                    // the path by index, so equal spacing is what makes the motion a constant
+                    // speed instead of a replay of how fast the pen was moving at each point.
+                    const path = preparePath(pts);
+                    if (path.length > 1) updLayerAnim(pathCapture.cutId, pathCapture.layerId, { path });
                 }
             }
             setPathCapture(null);

--- a/src/core/camera.js
+++ b/src/core/camera.js
@@ -1,0 +1,207 @@
+// Where the camera is looking, at a given moment in a cut.
+//
+// The camera is a window onto the artwork rather than something drawn into it: it has a centre
+// (the point in canvas coordinates that lands in the middle of the frame) and a zoom. Everything
+// composited for the cut goes through one transform derived from those two numbers, so the video
+// reference, the drawing and the text all move together the way a real camera move does.
+//
+// Two ways to drive it, because they answer different needs. A drawn path is for a move nobody
+// can name - follow this arc, past that, settle here - and reuses the pen the rest of the app is
+// built around. Presets are for the moves that come up constantly in a music video, where drawing
+// a straight line by hand would only make it crooked.
+//
+// The one thing worth knowing before reading the presets: a pan at zoom 1 shows the edge of the
+// artwork. There is nothing outside the canvas, so moving the window sideways slides blank paper
+// into frame. Every preset that moves the centre therefore zooms in first, and the amount is
+// chosen so the travel stays inside what the zoom buys.
+
+import { applyEase, samplePath } from '../canvas/canvasUtils.js';
+
+/** No camera at all: the default, and what every existing project has. */
+export const CAMERA_DEFAULT = {
+    preset: 'none',
+    /** Points in canvas coordinates. Overrides the preset's own path when present. */
+    path: null,
+    // null, not 1. A preset carries its own zoom, and a default of 1 here would be a real value
+    // that silently overrode it - picking "zoom in" would produce no zoom at all. null means
+    // "whatever the preset says"; a number means the user set it and it wins.
+    zoomFrom: null,
+    zoomTo: null,
+    /** Degrees, applied about the frame centre. Small values only - this is a tilt, not a spin. */
+    rotFrom: 0,
+    rotTo: 0,
+    ease: 'inout',
+    easePower: 2,
+};
+
+/**
+ * The smallest zoom at which a camera may sit `drift` off centre without the frame running off
+ * the artwork - where drift is a fraction of the frame, so 0.04 means four percent of the width.
+ *
+ * Worth deriving rather than picking by eye. The first draft of the ken burns preset had a drift
+ * its own zoom could not cover, and the frame showed blank paper for the first fifth of the move;
+ * the tests caught it, but only because the constraint happened to be written down as one. Now
+ * the presets cannot disagree with it, because they ask.
+ *
+ * @param {number} drift largest offset from centre, as a fraction of the frame
+ * @returns {number}
+ */
+export function zoomForDrift(drift) {
+    const d = Math.max(0, Math.min(0.49, drift));
+    return 1 / (1 - 2 * d);
+}
+
+// How far a pan preset travels, as a fraction of the frame. A third of the width reads as a
+// deliberate move at typical cut lengths; more than that and it becomes the subject.
+const PAN_TRAVEL = 1 / 3;
+const PAN_ZOOM = zoomForDrift(PAN_TRAVEL / 2);
+
+// Ken Burns drifts a few percent each way while it pushes in.
+const KB_DRIFT_X = 0.04, KB_DRIFT_Y = 0.03;
+
+/**
+ * The fixed moves. Each returns the same shape a hand-drawn camera produces, so nothing
+ * downstream has to know which one it came from.
+ *
+ * Keyed by id; the label is a translation key resolved by the UI.
+ */
+export const CAMERA_PRESETS = {
+    none: { label: '없음', build: () => null },
+
+    zoomIn: {
+        label: '줌 인',
+        build: (cw, ch) => ({ path: [{ x: cw / 2, y: ch / 2 }], zoomFrom: 1, zoomTo: 1.25 }),
+    },
+    zoomOut: {
+        label: '줌 아웃',
+        build: (cw, ch) => ({ path: [{ x: cw / 2, y: ch / 2 }], zoomFrom: 1.25, zoomTo: 1 }),
+    },
+
+    panLeft: {
+        label: '왼쪽으로',
+        build: (cw, ch) => panPreset(cw, ch, +1, 0),
+    },
+    panRight: {
+        label: '오른쪽으로',
+        build: (cw, ch) => panPreset(cw, ch, -1, 0),
+    },
+    panUp: {
+        label: '위로',
+        build: (cw, ch) => panPreset(cw, ch, 0, +1),
+    },
+    panDown: {
+        label: '아래로',
+        build: (cw, ch) => panPreset(cw, ch, 0, -1),
+    },
+
+    // The staple: a slow push in with a little drift, so a still drawing stops looking still.
+    kenBurns: {
+        label: '켄 번스',
+        build: (cw, ch) => ({
+            path: [
+                { x: cw / 2 - cw * KB_DRIFT_X, y: ch / 2 + ch * KB_DRIFT_Y },
+                { x: cw / 2 + cw * KB_DRIFT_X, y: ch / 2 - ch * KB_DRIFT_Y },
+            ],
+            // The start is the tight case: it is the widest the frame ever gets, and it is
+            // already off centre. Asking keeps the two numbers from drifting apart later.
+            zoomFrom: zoomForDrift(Math.max(KB_DRIFT_X, KB_DRIFT_Y)),
+            zoomTo: 1.25,
+        }),
+    },
+};
+
+/**
+ * A pan across the frame in one direction, with the zoom that keeps the edges out of shot.
+ * `dx`/`dy` are -1, 0 or +1 and point at where the camera STARTS, so panLeft starts on the right.
+ */
+function panPreset(cw, ch, dx, dy) {
+    const rx = (cw * PAN_TRAVEL) / 2, ry = (ch * PAN_TRAVEL) / 2;
+    return {
+        path: [
+            { x: cw / 2 + dx * rx, y: ch / 2 + dy * ry },
+            { x: cw / 2 - dx * rx, y: ch / 2 - dy * ry },
+        ],
+        zoomFrom: PAN_ZOOM,
+        zoomTo: PAN_ZOOM,
+    };
+}
+
+/**
+ * Resolve a camera setting into the path and zoom range actually used.
+ *
+ * A drawn path wins over the preset's own, so somebody can pick "ken burns" for its zoom and then
+ * replace the movement without losing the zoom.
+ *
+ * @param {typeof CAMERA_DEFAULT | null | undefined} cam
+ * @param {number} cw @param {number} ch
+ * @returns {{path: {x:number,y:number}[], zoomFrom: number, zoomTo: number, rotFrom: number, rotTo: number} | null}
+ */
+export function resolveCamera(cam, cw, ch) {
+    if (!cam) return null;
+    const preset = CAMERA_PRESETS[cam.preset]?.build(cw, ch) || null;
+    const drawn = Array.isArray(cam.path) && cam.path.length > 0 ? cam.path : null;
+    const path = drawn || preset?.path || null;
+
+    // Explicit values on the camera win; otherwise the preset's, otherwise no change at all.
+    const zoomFrom = num(cam.zoomFrom, preset?.zoomFrom, 1);
+    const zoomTo = num(cam.zoomTo, preset?.zoomTo, 1);
+    const rotFrom = num(cam.rotFrom, 0, 0);
+    const rotTo = num(cam.rotTo, 0, 0);
+
+    // Nothing to do is worth detecting: it lets the renderer skip the transform entirely rather
+    // than multiplying by an identity matrix on every frame of every cut that has no camera.
+    const still = (!path || path.length < 2) && zoomFrom === 1 && zoomTo === 1 && rotFrom === 0 && rotTo === 0;
+    if (still) return null;
+
+    return { path: path || [{ x: cw / 2, y: ch / 2 }], zoomFrom, zoomTo, rotFrom, rotTo };
+}
+
+/** First of the three that is an actual number: the user's value, the preset's, then the base. */
+const num = (v, fallback, base) => {
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+    if (typeof fallback === 'number' && Number.isFinite(fallback)) return fallback;
+    return base;
+};
+
+/**
+ * Where the camera is at a normalised time through the cut.
+ *
+ * @param {typeof CAMERA_DEFAULT | null | undefined} cam
+ * @param {number} t01 0 at the start of the cut, 1 at the end
+ * @param {number} cw @param {number} ch
+ * @returns {{cx: number, cy: number, zoom: number, rot: number} | null} null when there is no
+ *   camera move, so the caller skips the transform rather than applying an identity
+ */
+export function computeCamera(cam, t01, cw, ch) {
+    const r = resolveCamera(cam, cw, ch);
+    if (!r) return null;
+
+    // Eased once and used for everything, so the position, the zoom and the tilt stay in step.
+    // Easing them separately is what makes a move feel like two moves.
+    const p = applyEase(Math.max(0, Math.min(1, t01)), cam.ease ?? 'inout', cam.easePower ?? 2);
+
+    const c = r.path.length > 1 ? samplePath(r.path, p) : r.path[0];
+    return {
+        cx: c.x,
+        cy: c.y,
+        zoom: r.zoomFrom + (r.zoomTo - r.zoomFrom) * p,
+        rot: (r.rotFrom + (r.rotTo - r.rotFrom) * p) * Math.PI / 180,
+    };
+}
+
+/**
+ * Put the camera onto a 2D context. The caller owns the save/restore.
+ *
+ * Reads as: move the origin to the middle of the frame, scale and tilt about it, then shift so
+ * the camera's centre is the thing sitting there.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {{cx:number, cy:number, zoom:number, rot:number}} cam
+ * @param {number} cw @param {number} ch
+ */
+export function applyCamera(ctx, cam, cw, ch) {
+    ctx.translate(cw / 2, ch / 2);
+    ctx.scale(cam.zoom, cam.zoom);
+    if (cam.rot) ctx.rotate(cam.rot);
+    ctx.translate(-cam.cx, -cam.cy);
+}

--- a/src/core/cutsReducer.js
+++ b/src/core/cutsReducer.js
@@ -21,6 +21,7 @@
 
 import { offsetLayers, mergeDown } from './layerOps.js';
 import { assignPart, renamePartIn, ungroupPartIn, removeVideoBatch } from './partOps.js';
+import { CAMERA_DEFAULT } from './camera.js';
 import { ANIM_DEFAULT, LAYER_ANIM_DEFAULT, safeArray } from '../canvas/canvasUtils.js';
 
 // ── action creators ────────────────────────────────────────────────────────
@@ -33,6 +34,12 @@ export const addCuts = (cuts) => ({ type: 'addCuts', cuts });
 export const updateCut = (cutId, patch) => ({ type: 'updateCut', cutId, patch });
 /** Merge into a cut's animation, over the defaults. */
 export const setCutAnim = (cutId, patch) => ({ type: 'setCutAnim', cutId, patch });
+/**
+ * Merge into a cut's camera move. Passing null clears it, which is not the same as setting every
+ * field back to its default: the renderer skips the transform entirely when there is no camera
+ * object at all, and that is the state every existing project is in.
+ */
+export const setCutCamera = (cutId, patch) => ({ type: 'setCutCamera', cutId, patch });
 /** Empty a cut's drawing and text, keeping its layers. */
 export const clearCut = (cutId) => ({ type: 'clearCut', cutId });
 
@@ -95,6 +102,12 @@ export function cutsReducer(cuts, action) {
             return mapCut(list, action.cutId, c => ({ ...c, ...action.patch }));
         case 'setCutAnim':
             return mapCut(list, action.cutId, c => ({ ...c, anim: { ...ANIM_DEFAULT, ...c.anim, ...action.patch } }));
+        case 'setCutCamera':
+            return mapCut(list, action.cutId, c => (
+                action.patch === null
+                    ? { ...c, camera: null }
+                    : { ...c, camera: { ...CAMERA_DEFAULT, ...c.camera, ...action.patch } }
+            ));
         case 'clearCut':
             // The layers stay - emptying a cut is not deleting its structure - but everything
             // drawn on them goes, redo included, since those strokes can no longer be restored

--- a/src/core/pathMotion.js
+++ b/src/core/pathMotion.js
@@ -1,0 +1,128 @@
+// Turning a drawn line into something that can be moved along smoothly.
+//
+// A path captured from a pen is not a shape, it is a recording of a hand: points pile up wherever
+// the pen slowed down and spread out wherever it sped up, and every one of them carries a little
+// tremor. Animating along it by index - step one point per tick - replays the drawing speed
+// rather than the drawn shape, so the motion crawls through the careful parts and lurches through
+// the confident ones. That is the stutter, and it is not a rendering problem: the data is uneven.
+//
+// The fix is to even out the data once, when the drawing is committed, rather than to do
+// arc-length work on every frame. A prepared path has its points equally spaced, so sampling it
+// by index IS sampling it by distance, and the renderer keeps the cheap lookup it already had.
+// Nothing in the animation loop gets slower.
+//
+// Smoothing runs first because resampling a jittery line just produces evenly spaced jitter.
+
+/** Total length along a polyline. @param {{x:number,y:number}[]} pts @returns {number} */
+export function pathLength(pts) {
+    let total = 0;
+    for (let i = 1; i < pts.length; i++) total += Math.hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y);
+    return total;
+}
+
+/**
+ * Chaikin corner cutting: replace each point with two points a quarter in from its neighbours.
+ *
+ * Chosen over a spline fit because it is a few multiplications per point with no solver, and
+ * because it cannot overshoot - the result stays inside the hull of what was drawn, so a
+ * deliberately sharp corner softens rather than bulging past where the pen went.
+ *
+ * The endpoints are kept exactly. Somebody who starts a camera move at the edge of the frame
+ * means the edge, and an interpolation that quietly pulls the start inward is a bug they cannot
+ * see the cause of.
+ *
+ * @param {{x:number,y:number}[]} pts
+ * @param {number} [iterations] each pass roughly doubles the point count
+ * @returns {{x:number,y:number}[]}
+ */
+export function smoothPath(pts, iterations = 2) {
+    let out = pts;
+    for (let n = 0; n < iterations; n++) {
+        if (out.length < 3) return out;
+        const next = [out[0]];
+        for (let i = 0; i < out.length - 1; i++) {
+            const a = out[i], b = out[i + 1];
+            next.push(
+                { x: a.x * 0.75 + b.x * 0.25, y: a.y * 0.75 + b.y * 0.25 },
+                { x: a.x * 0.25 + b.x * 0.75, y: a.y * 0.25 + b.y * 0.75 },
+            );
+        }
+        next.push(out[out.length - 1]);
+        out = next;
+    }
+    return out;
+}
+
+/**
+ * Re-space a polyline so consecutive points are an equal distance apart.
+ *
+ * This is the whole trick. Afterwards, walking the array at a constant rate moves at a constant
+ * speed, which is what the animation loop already does.
+ *
+ * @param {{x:number,y:number}[]} pts
+ * @param {number} count how many points to produce, including both ends
+ * @returns {{x:number,y:number}[]}
+ */
+export function resampleByLength(pts, count = 64) {
+    if (!Array.isArray(pts) || pts.length < 2) return Array.isArray(pts) ? pts.slice() : [];
+    const n = Math.max(2, Math.floor(count));
+
+    // Cumulative distance to each input point, so a target distance can be located by scanning.
+    const cum = [0];
+    for (let i = 1; i < pts.length; i++) cum.push(cum[i - 1] + Math.hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y));
+    const total = cum[cum.length - 1];
+    // A path drawn as a single dot, or one that returns exactly to its start with no travel, has
+    // no length to distribute along. Spreading points over it would divide by zero.
+    if (total <= 0) return Array.from({ length: n }, () => ({ x: pts[0].x, y: pts[0].y }));
+
+    const out = [{ x: pts[0].x, y: pts[0].y }];
+    let seg = 1;
+    for (let i = 1; i < n - 1; i++) {
+        const want = (total * i) / (n - 1);
+        while (seg < cum.length - 1 && cum[seg] < want) seg++;
+        const span = cum[seg] - cum[seg - 1];
+        const f = span > 0 ? (want - cum[seg - 1]) / span : 0;
+        const a = pts[seg - 1], b = pts[seg];
+        out.push({ x: a.x + (b.x - a.x) * f, y: a.y + (b.y - a.y) * f });
+    }
+    out.push({ x: pts[pts.length - 1].x, y: pts[pts.length - 1].y });
+    return out;
+}
+
+/**
+ * What gets stored when a drawn path is committed: smoothed, evenly spaced, rounded.
+ *
+ * Rounding to whole pixels is deliberate - it keeps the saved project small, and a path is a
+ * motion guide rather than artwork, so a half-pixel of precision buys nothing.
+ *
+ * @param {{x:number,y:number}[]} pts raw pointer samples
+ * @param {{smooth?: number, samples?: number}} [opts]
+ * @returns {{x:number,y:number}[]} empty when there was no real gesture to record
+ */
+export function preparePath(pts, { smooth = 2, samples = 64 } = {}) {
+    if (!Array.isArray(pts) || pts.length < 2) return [];
+    const even = resampleByLength(smoothPath(pts, smooth), samples);
+    return even.map(p => ({ x: Math.round(p.x), y: Math.round(p.y) }));
+}
+
+/**
+ * How evenly spaced a path is: the longest gap between consecutive points divided by the mean.
+ *
+ * 1 is perfect. A raw hand-drawn path is usually somewhere past 5, which is the same thing as
+ * saying it would stutter. Exported so the tests can state the property rather than assert on
+ * particular coordinates.
+ *
+ * @param {{x:number,y:number}[]} pts
+ * @returns {number} Infinity for a path with no length
+ */
+export function spacingRatio(pts) {
+    if (!pts || pts.length < 3) return 1;
+    let max = 0, total = 0;
+    for (let i = 1; i < pts.length; i++) {
+        const d = Math.hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y);
+        if (d > max) max = d;
+        total += d;
+    }
+    const mean = total / (pts.length - 1);
+    return mean > 0 ? max / mean : Infinity;
+}

--- a/src/ui/AnimPanels.jsx
+++ b/src/ui/AnimPanels.jsx
@@ -1,6 +1,7 @@
 import { Circle } from 'lucide-react';
 import React from 'react';
 import { ANIM_DEFAULT, LAYER_ANIM_DEFAULT } from '../canvas/canvasUtils';
+import { CAMERA_DEFAULT, CAMERA_PRESETS, resolveCamera } from '../core/camera.js';
 import { NumField } from './NumField';
 import { tr } from '../i18n';
 
@@ -90,6 +91,66 @@ export function CutAnimPanel({ cut, updCutAnim }) {
         </div>
     );
 }
+
+/**
+ * The camera move for one cut.
+ *
+ * Separate from the cut animation panel above even though both hang off the cut, because they are
+ * different things: that one moves the drawing inside the frame, this one moves the frame. Putting
+ * them in one list made it impossible to tell at a glance which was which.
+ */
+export function CameraPanel({ cut, updCutCamera, cameraCapture, setCameraCapture, canvasW, canvasH }) {
+    const c = { ...CAMERA_DEFAULT, ...cut.camera };
+    const set = (o) => updCutCamera(cut.id, o);
+    // What the camera actually resolves to, preset included. Reading the raw fields would show
+    // zoom 1 while the picture visibly zooms, because a preset's zoom lives on the preset.
+    const eff = resolveCamera(cut.camera, canvasW, canvasH);
+    const capturing = !!cameraCapture && cameraCapture.cutId === cut.id;
+
+    return (
+        <div style={{ marginTop: 8, borderTop: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)', paddingTop: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <div style={{ fontSize: 10, color: '#888' }}>{tr('카메라 (재생 시 적용)')}</div>
+            <div style={R()}>
+                <span style={{ width: 34, color: '#aaa', flexShrink: 0 }}>{tr('동작')}</span>
+                <select value={c.preset || 'none'} onChange={e => set({ preset: e.target.value })} className="time-input" style={{ flex: 1, minWidth: 76 }}>
+                    {Object.entries(CAMERA_PRESETS).map(([id, p]) => <option key={id} value={id}>{tr(p.label)}</option>)}
+                </select>
+            </div>
+            <div style={R()}>
+                <span style={{ width: 34, color: '#aaa', flexShrink: 0 }}>{tr('줌')}</span>
+                <NumIn value={round2(eff ? eff.zoomFrom : 1)} onChange={v => set({ zoomFrom: clampZoom(v) })} step={0.05} min={0.2} w={54} label={tr('시작')} title={tr('시작 배율')} />
+                <NumIn value={round2(eff ? eff.zoomTo : 1)} onChange={v => set({ zoomTo: clampZoom(v) })} step={0.05} min={0.2} w={54} label={tr('끝')} title={tr('끝 배율')} />
+            </div>
+            <div style={R()}>
+                <span style={{ width: 34, color: '#aaa', flexShrink: 0 }}>{tr('기울기')}</span>
+                <NumIn value={c.rotFrom || 0} onChange={v => set({ rotFrom: v })} step={1} w={54} label={tr('시작')} suffix="°" title={tr('시작 각도')} />
+                <NumIn value={c.rotTo || 0} onChange={v => set({ rotTo: v })} step={1} w={54} label={tr('끝')} suffix="°" title={tr('끝 각도')} />
+            </div>
+            <div style={R()}>
+                <span style={{ width: 34, color: '#aaa', flexShrink: 0 }}>{tr('속도감')}</span>
+                <select value={c.ease} onChange={e => set({ ease: e.target.value })} className="time-input" style={{ flex: 1, minWidth: 60 }} title={tr('가속/감속 곡선')}>
+                    {EASE_OPTS.map(([v, l]) => <option key={v} value={v}>{tr(l)}</option>)}
+                </select>
+                <NumIn value={c.easePower} onChange={v => set({ easePower: Math.max(0.1, v) })} step={0.5} min={0.1} w={48} title={tr('가감속 세기')}
+                    label={<span style={{ color: c.ease === 'linear' ? '#555' : '#aaa' }}>{tr('가중치')}</span>} />
+            </div>
+            <div style={R()}>
+                <button className="button" style={{ flex: 1, height: 26, background: capturing ? 'var(--accent)' : undefined }}
+                    onClick={() => setCameraCapture(capturing ? null : { cutId: cut.id })}
+                    title={tr('캔버스에 카메라가 지나갈 길을 그립니다')}>
+                    {capturing ? tr('그리는 중… (다시 눌러 취소)') : (c.path ? tr('경로 다시 그리기') : tr('경로 그리기'))}
+                </button>
+                {c.path && <button className="button" style={{ height: 26 }} onClick={() => set({ path: null })} title={tr('그린 경로를 지우고 프리셋 동작으로 되돌립니다')}>{tr('경로 지움')}</button>}
+            </div>
+            {eff && <button className="button" style={{ height: 24, fontSize: 10 }} onClick={() => updCutCamera(cut.id, null)}>{tr('카메라 끄기')}</button>}
+        </div>
+    );
+}
+
+const round2 = (v) => Math.round(v * 100) / 100;
+// Zooming out past 1 shows blank paper around the artwork. That is a legitimate thing to want -
+// a pull-back reveal - but not by accident, so the floor sits well below 1 rather than at it.
+const clampZoom = (v) => Math.max(0.2, Math.min(8, v));
 
 // Motion presets: rather than dialling in each value, drop in a common soft movement at once.
 // Each preset fills move, rotate and scale together with the ping-pong flag and the easing.

--- a/src/ui/CutLayerPanel.jsx
+++ b/src/ui/CutLayerPanel.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Plus, FolderPlus, Trash2, Copy, CopyPlus, ClipboardPaste, Eye, EyeOff, Settings, ChevronDown, ChevronRight } from 'lucide-react';
 import { safeArray } from '../canvas/canvasUtils';
-import { CutAnimPanel } from './AnimPanels';
+import { CutAnimPanel, CameraPanel } from './AnimPanels';
 import { tr } from '../i18n';
 
 // CUT / LAYER panel: the cut list, each cut's layer tree, cut animation and text list.
@@ -12,6 +12,7 @@ export function CutLayerPanel({
     deleteVideoBatch, dragLayerInfo, expandedCuts, handleAddCut, handleAddFolder,
     handleAddLayer, handleCopyCut, handleCutClick, handleDeleteCut, handleDuplicateCut,
     handlePasteCut, handleSetTool, openEditText, renameCut, renamingCutId,
+    updCutCamera, cameraCapture, setCameraCapture, canvasW, canvasH,
     renderLayers, rightW, selectedCutIds, selectedText, setDragLayerInfo,
     setDropInfo, setRenamingCutId, setSelectedText, setShowRight, showRight,
     toggleCutCollapse, toggleCutSettings, toggleTextVisible, updCutAnim, updCutTime,
@@ -55,6 +56,8 @@ export function CutLayerPanel({
                                         <label>End<input type="number" step="0.5" min="0" className="time-input" value={cut.endTime} onChange={e => updCutTime(cut.id, 'endTime', e.target.value)} /></label>
                                     </div>
                                     <CutAnimPanel cut={cut} updCutAnim={updCutAnim} />
+                                    <CameraPanel cut={cut} updCutCamera={updCutCamera} cameraCapture={cameraCapture}
+                                        setCameraCapture={setCameraCapture} canvasW={canvasW} canvasH={canvasH} />
                                 </div>
                             )}
                             <div className="layer-list" onDragOver={e => e.preventDefault()} onDrop={e => { e.preventDefault(); if (dragLayerInfo && dragLayerInfo.cutId === cut.id) { updLayers(cut.id, c => { const layers = [...c.layers], di = layers.findIndex(l => l.id === dragLayerInfo.layerId), dragged = { ...layers[di], parentId: null }; layers.splice(di, 1); layers.push(dragged); return { layers }; }); setDragLayerInfo(null); setDropInfo(null); } }}>

--- a/test/camera.test.js
+++ b/test/camera.test.js
@@ -1,0 +1,172 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CAMERA_DEFAULT, CAMERA_PRESETS, resolveCamera, computeCamera, applyCamera, zoomForDrift } from '../src/core/camera.js';
+
+const W = 1920, H = 1080;
+const cam = (over) => ({ ...CAMERA_DEFAULT, ...over });
+
+test('no camera means no transform, so the renderer can skip it', () => {
+    assert.equal(computeCamera(CAMERA_DEFAULT, 0.5, W, H), null);
+    assert.equal(computeCamera(null, 0.5, W, H), null);
+    assert.equal(computeCamera(undefined, 0.5, W, H), null);
+    assert.equal(computeCamera(cam({ preset: 'none' }), 0.5, W, H), null);
+    // A one-point path is a position, not a move, and with no zoom change there is nothing to do.
+    assert.equal(computeCamera(cam({ path: [{ x: 10, y: 10 }] }), 0.5, W, H), null);
+});
+
+test('an unknown preset is treated as no camera rather than throwing', () => {
+    assert.equal(computeCamera(cam({ preset: 'nonsense' }), 0.5, W, H), null);
+});
+
+test('zoom in starts at 1 and ends zoomed, centred throughout', () => {
+    const c = cam({ preset: 'zoomIn' });
+    const a = computeCamera(c, 0, W, H), b = computeCamera(c, 1, W, H);
+    assert.equal(a.zoom, 1);
+    assert.ok(b.zoom > 1);
+    assert.equal(a.cx, W / 2);
+    assert.equal(b.cx, W / 2);
+    assert.equal(a.cy, H / 2);
+});
+
+test('zoom out is zoom in backwards', () => {
+    const i = CAMERA_PRESETS.zoomIn.build(W, H), o = CAMERA_PRESETS.zoomOut.build(W, H);
+    assert.equal(i.zoomFrom, o.zoomTo);
+    assert.equal(i.zoomTo, o.zoomFrom);
+});
+
+test('pan presets move the camera and end up opposite where they started', () => {
+    for (const [id, axis] of [['panLeft', 'cx'], ['panRight', 'cx'], ['panUp', 'cy'], ['panDown', 'cy']]) {
+        const c = cam({ preset: id });
+        const a = computeCamera(c, 0, W, H), b = computeCamera(c, 1, W, H);
+        const mid = axis === 'cx' ? W / 2 : H / 2;
+        assert.ok(Math.abs(a[axis] - mid) > 1, `${id} did not start off centre`);
+        assert.ok((a[axis] - mid) * (b[axis] - mid) < 0, `${id} did not cross the centre`);
+    }
+});
+
+test('panLeft moves leftwards, and the others point the way their names say', () => {
+    const dir = (id, axis) => computeCamera(cam({ preset: id }), 1, W, H)[axis] - computeCamera(cam({ preset: id }), 0, W, H)[axis];
+    assert.ok(dir('panLeft', 'cx') < 0);
+    assert.ok(dir('panRight', 'cx') > 0);
+    assert.ok(dir('panUp', 'cy') < 0);
+    assert.ok(dir('panDown', 'cy') > 0);
+});
+
+test('a pan never shows anything outside the artwork', () => {
+    // The reason pan presets zoom in at all. At every moment the visible window - the frame
+    // divided by the zoom - has to sit inside the canvas, or blank paper slides into shot.
+    for (const id of ['panLeft', 'panRight', 'panUp', 'panDown', 'kenBurns']) {
+        for (let i = 0; i <= 20; i++) {
+            const c = computeCamera(cam({ preset: id }), i / 20, W, H);
+            const halfW = W / (2 * c.zoom), halfH = H / (2 * c.zoom);
+            assert.ok(c.cx - halfW >= -0.5, `${id} at ${i / 20} shows past the left edge`);
+            assert.ok(c.cx + halfW <= W + 0.5, `${id} at ${i / 20} shows past the right edge`);
+            assert.ok(c.cy - halfH >= -0.5, `${id} at ${i / 20} shows past the top edge`);
+            assert.ok(c.cy + halfH <= H + 0.5, `${id} at ${i / 20} shows past the bottom edge`);
+        }
+    }
+});
+
+test('a drawn path overrides the preset movement but keeps its zoom', () => {
+    // So somebody can take ken burns for the push-in and then say where it should go.
+    const drawn = [{ x: 100, y: 100 }, { x: 200, y: 300 }];
+    const c = cam({ preset: 'kenBurns', path: drawn });
+    const a = computeCamera(c, 0, W, H), b = computeCamera(c, 1, W, H);
+    assert.deepEqual({ x: a.cx, y: a.cy }, drawn[0]);
+    assert.deepEqual({ x: b.cx, y: b.cy }, drawn[1]);
+    assert.equal(a.zoom, CAMERA_PRESETS.kenBurns.build(W, H).zoomFrom);
+    assert.equal(b.zoom, CAMERA_PRESETS.kenBurns.build(W, H).zoomTo);
+});
+
+test('a drawn path with no preset still moves the camera', () => {
+    const c = cam({ path: [{ x: 0, y: 0 }, { x: W, y: H }] });
+    assert.deepEqual(computeCamera(c, 0, W, H), { cx: 0, cy: 0, zoom: 1, rot: 0 });
+    const b = computeCamera(c, 1, W, H);
+    assert.equal(b.cx, W);
+    assert.equal(b.cy, H);
+});
+
+test('the move is monotonic - it never doubles back on a straight path', () => {
+    // Position, zoom and tilt all take the same eased progress. Easing them apart is what makes
+    // one move read as two.
+    const c = cam({ path: [{ x: 0, y: 0 }, { x: 1000, y: 0 }], zoomFrom: 1, zoomTo: 2, rotTo: 10 });
+    let px = -1, pz = -1, pr = -1;
+    for (let i = 0; i <= 30; i++) {
+        const s = computeCamera(c, i / 30, W, H);
+        assert.ok(s.cx >= px - 1e-9, `x went backwards at ${i / 30}`);
+        assert.ok(s.zoom >= pz - 1e-9, `zoom went backwards at ${i / 30}`);
+        assert.ok(s.rot >= pr - 1e-9, `rotation went backwards at ${i / 30}`);
+        px = s.cx; pz = s.zoom; pr = s.rot;
+    }
+});
+
+test('easing changes the middle but never the ends', () => {
+    const path = [{ x: 0, y: 0 }, { x: 1000, y: 0 }];
+    const lin = cam({ path, ease: 'linear' });
+    const io = cam({ path, ease: 'inout', easePower: 3 });
+    for (const c of [lin, io]) {
+        assert.equal(computeCamera(c, 0, W, H).cx, 0);
+        assert.equal(computeCamera(c, 1, W, H).cx, 1000);
+    }
+    assert.notEqual(computeCamera(lin, 0.25, W, H).cx, computeCamera(io, 0.25, W, H).cx);
+    // Ease in-out is symmetric, so the halfway point is the one place it agrees with linear.
+    assert.ok(Math.abs(computeCamera(io, 0.5, W, H).cx - 500) < 1e-9);
+});
+
+test('time outside the cut clamps to the ends rather than extrapolating', () => {
+    const c = cam({ path: [{ x: 0, y: 0 }, { x: 1000, y: 0 }] });
+    assert.equal(computeCamera(c, -5, W, H).cx, 0);
+    assert.equal(computeCamera(c, 5, W, H).cx, 1000);
+});
+
+test('rotation is returned in radians', () => {
+    const c = cam({ path: [{ x: 0, y: 0 }, { x: 1, y: 0 }], rotFrom: 0, rotTo: 180 });
+    assert.ok(Math.abs(computeCamera(c, 1, W, H).rot - Math.PI) < 1e-9);
+});
+
+test('resolveCamera reports nothing to do so the renderer can skip the transform', () => {
+    assert.equal(resolveCamera(cam({}), W, H), null);
+    assert.notEqual(resolveCamera(cam({ preset: 'zoomIn' }), W, H), null);
+    assert.notEqual(resolveCamera(cam({ zoomTo: 1.5 }), W, H), null);
+    assert.notEqual(resolveCamera(cam({ rotTo: 3 }), W, H), null);
+});
+
+test('applyCamera puts the camera centre in the middle of the frame', () => {
+    // A fake context that records the transform, so the maths can be checked without a canvas.
+    let m = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+    const mul = (n) => {
+        m = {
+            a: m.a * n.a + m.c * n.b, b: m.b * n.a + m.d * n.b,
+            c: m.a * n.c + m.c * n.d, d: m.b * n.c + m.d * n.d,
+            e: m.a * n.e + m.c * n.f + m.e, f: m.b * n.e + m.d * n.f + m.f,
+        };
+    };
+    const ctx = {
+        translate: (x, y) => mul({ a: 1, b: 0, c: 0, d: 1, e: x, f: y }),
+        scale: (x, y) => mul({ a: x, b: 0, c: 0, d: y, e: 0, f: 0 }),
+        rotate: (r) => mul({ a: Math.cos(r), b: Math.sin(r), c: -Math.sin(r), d: Math.cos(r), e: 0, f: 0 }),
+    };
+    const at = (x, y) => ({ x: m.a * x + m.c * y + m.e, y: m.b * x + m.d * y + m.f });
+
+    applyCamera(/** @type {any} */(ctx), { cx: 400, cy: 300, zoom: 2, rot: 0 }, W, H);
+
+    const centre = at(400, 300);
+    assert.ok(Math.abs(centre.x - W / 2) < 1e-9, `centre landed at ${centre.x}`);
+    assert.ok(Math.abs(centre.y - H / 2) < 1e-9, `centre landed at ${centre.y}`);
+    // And a point 10px away from the camera centre lands 20px away on screen, at zoom 2.
+    const off = at(410, 300);
+    assert.ok(Math.abs(off.x - (W / 2 + 20)) < 1e-9);
+});
+
+test('zoomForDrift gives exactly the zoom that fits, and no more', () => {
+    // At the returned zoom the visible window is exactly 1-2*drift of the frame, so a camera
+    // sitting `drift` off centre touches the edge without crossing it.
+    for (const d of [0, 0.04, 0.1, 1 / 6, 0.3]) {
+        const z = zoomForDrift(d);
+        assert.ok(Math.abs((1 / z) - (1 - 2 * d)) < 1e-12, `drift ${d} gave zoom ${z}`);
+    }
+    assert.equal(zoomForDrift(0), 1);
+    // Nonsense in, something usable out - a half-frame drift would need infinite zoom.
+    assert.ok(Number.isFinite(zoomForDrift(0.9)));
+    assert.equal(zoomForDrift(-1), 1);
+});

--- a/test/cutsReducer.test.js
+++ b/test/cutsReducer.test.js
@@ -12,7 +12,7 @@ import {
     upsertText, moveText, deleteText, toggleTextVisible,
     assignPartTo, renamePart, ungroupPart, removeBatch,
     insertCutsShifting, deleteTrack, moveCutGroup, replaceBatchCuts,
-    patchCut, patchCuts,
+    patchCut, patchCuts, setCutCamera,
 } from '../src/core/cutsReducer.js';
 
 const layer = (id, extra = {}) => ({ id, type: 'layer', parentId: null, visible: true, strokes: [], ...extra });
@@ -253,4 +253,33 @@ test('replaceBatchCuts: swaps one import, leaving other imports and hand-drawn c
     ];
     const out = cutsReducer(d, replaceBatchCuts('a', [{ id: 9, videoSrc: 'a', startTime: 0, endTime: 1 }]));
     assert.deepEqual(out.map(c => c.id), [2, 3, 9]);
+});
+
+test('setCutCamera: merges over the defaults, like cut animation does', () => {
+    const s = cutsReducer([cut(1)], setCutCamera(1, { preset: 'zoomIn' }));
+    assert.equal(s[0].camera.preset, 'zoomIn');
+    assert.equal(s[0].camera.ease, 'inout');
+    // null, not 1 - a numeric default here would override the preset's own zoom.
+    assert.equal(s[0].camera.zoomFrom, null);
+});
+
+test('setCutCamera: a second call keeps what the first set', () => {
+    let s = cutsReducer([cut(1)], setCutCamera(1, { preset: 'kenBurns' }));
+    s = cutsReducer(s, setCutCamera(1, { rotTo: 4 }));
+    assert.equal(s[0].camera.preset, 'kenBurns');
+    assert.equal(s[0].camera.rotTo, 4);
+});
+
+test('setCutCamera: null removes the camera rather than resetting its fields', () => {
+    // Not the same thing: the renderer skips the transform entirely when there is no camera
+    // object, which is the state every project that has never used one is in.
+    let s = cutsReducer([cut(1)], setCutCamera(1, { preset: 'zoomIn' }));
+    s = cutsReducer(s, setCutCamera(1, null));
+    assert.equal(s[0].camera, null);
+});
+
+test('setCutCamera: leaves other cuts alone', () => {
+    const s = cutsReducer([cut(1), cut(2)], setCutCamera(2, { preset: 'panLeft' }));
+    assert.equal(s[0].camera, undefined);
+    assert.equal(s[1].camera.preset, 'panLeft');
 });

--- a/test/pathMotion.test.js
+++ b/test/pathMotion.test.js
@@ -1,0 +1,139 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { pathLength, smoothPath, resampleByLength, preparePath, spacingRatio } from '../src/core/pathMotion.js';
+import { samplePath } from '../src/canvas/canvasUtils.js';
+
+/** A path drawn the way a hand draws one: dense where the pen dawdled, sparse where it hurried. */
+function handDrawn() {
+    const pts = [];
+    for (let i = 0; i <= 40; i++) pts.push({ x: i * 0.5, y: 0 });      // slow start, 0.5px apart
+    for (let i = 1; i <= 6; i++) pts.push({ x: 20 + i * 20, y: 0 });   // fast finish, 20px apart
+    return pts;
+}
+
+test('pathLength adds up the segments', () => {
+    assert.equal(pathLength([{ x: 0, y: 0 }, { x: 3, y: 4 }]), 5);
+    assert.equal(pathLength([{ x: 0, y: 0 }, { x: 3, y: 4 }, { x: 3, y: 4 }]), 5);
+    assert.equal(pathLength([{ x: 1, y: 1 }]), 0);
+});
+
+test('a hand-drawn path really is as uneven as the stutter suggests', () => {
+    // The premise of the whole module. If this were near 1 there would be nothing to fix.
+    assert.ok(spacingRatio(handDrawn()) > 5, `ratio was ${spacingRatio(handDrawn())}`);
+});
+
+test('resampling makes the spacing even', () => {
+    const even = resampleByLength(handDrawn(), 64);
+    assert.equal(even.length, 64);
+    assert.ok(spacingRatio(even) < 1.05, `ratio was ${spacingRatio(even)}`);
+});
+
+test('resampling keeps both ends exactly where they were drawn', () => {
+    const pts = handDrawn();
+    const even = resampleByLength(pts, 20);
+    assert.deepEqual(even[0], { x: pts[0].x, y: pts[0].y });
+    assert.deepEqual(even[even.length - 1], { x: pts[pts.length - 1].x, y: pts[pts.length - 1].y });
+});
+
+test('resampling preserves the shape, not just the spacing', () => {
+    // An L: right then down. Every resampled point must still sit on one of the two arms.
+    const L = [{ x: 0, y: 0 }, { x: 100, y: 0 }, { x: 100, y: 100 }];
+    for (const p of resampleByLength(L, 33)) {
+        const onTop = Math.abs(p.y) < 1e-9 && p.x >= 0 && p.x <= 100;
+        const onSide = Math.abs(p.x - 100) < 1e-9 && p.y >= 0 && p.y <= 100;
+        assert.ok(onTop || onSide, `${JSON.stringify(p)} left the path`);
+    }
+});
+
+test('resampling barely changes the length', () => {
+    const pts = handDrawn();
+    const even = resampleByLength(pts, 128);
+    // Chords across a curve are always slightly shorter; on a path this dense it is negligible.
+    assert.ok(Math.abs(pathLength(even) - pathLength(pts)) < 0.5);
+});
+
+test('a path with no length does not divide by zero', () => {
+    const dot = [{ x: 7, y: 9 }, { x: 7, y: 9 }, { x: 7, y: 9 }];
+    const out = resampleByLength(dot, 10);
+    assert.equal(out.length, 10);
+    for (const p of out) assert.deepEqual(p, { x: 7, y: 9 });
+});
+
+test('too short to be a path comes back unchanged rather than throwing', () => {
+    assert.deepEqual(resampleByLength([], 10), []);
+    assert.deepEqual(resampleByLength([{ x: 1, y: 2 }], 10), [{ x: 1, y: 2 }]);
+    assert.deepEqual(resampleByLength(null, 10), []);
+});
+
+test('smoothing keeps the endpoints and stays inside what was drawn', () => {
+    const zig = [{ x: 0, y: 0 }, { x: 10, y: 40 }, { x: 20, y: 0 }, { x: 30, y: 40 }];
+    const s = smoothPath(zig, 2);
+    assert.deepEqual(s[0], zig[0]);
+    assert.deepEqual(s[s.length - 1], zig[zig.length - 1]);
+    // Corner cutting cannot overshoot: a deliberate spike softens, it does not grow.
+    for (const p of s) {
+        assert.ok(p.y >= -1e-9 && p.y <= 40 + 1e-9, `y=${p.y} escaped the drawn range`);
+        assert.ok(p.x >= -1e-9 && p.x <= 30 + 1e-9, `x=${p.x} escaped the drawn range`);
+    }
+});
+
+test('smoothing shortens a jagged line and leaves a straight one alone', () => {
+    const zig = [{ x: 0, y: 0 }, { x: 10, y: 40 }, { x: 20, y: 0 }, { x: 30, y: 40 }];
+    assert.ok(pathLength(smoothPath(zig, 3)) < pathLength(zig));
+
+    const straight = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 20, y: 0 }, { x: 30, y: 0 }];
+    assert.ok(Math.abs(pathLength(smoothPath(straight, 3)) - 30) < 1e-6);
+});
+
+test('smoothing a two-point line has nothing to cut', () => {
+    const line = [{ x: 0, y: 0 }, { x: 10, y: 10 }];
+    assert.deepEqual(smoothPath(line, 3), line);
+});
+
+test('preparePath rounds to whole pixels and produces the requested count', () => {
+    const p = preparePath(handDrawn(), { samples: 32 });
+    assert.equal(p.length, 32);
+    for (const q of p) {
+        assert.equal(q.x, Math.round(q.x));
+        assert.equal(q.y, Math.round(q.y));
+    }
+});
+
+test('preparePath refuses a gesture that is not a path', () => {
+    assert.deepEqual(preparePath([{ x: 1, y: 1 }]), []);
+    assert.deepEqual(preparePath([]), []);
+    assert.deepEqual(preparePath(undefined), []);
+});
+
+test('the point of all this: sampling a prepared path moves at a constant speed', () => {
+    // samplePath walks the array by index. On raw points that replays the drawing speed; on a
+    // prepared path each index step is the same distance, so equal time gives equal travel.
+    const raw = handDrawn();
+    const prepared = preparePath(raw, { samples: 64 });
+
+    const travel = (path) => {
+        const steps = [];
+        for (let i = 0; i < 20; i++) {
+            const a = samplePath(path, i / 20), b = samplePath(path, (i + 1) / 20);
+            steps.push(Math.hypot(b.x - a.x, b.y - a.y));
+        }
+        return steps;
+    };
+
+    const rawSteps = travel(raw);
+    const prepSteps = travel(prepared);
+    const spread = (s) => Math.max(...s) / (Math.min(...s) || 1e-9);
+
+    assert.ok(spread(rawSteps) > 5, `raw was already even: ${spread(rawSteps)}`);
+    assert.ok(spread(prepSteps) < 1.2, `prepared still stutters: ${spread(prepSteps)}`);
+});
+
+test('a prepared path still starts and ends where the pen did', () => {
+    // Motion along a path is stored as an offset from path[0], so moving the first point would
+    // shift the whole animation away from where it was drawn.
+    const raw = handDrawn();
+    const p = preparePath(raw, { samples: 40 });
+    assert.deepEqual(p[0], { x: Math.round(raw[0].x), y: Math.round(raw[0].y) });
+    const last = raw[raw.length - 1];
+    assert.deepEqual(p[p.length - 1], { x: Math.round(last.x), y: Math.round(last.y) });
+});


### PR DESCRIPTION
Closes #31. Two commits, and they are worth reading in order — the second only works because of the first.

## 1. The stutter was in the data, not the renderer

A path captured from a pen is a recording of a hand: points pile up where the pen slowed and spread out where it sped up. `samplePath` walks the array **by index**, so animating along raw capture data replays the *drawing speed* rather than the drawn *shape* — crawling through the careful parts, lurching through the confident ones. This was already visible on part paths today.

Measured on a path drawn the way a hand draws one, consecutive steps varied by **more than 5×**. Now **under 1.2×**. The tests assert the premise before the fix, so they fail if the problem stops being real:

```js
assert.ok(spread(rawSteps) > 5,    `raw was already even: ${spread(rawSteps)}`);
assert.ok(spread(prepSteps) < 1.2, `prepared still stutters: ${spread(prepSteps)}`);
```

**It costs nothing per frame.** The path is evened out once, when the drawing is committed — Chaikin corner cutting to take out the tremor, then resampled to equal spacing. Sampling by index then *is* sampling by distance, so the render loop is unchanged. That is the cost constraint in #31.

Chaikin rather than a spline fit: a few multiplications per point, no solver, and it cannot overshoot, so a deliberately sharp corner softens instead of bulging past where the pen went.

## 2. The camera

A window onto the frame rather than something drawn into it: a centre, a zoom and a tilt, resolved to one transform wrapping everything composited for the cut — video reference, artwork and text move together, which is what makes it read as a camera instead of another per-layer move. The white background stays outside it; that is the viewport, and zooming it would leave the edges unpainted.

**Drawn paths and presets** answer different needs. A drawn path is for a move nobody can name. Presets — push in, pull out, pan each way, ken burns — are for the moves an MV needs constantly, where drawing a straight line by hand only makes it crooked. A drawn path overrides the preset's *movement* but keeps its *zoom*, so ken burns can supply the push-in while you say where it goes.

**Panning is the non-obvious part.** There is nothing outside the canvas, so moving the window sideways at zoom 1 slides blank paper into shot. Presets that move the centre zoom in first, and the amount is **derived, not chosen**:

```js
export function zoomForDrift(drift) { return 1 / (1 - 2 * clamp(drift)); }
```

The first ken burns preset had a drift its own zoom could not cover and showed blank paper for the first fifth of the move. The test caught it. Presets now ask for the number rather than being told it.

Position, zoom and tilt all take the same eased progress — easing them separately is what makes one move read as two.

**Playback only**, like cut and part animation: while editing, a moved canvas would put the pen somewhere other than where the drawing appears. `computeCamera` returns `null` when there is nothing to do, so every cut without a camera — all of them, in every existing project — skips the transform rather than multiplying by an identity each frame.

## Verified

- [x] `npm run check` — 364 tests (was 344), typecheck and build clean
- [x] 20 new tests; the "a pan never shows past the edge" invariant is checked at 20 points across every preset

## Worth trying

1. Cut settings (⚙) → **카메라** → pick 켄 번스 or 줌 인 → play
2. **경로 그리기**, draw a line across the canvas, play — the camera should follow it at an even speed
3. Draw the path deliberately **slowly at the start, fast at the end** — it should still move evenly
4. Part motion path (the pre-existing feature) should also be smoother than before
5. A project with no camera should look **exactly** as it did