### PR TITLE
refactor: give the document shapes real types, and upgrade to TypeScript 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "eslint": "^9.39.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "playwright-core": "^1.62.1",
-        "typescript": "^5.9.3",
+        "typescript": "^7.0.2",
         "vite": "^6.1.1",
         "vite-plugin-qrcode": "^0.4.1",
         "wait-on": "^9.1.0"
@@ -1881,6 +1881,346 @@
       "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -4990,17 +5330,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint": "^9.39.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "playwright-core": "^1.62.1",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vite": "^6.1.1",
     "vite-plugin-qrcode": "^0.4.1",
     "wait-on": "^9.1.0"

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -844,10 +844,10 @@ export async function extractVideoFrames(file, { fps = 6, maxFrames = 0, start =
     const video = document.createElement('video');
     video.muted = true; video.playsInline = true; video.preload = 'auto'; video.src = url;
     try {
-        await new Promise((res, rej) => {
+        await /** @type {Promise<void>} */ (new Promise((res, rej) => {
             video.onloadedmetadata = () => res();
             video.onerror = () => rej(new Error(tr('영상을 읽을 수 없습니다 (형식 미지원)')));
-        });
+        }));
         const duration = video.duration;
         if (!isFinite(duration) || duration <= 0) throw new Error(tr('영상 길이를 알 수 없습니다'));
         const to = Math.min(end ?? duration, duration);
@@ -871,11 +871,11 @@ export async function extractVideoFrames(file, { fps = 6, maxFrames = 0, start =
         const ctx = cnv.getContext('2d');
         ctx.imageSmoothingEnabled = true; ctx.imageSmoothingQuality = 'high'; // crisp resampling when scaling
         const r = useNative ? { x: 0, y: 0, w: fw, h: fh } : fitRect(vW, vH, fw, fh);
-        const seek = (t) => new Promise((res) => {
+        const seek = (t) => /** @type {Promise<void>} */ (new Promise((res) => {
             const on = () => { video.removeEventListener('seeked', on); res(); };
             video.addEventListener('seeked', on);
             video.currentTime = t;
-        });
+        }));
         const toBlob = format === 'png'
             ? () => new Promise((res) => cnv.toBlob(res, 'image/png'))                    // lossless
             : () => new Promise((res) => cnv.toBlob(b => b ? res(b) : cnv.toBlob(res, 'image/jpeg', quality), 'image/webp', quality));
@@ -971,14 +971,14 @@ export async function detectSceneCuts(file, { start = 0, end = null, step = 0.2,
     const video = document.createElement('video');
     video.muted = true; video.playsInline = true; video.preload = 'auto'; video.src = url;
     try {
-        await new Promise((res, rej) => { video.onloadedmetadata = () => res(); video.onerror = () => rej(new Error('scene-detect: cannot read video')); });
+        await /** @type {Promise<void>} */ (new Promise((res, rej) => { video.onloadedmetadata = () => res(); video.onerror = () => rej(new Error('scene-detect: cannot read video')); }));
         const dur = video.duration; if (!isFinite(dur) || dur <= 0) return [];
         const to = Math.min(end ?? dur, dur), from = Math.max(0, Math.min(start, to - 0.05));
         const sw = 48, sh = 48, c = document.createElement('canvas'); c.width = sw; c.height = sh; // finer signature = more accurate
         const cx = c.getContext('2d', { willReadFrequently: true });
         const sig = () => { cx.drawImage(video, 0, 0, sw, sh); const d = cx.getImageData(0, 0, sw, sh).data, o = new Uint8Array(sw * sh); for (let i = 0, j = 0; j < o.length; i += 4, j++) o[j] = (d[i] * 0.299 + d[i + 1] * 0.587 + d[i + 2] * 0.114) | 0; return o; };
         const diff = (a, b) => { let s = 0; for (let i = 0; i < a.length; i++) s += Math.abs(a[i] - b[i]); return s / a.length; };
-        const seek = (t) => new Promise((res) => { const on = () => { video.removeEventListener('seeked', on); res(); }; video.addEventListener('seeked', on); video.currentTime = Math.max(0, Math.min(t, dur - 0.02)); });
+        const seek = (t) => /** @type {Promise<void>} */ (new Promise((res) => { const on = () => { video.removeEventListener('seeked', on); res(); }; video.addEventListener('seeked', on); video.currentTime = Math.max(0, Math.min(t, dur - 0.02)); }));
         // Binary-search the exact moment the picture stops matching the pre-cut frame → precise boundary.
         const refineCut = async (refSig, a, b) => {
             for (let k = 0; k < 6; k++) { const mid = (a + b) / 2; await seek(mid); if (diff(refSig, sig()) > threshold) b = mid; else a = mid; }

--- a/src/canvas/textRender.js
+++ b/src/canvas/textRender.js
@@ -1,3 +1,59 @@
+/**
+ * A text object as the document stores it.
+ *
+ * Written out because every function here took it as `{object}`, which the type checker reads as
+ * "anything" - so a misspelt field was a silent no-effect rather than an error, and the only way
+ * to learn what a text actually holds was to read all of paintFrame. These are the fields the
+ * renderer reads; all of them are optional, because a text created before a feature existed
+ * simply does not have that key and every read below already has a default.
+ *
+ * @typedef {object} TextObject
+ * @property {string} [text] the content, newline-separated for multiple lines
+ * @property {number} [x] anchor, not the left edge - see measureTextBox
+ * @property {number} [y] top of the first line
+ * @property {'left'|'center'|'right'} [align] which edge x anchors
+ * @property {number} [fontSize] clamped to 6..400 on read
+ * @property {string} [fontFamily]
+ * @property {boolean} [bold]
+ * @property {boolean} [italic]
+ * @property {number} [lineHeight] multiple of the font size
+ * @property {number} [letterSpacing] px; skipped on engines without the property
+ * @property {string} [color] the fill, and the top stop when gradient is on
+ * @property {boolean} [gradient] fill vertically from color to color2 instead of flat
+ * @property {string} [color2] the bottom stop; only read when gradient is on
+ * @property {string} [bgColor] rounded highlight painted behind the text
+ * @property {number} [outline] stroke width in px
+ * @property {string} [outlineColor]
+ * @property {boolean} [shadow]
+ * @property {string} [shadowColor]
+ * @property {number} [shadowBlur]
+ * @property {number} [shadowDX]
+ * @property {number} [shadowDY]
+ * @property {number} [rotation] degrees, about the centre of the box
+ * @property {number} [opacity] 0..1, multiplied with any animation alpha
+ */
+
+/**
+ * The rectangle a text occupies, in canvas coordinates.
+ * @typedef {object} TextBox
+ * @property {number} x left edge
+ * @property {number} y top edge
+ * @property {number} w
+ * @property {number} h
+ */
+
+/**
+ * What computeTextAnim returns for one instant, or null when nothing is animating.
+ * @typedef {object} TextAnim
+ * @property {number} alpha
+ * @property {number} dx
+ * @property {number} dy
+ * @property {number} scale
+ * @property {number} blur px
+ * @property {number} rot degrees
+ * @property {number} chars how much of the string is revealed, for the typing effect
+ */
+
 // Measuring and drawing text objects.
 //
 // This was ~70 lines in the middle of paintFrame, which is the render hot path and the last
@@ -6,17 +62,29 @@
 // and the fiddly parts (what order the effects go in, how typing slices a multi-line string)
 // become checkable with a recording context.
 
-/** Font size, clamped to what the editor allows. Three call sites relied on the same clamp. */
+/**
+ * Font size, clamped to what the editor allows. Three call sites relied on the same clamp.
+ * @param {TextObject | null | undefined} t
+ * @returns {number}
+ */
 export function clampFontSize(t) {
     return Math.max(6, Math.min(400, t?.fontSize ?? 32));
 }
 
-/** The CSS font string, in the order the canvas shorthand requires: style, weight, size, family. */
+/**
+ * The CSS font string, in the order the canvas shorthand requires: style, weight, size, family.
+ * @param {TextObject | null | undefined} t
+ * @returns {string}
+ */
 export function textFontOf(t) {
     return `${t?.italic ? 'italic ' : ''}${t?.bold ? 'bold ' : ''}${clampFontSize(t)}px ${t?.fontFamily ?? 'sans-serif'}`;
 }
 
-/** Baseline-to-baseline distance for stacked lines. */
+/**
+ * Baseline-to-baseline distance for stacked lines.
+ * @param {TextObject | null | undefined} t
+ * @returns {number}
+ */
 export function textLineHeight(t) {
     return Math.round(clampFontSize(t) * (t?.lineHeight ?? 1.25));
 }
@@ -28,8 +96,9 @@ export function textLineHeight(t) {
  * right-aligned text hangs off its anchor, and everything that boxes the text - the background
  * highlight, rotation, the editor's dashed outline - needs the real left edge, not the anchor.
  *
- * @param {object} t the text object
+ * @param {TextObject | null | undefined} t
  * @param {CanvasRenderingContext2D} measureCtx any context; only its font and measureText are used
+ * @returns {TextBox}
  */
 export function measureTextBox(t, measureCtx) {
     const fontSize = clampFontSize(t);
@@ -51,6 +120,10 @@ export function measureTextBox(t, measureCtx) {
  * Measuring costs a measureText per line, so it is skipped for plain text. Anything that needs
  * to know where the text actually sits - a pivot to rotate or scale about, a box to paint behind
  * it, a gradient to span it - does need it.
+ *
+ * @param {TextObject | null | undefined} t
+ * @param {TextAnim | null} [anim]
+ * @returns {boolean}
  */
 export function textNeedsBox(t, anim) {
     return !!(t?.gradient || t?.bgColor || t?.rotation || anim);
@@ -86,10 +159,10 @@ export function revealLines(text, chars) {
  * outline.
  *
  * @param {CanvasRenderingContext2D} ctx
- * @param {object} t the text object
+ * @param {TextObject} t
  * @param {object} [opts]
- * @param {object|null} [opts.anim] computeTextAnim output for this instant, or null when paused
- * @param {object|null} [opts.box] the measured box; required whenever textNeedsBox says so
+ * @param {TextAnim|null} [opts.anim] computeTextAnim output for this instant, or null when paused
+ * @param {TextBox|null} [opts.box] the measured box; required whenever textNeedsBox says so
  * @param {number} [opts.alpha] extra opacity from the cut or layer animation
  */
 export function drawTextObject(ctx, t, { anim = null, box = null, alpha = 1 } = {}) {
@@ -133,7 +206,8 @@ export function drawTextObject(ctx, t, { anim = null, box = null, alpha = 1 } = 
 
     const lines = revealLines(t.text, anim ? anim.chars : null);
 
-    // Either a vertical two-colour gradient across the box, or a flat fill.
+    // Either a vertical two-colour gradient down the box, or a flat fill.
+    /** @type {string | CanvasGradient} */
     let fillStyle = t.color ?? '#000';
     if (t.gradient && box) {
         const g = ctx.createLinearGradient(0, box.y, 0, box.y + box.h);

--- a/src/core/bitmapRefs.js
+++ b/src/core/bitmapRefs.js
@@ -24,11 +24,11 @@ function scanCuts(cuts, into) {
 
 /**
  * @param {object} [sources]
- * @param {Array}  [sources.cuts]       the cuts on screen now
- * @param {Array}  [sources.history]    undo snapshots, each { cuts }
- * @param {object|Array} [sources.copiedCut] clipboard: one cut or several
- * @param {object} [sources.lassoClip]  copied lasso selection
- * @param {object} [sources.selection]  the live selection, which has a mask as well
+ * @param {Cut[]} [sources.cuts]       the cuts on screen now
+ * @param {{cuts?: Cut[]}[]} [sources.history] undo snapshots
+ * @param {Cut|Cut[]|null} [sources.copiedCut] clipboard: one cut or several
+ * @param {{bitmapId?: string|null}|null} [sources.lassoClip] copied lasso selection
+ * @param {{bitmapId?: string|null, maskBitmapId?: string|null}|null} [sources.selection] the live selection, which has a mask as well
  * @returns {Set<string>} every id that must be kept
  */
 export function collectUsedBitmapIds({ cuts, history, copiedCut, lassoClip, selection } = {}) {

--- a/src/core/cutClone.js
+++ b/src/core/cutClone.js
@@ -13,10 +13,10 @@
 //    bitmap rather than becoming several.
 
 /**
- * @param {object} srcCut the cut to copy from
+ * @param {Cut} srcCut the cut to copy from
  * @param {(oldId: any, cache: Map) => any} cloneBitmapId copies stored pixels, returning the new
  *   id; given the shared cache so it can return the same new id for a repeated old one
- * @returns {{layers: Array, activeLayerId: any, texts: Array}} the contents, ready for a new cut
+ * @returns {{layers: Layer[], activeLayerId: any, texts: CutText[]}} the contents, ready for a new cut
  */
 export function cloneCutContents(srcCut, cloneBitmapId) {
     const srcLayers = Array.isArray(srcCut?.layers) ? srcCut.layers : [];

--- a/src/core/layerOps.js
+++ b/src/core/layerOps.js
@@ -145,8 +145,8 @@ export function insertFill(strokes, fill, overPaint) {
  *    last stroke's identity - does not notice, and the layer would keep drawing at its old
  *    position. Bumping rev is what invalidates it.
  *
- * @param {object} cut the cut being edited
- * @param {Array} layerIds ids of the layers to move
+ * @param {Cut} cut the cut being edited
+ * @param {any[]} layerIds ids of the layers to move
  * @param {number} dx
  * @param {number} dy
  * @param {boolean} [withTexts] move the cut's text objects too

--- a/src/db.js
+++ b/src/db.js
@@ -33,11 +33,11 @@ function tx(db, mode) {
 
 export async function saveProject(id, data, name) {
     const db = await openDB();
-    return new Promise((resolve, reject) => {
+    return /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
         const req = tx(db, 'readwrite').put({ id, name: name ?? data?.name ?? id, savedAt: data?.savedAt ?? new Date().toISOString(), data });
         req.onsuccess = () => resolve();
         req.onerror = () => reject(req.error);
-    });
+    }));
 }
 
 export async function loadProject(id) {
@@ -60,11 +60,11 @@ export async function listProjects() {
 
 export async function deleteProject(id) {
     const db = await openDB();
-    return new Promise((resolve, reject) => {
+    return /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
         const req = tx(db, 'readwrite').delete(id);
         req.onsuccess = () => resolve();
         req.onerror = () => reject(req.error);
-    });
+    }));
 }
 
 export const autosaveKey = AUTOSAVE_ID;

--- a/src/document.d.ts
+++ b/src/document.d.ts
@@ -1,0 +1,71 @@
+// The shapes the document is made of.
+//
+// These were written as `{object}` in JSDoc wherever they crossed a function boundary, which the
+// checker reads as "has no properties" - so `cut.layers` was an error waiting for a stricter
+// TypeScript, and, worse, a misspelt field was never anything at all. The only way to learn what
+// a cut held was to read every function that touched one.
+//
+// Ambient on purpose: these are the vocabulary of the whole app, and requiring an import in every
+// JSDoc comment would mean most comments simply not using them.
+//
+// Deliberately not exhaustive and deliberately not sealed with an index signature. Listing every
+// field would make this a second copy of the reducer to keep in step; allowing any field would
+// bring back the problem it exists to solve. What is here is what crosses a boundary.
+
+/** One drawn mark. Its shape depends on `tool`; the fields below are the ones shared code reads. */
+interface Stroke {
+    tool?: string;
+    /** Pixels held in the bitmap store rather than in the document - fill, lasso and paste. */
+    bitmapId?: string | null;
+    /** A lasso paste also keeps the mask that shaped it. */
+    maskBitmapId?: string | null;
+    [extra: string]: any;
+}
+
+/** A layer, or a folder holding layers. Folders have no strokes of their own. */
+interface Layer {
+    id: any;
+    type?: 'layer' | 'folder';
+    parentId?: any;
+    name?: string;
+    visible?: boolean;
+    locked?: boolean;
+    opacity?: number;
+    strokes?: Stroke[];
+    /** Cleared when a project is opened - redo is a within-session affair. */
+    redoStrokes?: Stroke[];
+    /**
+     * Bumped when something changes that the cached-canvas signature cannot see. Moving a layer
+     * changes coordinates without changing the stroke count, so without this the cache keeps
+     * drawing the old position.
+     */
+    rev?: number;
+    anim?: any;
+    [extra: string]: any;
+}
+
+/** A text object. The renderer's view of one is TextObject in canvas/textRender.js. */
+interface CutText {
+    id: any;
+    visible?: boolean;
+    [extra: string]: any;
+}
+
+/** One shot on the timeline. */
+interface Cut {
+    id: any;
+    name?: string;
+    startTime: number;
+    endTime: number;
+    track: number;
+    layers: Layer[];
+    activeLayerId?: any;
+    texts?: CutText[];
+    /** Set when the cut belongs to a part - a group made from an import or a lasso selection. */
+    partId?: any;
+    partName?: string;
+    anim?: any;
+    /** A camera move for this shot; absent on every cut that has never had one. */
+    camera?: any;
+    [extra: string]: any;
+}

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -15,3 +15,11 @@ interface Window {
 interface ImportMeta {
     env: Record<string, any>;
 }
+
+// A bare `import './App.css'` is a Vite side-effect import: the bundler turns it into a stylesheet
+// link and there is no module to type. TypeScript 5 let it pass; 7 asks for a declaration (TS2882),
+// and this is it. Same for the asset types Vite can import.
+declare module '*.css';
+declare module '*.svg';
+declare module '*.png';
+declare module '*.webp';


### PR DESCRIPTION
Closes #40. Supersedes Dependabot's #35, which failed with 21 errors.

## The version bump was never the work

Nineteen of those errors were JSDoc parameters written as `{object}`, which the checker reads as **"has no properties"** — so `cut.layers` was an error waiting for a stricter compiler, and, worse, a misspelt field had never been anything at all. The only way to learn what a cut held was to read every function that touched one.

`src/document.d.ts` now says. Ambient, because these are the vocabulary of the whole app and requiring an import in every JSDoc comment means most comments not using them.

It is deliberately **not exhaustive** and deliberately **not sealed with an index signature**: listing every field would make it a second copy of the reducer to keep in step, and allowing any field would bring back the problem it exists to solve. What is there is what crosses a boundary.

## It paid before the commit

Text got the same treatment in `textRender.js`. Writing the typedef from what the code reads, I recorded `gradient` as a pair of colours. The checker rejected it:

```
error TS2551: Property 'color2' does not exist on type 'TextObject'. Did you mean 'color'?
```

`gradient` is a **boolean toggle**, the second colour is `color2` — a field I had not noticed at all — and the fill runs vertically, not horizontally as I had written. A guess that would otherwise have shipped as documentation, which is worse than no documentation.

## The other two error classes

**TS2810 (5 sites).** TypeScript 7 will not infer `Promise<void>` from a `resolve()` called with no argument. Three forms silence it — a cast, an annotated variable, an explicit `undefined`. All three were checked against `tsc 7.0.2` before picking the cast, which is the one that leaves the code shape alone:

```js
await /** @type {Promise<void>} */ (new Promise((res, rej) => { … }));
```

**TS2882.** `import './App.css'` is a Vite side-effect import — the bundler turns it into a stylesheet link and there is no module to type. Declared alongside the other asset types Vite can import.

## Verified under 7.0.2, not predicted

TypeScript 7 was installed and every fix confirmed against it rather than reasoned about:

- [x] `npx tsc --noEmit` — **0 errors** (was 21)
- [x] 364 tests pass
- [x] Build clean
- [x] Boot smoke test passes against the built bundle

## Note on the branch commit message

Backticks in the commit body were expanded by the shell, so that paragraph on the branch is missing three identifiers. The squash message will carry the correct text; the content is above.
