### PR TITLE
fix: the smoke test could not detect the regression it was written for

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,15 @@ updates:
       # one that needs the release notes read.
       routine:
         update-types: [minor, patch]
+      # Packages that peer-depend on each other have to move together or not at all. Bumping one
+      # half produces a pull request that cannot install - which is what happened on the first
+      # run: react-dom 19 against react 18, and @capacitor/android 8 against @capacitor/core 7.
+      # Both were correctly rejected by CI, but they were never mergeable, and reviewing a broken
+      # pull request costs the same as reviewing a real one.
+      react:
+        patterns: ['react', 'react-dom', '@types/react*']
+      capacitor:
+        patterns: ['@capacitor/*']
     commit-message:
       prefix: 'chore(deps)'
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,9 +20,11 @@ on:
 permissions:
   contents: write
 
+# Never cancel a tag build. It creates the Release before uploading the APK, so interrupting it
+# can leave a published release with no file attached - worse than two builds racing.
 concurrency:
   group: apk-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   apk:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,11 @@ jobs:
       # The app probes /api on load to decide whether server save is available, so the API has
       # to be up or the page comes up reporting itself offline - which is what the first run of
       # this job caught.
+      # Backgrounding with `&` means this step succeeds whatever the server does, so its output
+      # has to be kept: without it a startup failure shows up a minute later as a bare wait-on
+      # timeout, with the stack trace that explains it already gone.
       - name: Start the API server
-        run: npm run server &
+        run: npm run server > api.log 2>&1 &
 
       # vite preview serves dist/ the way a static host would, so this exercises the built
       # bundle rather than the dev server's module graph.
@@ -85,6 +88,10 @@ jobs:
 
       - name: Wait for both servers
         run: npx wait-on http://localhost:8787/api/projects http://localhost:4173 --timeout 60000
+
+      - name: Why the API did not start
+        if: failure()
+        run: cat api.log || true
 
       # The runner image ships Google Chrome, which is what the test drives - no browser
       # download, no playwright install step.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,9 +18,12 @@ permissions:
   contents: read
   security-events: write
 
+# main is exempt for the same reason it is in ci.yml, and one more: the analysis of main is the
+# baseline that pull-request alerts are compared against, so cancelling it leaves the comparison
+# pointing at an older commit.
 concurrency:
   group: codeql-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   analyze:

--- a/test/smoke/boot.mjs
+++ b/test/smoke/boot.mjs
@@ -35,12 +35,13 @@ if (!browser) {
     process.exit(1);
 }
 
-const page = await browser.newPage();
-page.on('console', m => { if (m.type() === 'error') errors.push(m.text()); });
-page.on('pageerror', e => errors.push(`uncaught: ${e.message}`));
-
 let failure = null;
+let page = null;
 try {
+    page = await browser.newPage();
+    page.on('console', m => { if (m.type() === 'error') errors.push(m.text()); });
+    page.on('pageerror', e => errors.push(`uncaught: ${e.message}`));
+
     const res = await page.goto(url, { waitUntil: 'load', timeout: 30_000 });
     if (!res || !res.ok()) throw new Error(`the page did not load: ${res && res.status()}`);
 
@@ -67,16 +68,29 @@ try {
         panels: document.querySelectorAll('.panel-title, .tl-tracks, .toolbar').length,
     }));
     if (counts.buttons < 5) throw new Error(`only ${counts.buttons} buttons rendered - the UI did not come up`);
+    // Counted separately on purpose: the panels and the timeline are different subtrees from the
+    // toolbar, and one of them throwing while the others survive is exactly the failure a button
+    // count on its own sails straight past.
+    if (counts.panels < 2) throw new Error(`only ${counts.panels} panels rendered - part of the UI is missing`);
+
+    // The regression this test was written after was the built app having no backend: the API
+    // proxy is configured for the dev server, and `vite preview` does not inherit it. The console
+    // says nothing about that - the app catches the failed probe and quietly calls itself offline
+    // - so the check has to be made from the page, against the origin the page actually uses.
+    const api = await page.evaluate(async () => {
+        try { return (await fetch('/api/projects')).status; } catch (e) { return String(e); }
+    });
+    if (api !== 200) throw new Error(`the API is not reachable from the page: /api/projects gave ${api}`);
 
     // A failed asset or a caught-but-real exception shows up here and nowhere else.
     if (errors.length) throw new Error('console errors:' + errors.map(e => '\n  ' + e).join(''));
 
-    console.log(`smoke passed - canvas ${size.w}x${size.h}, ${counts.buttons} buttons, no console errors`);
+    console.log(`smoke passed - canvas ${size.w}x${size.h}, ${counts.buttons} buttons, API reachable, no console errors`);
 } catch (e) {
     failure = e;
     // A screenshot is the only way to tell "white screen" from "loaded but missing an element"
     // when this fails on a machine nobody is sitting at.
-    try { await page.screenshot({ path: 'smoke-failure.png', fullPage: true }); } catch { }
+    try { if (page) await page.screenshot({ path: 'smoke-failure.png', fullPage: true }); } catch { }
 } finally {
     await browser.close();
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,6 +26,10 @@ export default defineConfig({
   // static server, and shows itself as offline. That is also what the boot smoke test saw.
   preview: {
     port: 4173,
+    // Enforced, not preferred. The smoke test drives http://localhost:4173 by name; if the port
+    // were taken and vite quietly moved to 4174, the test would pass or fail against whatever
+    // else was listening there.
+    strictPort: true,
     proxy: API_PROXY,
   },
 })


### PR DESCRIPTION
Seven findings from a review of #30, all real, plus the Dependabot grouping the first run exposed.

## The one that matters

The boot smoke test was added **because** `vite preview` had no API proxy, so the built app came up with no backend. **The test could not have caught that.** The app catches the failed probe and quietly calls itself offline, and a fetch that resolves with a 500 logs nothing to the console — so removing the proxy again left the test green.

Verified by stopping the API and re-running: the old assertions still passed. Now:

```
smoke failed: the API is not reachable from the page: /api/projects gave 500
```

It asks the page itself whether `/api/projects` answers, from the origin the page actually uses, and reports the status it got. Confirmed failing with the API down and passing with it up.

## The rest

| | |
|---|---|
| `boot.mjs` | `panels` was counted and never asserted — while the comment beside it claimed it caught the timeline throwing with the toolbar intact. Now asserted. |
| `ci.yml` | `npm run server &` succeeds whatever the child does and nothing captured its output, so a startup failure appeared a minute later as a bare `wait-on` timeout with the cause gone. Kept and printed on failure. |
| `codeql.yml` | Cancelled in-progress runs on `main`, which `ci.yml` deliberately does not. Worse here — the analysis of main is the **baseline PR alerts are diffed against**. |
| `android.yml` | Cancelled tag builds. It creates the Release *before* attaching the APK, so an interrupted one can leave a **published release with no file in it**. Tags exempt. |
| `vite.config.js` | `preview.port` pinned without `strictPort`, so it was advisory; a taken port would move the server silently and leave the smoke test driving whatever else was on 4173. |
| `boot.mjs` | `browser.newPage()` sat outside the `try` owning `browser.close()`, orphaning the browser if it threw. |

## Dependabot grouping

The first run opened two PRs that could never have installed — react-dom 19 against react 18 (#34), @capacitor/android 8 against @capacitor/core 7 (#36). CI rejected both, which is the system working, but they were unmergeable from the moment they opened and reviewing a broken PR costs the same as a real one. Peer-dependent packages now move together.

## Verified

- [x] `npm run check` — 329 tests, build clean
- [x] Smoke **fails** with the API down, **passes** with it up
- [x] All four YAML files parse