### PR TITLE
security: bind the API to loopback, and only hand YouTube addresses to yt-dlp

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -8,10 +8,19 @@ import path from 'node:path';
 import os from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { isYouTubeUrl } from './youtubeUrl.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.join(__dirname, 'data');
 const PORT = process.env.MV_API_PORT ? Number(process.env.MV_API_PORT) : 8787;
+// Loopback unless somebody asks otherwise. Passing no host to app.listen binds every interface,
+// which is what this did - so on a laptop joined to any network, all fourteen endpoints were
+// reachable by anyone on it, with no authentication in front of them.
+//
+// Nothing needs the wider binding. A tablet reaches the app through the Vite dev server's /api
+// proxy, and that proxy runs on this machine and connects to localhost - so the tablet workflow
+// keeps working with the API bound to loopback. Set MV_API_HOST=0.0.0.0 to open it deliberately.
+const HOST = process.env.MV_API_HOST || '127.0.0.1';
 
 const app = express();
 app.use(express.json({ limit: '256mb' })); // projects embed base64 bitmaps, so allow large bodies
@@ -220,9 +229,10 @@ app.delete('/api/projects/:id', async (req, res) => {
 // Local-only: extract audio from a URL (YouTube etc) via yt-dlp + ffmpeg. Not for the
 // deployed build. For personal/authorized use; respect source ToS and copyright.
 const audioType = (ext) => ({ '.webm': 'audio/webm', '.m4a': 'audio/mp4', '.mp4': 'audio/mp4', '.mp3': 'audio/mpeg', '.opus': 'audio/ogg', '.ogg': 'audio/ogg' }[ext] || 'application/octet-stream');
+
 app.get('/api/youtube-audio', async (req, res) => {
     const url = String(req.query.url || '');
-    if (!/^https?:\/\//.test(url)) { res.status(400).json({ error: 'invalid url' }); return; }
+    if (!isYouTubeUrl(url)) { res.status(400).json({ error: 'not a YouTube address' }); return; }
     const dir = path.join(os.tmpdir(), `yt_${Date.now()}_${Math.random().toString(36).slice(2)}`);
     await fs.mkdir(dir, { recursive: true });
     // bestaudio in its native container — no ffmpeg needed; browser plays m4a/webm.
@@ -307,7 +317,7 @@ console.log('[mv-api] ffmpeg:', FFMPEG_DIR ? path.join(FFMPEG_DIR, 'ffmpeg.exe')
 
 app.get('/api/youtube-video', async (req, res) => {
     const url = String(req.query.url || '');
-    if (!/^https?:\/\//.test(url)) { res.status(400).json({ error: 'invalid url' }); return; }
+    if (!isYouTubeUrl(url)) { res.status(400).json({ error: 'not a YouTube address' }); return; }
     const maxH = Math.max(144, Math.min(2160, Number(req.query.maxHeight) || 1080));
     const dir = path.join(os.tmpdir(), `ytv_${Date.now()}_${Math.random().toString(36).slice(2)}`);
     await fs.mkdir(dir, { recursive: true });
@@ -348,4 +358,12 @@ app.get('/api/youtube-video', async (req, res) => {
     }
 });
 
-app.listen(PORT, () => console.log(`[mv-api] project storage listening on http://localhost:${PORT}`));
+app.listen(PORT, HOST, () => {
+    // Printing the host it actually bound, not the one it probably meant. The old line said
+    // "localhost" while binding everything, which is the kind of message that stops anybody from
+    // looking further.
+    console.log(`[mv-api] project storage listening on http://${HOST}:${PORT}`);
+    if (HOST !== '127.0.0.1' && HOST !== 'localhost') {
+        console.log('[mv-api] WARNING: reachable from the network, and there is no authentication.');
+    }
+});

--- a/server/youtubeUrl.js
+++ b/server/youtubeUrl.js
@@ -1,0 +1,33 @@
+// Which addresses the importer will hand to yt-dlp.
+//
+// The two YouTube endpoints pass a URL straight to yt-dlp, which fetches it. They used to accept
+// anything matching /^https?:\/\//, which made the server a general-purpose downloader on behalf
+// of whoever could reach it - including for hosts only this machine can see, which is the part
+// that makes it more than a bandwidth problem.
+//
+// It is a YouTube importer. It takes YouTube addresses.
+//
+// This lives in its own file rather than inside index.js so it can be tested without starting a
+// server. It guards a boundary, so the awkward inputs are worth stating out loud.
+
+/** Hosts yt-dlp is allowed to be pointed at. */
+export const YOUTUBE_HOSTS = new Set([
+    'youtube.com', 'www.youtube.com', 'm.youtube.com', 'music.youtube.com',
+    'youtu.be', 'www.youtu.be', 'youtube-nocookie.com', 'www.youtube-nocookie.com',
+]);
+
+/**
+ * @param {unknown} raw
+ * @returns {boolean} whether this is a YouTube address worth handing to yt-dlp
+ */
+export function isYouTubeUrl(raw) {
+    if (typeof raw !== 'string') return false;
+    let u;
+    // Parsed, not pattern-matched. A regex looking for the domain anywhere in the string accepts
+    // https://evil.test/?next=youtube.com, and one anchored at the start accepts
+    // https://youtube.com.evil.test/ - the hostname is the only part worth comparing, and the
+    // URL parser is the only thing that knows where it ends.
+    try { u = new URL(raw); } catch { return false; }
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return YOUTUBE_HOSTS.has(u.hostname.toLowerCase());
+}

--- a/test/youtubeUrl.test.js
+++ b/test/youtubeUrl.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isYouTubeUrl } from '../server/youtubeUrl.js';
+
+test('the addresses people actually paste are accepted', () => {
+    for (const u of [
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        'https://youtube.com/watch?v=abc',
+        'https://m.youtube.com/watch?v=abc',
+        'https://music.youtube.com/watch?v=abc',
+        'https://youtu.be/abc',
+        'https://www.youtube.com/shorts/abc',
+        'https://www.youtube-nocookie.com/embed/abc',
+        'http://www.youtube.com/watch?v=abc',
+    ]) {
+        assert.ok(isYouTubeUrl(u), `rejected a real one: ${u}`);
+    }
+});
+
+test('a host that merely contains the word is not YouTube', () => {
+    // The two ways a string check gets this wrong. Searching anywhere in the URL accepts the
+    // first; anchoring at the start accepts the second. Only parsing gets both right.
+    assert.equal(isYouTubeUrl('https://evil.test/?next=youtube.com'), false);
+    assert.equal(isYouTubeUrl('https://youtube.com.evil.test/watch?v=abc'), false);
+    assert.equal(isYouTubeUrl('https://notyoutube.com/watch?v=abc'), false);
+    assert.equal(isYouTubeUrl('https://evil.test/youtube.com/watch'), false);
+});
+
+test('credentials in the URL do not smuggle a host past the check', () => {
+    // The classic: everything before @ is userinfo, so the real host is evil.test.
+    assert.equal(isYouTubeUrl('https://www.youtube.com@evil.test/x'), false);
+    assert.equal(isYouTubeUrl('https://user:pass@evil.test/?a=youtube.com'), false);
+});
+
+test('the internal addresses this check exists to block', () => {
+    // Handing these to yt-dlp would have it fetch from the host's own network - reachable from
+    // the server and from nowhere else, which is what made an open downloader worth closing.
+    for (const u of [
+        'http://localhost:8787/api/projects',
+        'http://127.0.0.1/',
+        'http://169.254.169.254/latest/meta-data/',
+        'http://192.168.1.1/',
+        'http://[::1]:8787/',
+    ]) {
+        assert.equal(isYouTubeUrl(u), false, `let through: ${u}`);
+    }
+});
+
+test('non-http schemes are refused', () => {
+    assert.equal(isYouTubeUrl('file:///etc/passwd'), false);
+    assert.equal(isYouTubeUrl('ftp://youtube.com/x'), false);
+    assert.equal(isYouTubeUrl('javascript:alert(1)'), false);
+    // Even one wearing the right hostname.
+    assert.equal(isYouTubeUrl('data:text/html,youtube.com'), false);
+});
+
+test('the host comparison ignores case', () => {
+    assert.ok(isYouTubeUrl('https://WWW.YouTube.COM/watch?v=abc'));
+});
+
+test('junk in, false out - never a throw', () => {
+    for (const v of ['', '   ', 'youtube.com/watch?v=abc', null, undefined, 42, {}, []]) {
+        assert.equal(isYouTubeUrl(/** @type {any} */(v)), false, `threw or accepted: ${String(v)}`);
+    }
+});


### PR DESCRIPTION
Closes #41.

## The binding

`app.listen` was called with no host, so Node bound **every interface**. On a laptop joined to any network, all fourteen endpoints were reachable by anyone on it with no authentication: read, overwrite and `DELETE` any project, `PUT` assets up to a gigabyte, and point the importer at any URL.

The startup line said `listening on http://localhost:8787` the whole time — the kind of message that stops anyone from looking further. Same class as the yt-dlp error text: it described an intention, not the behaviour.

**Nothing needed the wider binding.** A tablet reaches the app through the Vite dev server's `/api` proxy, and that proxy runs on the desktop and connects to localhost. Verified after the change:

```
http://<lan-ip>:8787/api/projects   ->  000   (refused)
http://<lan-ip>:5175/api/projects   ->  200   (tablet path, still fine)

[mv-api] project storage listening on http://127.0.0.1:8787
TCP    127.0.0.1:8787    LISTENING
```

`MV_API_HOST=0.0.0.0` opens it deliberately, and the server warns on startup when the host is not loopback.

## The downloader

Both YouTube endpoints accepted anything matching `/^https?:\/\//`, so the server would fetch arbitrary URLs on request — **including hosts only the server can see**, which is the part that makes it more than a bandwidth question.

The check parses rather than pattern-matches, because both obvious string versions are wrong in opposite directions, and there is a third way in:

| input | a naive check says | reality |
|---|---|---|
| `https://evil.test/?next=youtube.com` | contains "youtube.com" ✓ | not YouTube |
| `https://youtube.com.evil.test/` | starts with it ✓ | not YouTube |
| `https://www.youtube.com@evil.test/` | looks right to a human | host is `evil.test` |

All three are tests, along with the loopback and link-local addresses (`127.0.0.1`, `[::1]`, `169.254.169.254`) the check exists to refuse.

It lives in `server/youtubeUrl.js` so it can be tested without starting a server.

## Already fine — checked so nobody re-checks

- **No shell injection.** `spawn` takes an argv array, never a shell string, so a crafted URL is an argument and not a command.
- **No path traversal.** `safeId()` strips everything outside `[a-zA-Z0-9_-]` and caps at 64 chars; the asset extension is sanitised separately.
- **No secrets in the repository** — searched the working tree and all of git history.

## Not in this PR

Authentication on the project endpoints, and lower body limits. Those belong with the Render deployment, where they stop being precautions and start being the only thing in the way. Left open on #41.

## Verified

- [x] `npm run check` — 336 tests, build clean
- [x] Bind confirmed by `netstat` and by curl from the LAN address
- [x] Tablet path confirmed still working after the change
