### PR TITLE
docs: index every shared helper, and fail the build when one is missing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,10 @@
 # Architecture map (read this before editing — saves grep/read passes)
 
+> **Looking for a helper? [HELPERS.md](HELPERS.md) lists all of them.** Check there before
+> writing one — `clearLiveOverlay` was reimplemented four times while the real one sat two
+> hundred lines away, and the timeline gutter width had seven copies. `npm run check` fails when
+> a shared export is missing from that index, so it cannot quietly go out of date.
+
 Frame-by-frame MV/animation app. Vite + React 18, single big component. Capacitor wraps it for Android.
 
 ## Files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,10 @@ reasons: every PR gets a Vercel preview, so it can be tried as a real deployment
 lands; CI is a gate, so broken code cannot reach `main`; and why something was done stays with
 the code.
 
+**Before writing a helper, look in [HELPERS.md](HELPERS.md).** It indexes every shared export,
+and `npm run check` fails when one is missing from it. The reason it exists is that the same
+helpers kept being written twice.
+
 **Write issues, pull requests, commit messages and code comments in English.** It is the
 convention for a public repository and keeps everything in one language.
 

--- a/HELPERS.md
+++ b/HELPERS.md
@@ -1,0 +1,343 @@
+# What already exists
+
+An index of every shared helper, so the next person does not write one that is already here.
+
+It exists because that kept happening. `clearLiveOverlay` was reimplemented by hand in four
+places while the real one sat two hundred lines below them; the timeline gutter width had seven
+copies; the current-cut lookup had thirteen, under five names. None of that was carelessness — a
+four-thousand-line component does not announce what it already has.
+
+`scripts/helper-index.mjs` runs in `npm run check` and fails when a shared export is missing from
+this file, or when a row here names something that no longer exists. A document nobody updates is
+worse than none: it teaches you to distrust it, and then you stop looking.
+
+Each row says what the helper is **for** and, where it matters, **what goes wrong without it** —
+that second part is usually the reason it exists.
+
+## `src/core/bitmapRefs.js`
+
+Which stored bitmaps are still reachable, for garbage collection.
+
+| | |
+|---|---|
+| `collectUsedBitmapIds` | Ids referenced by the strokes of a list of cuts. */ |
+| `unusedBitmapIds` | Ids referenced by the strokes of a list of cuts. */ |
+
+## `src/core/camera.js`
+
+Camera moves: presets, drawn paths, and the transform they resolve to.
+
+| | |
+|---|---|
+| `applyCamera` | No camera at all: the default, and what every existing project has. */ |
+| `CAMERA_DEFAULT` | No camera at all: the default, and what every existing project has. |
+| `CAMERA_PRESETS` | No camera at all: the default, and what every existing project has. */ |
+| `computeCamera` | No camera at all: the default, and what every existing project has. */ |
+| `resolveCamera` | No camera at all: the default, and what every existing project has. */ |
+| `zoomForDrift` | The smallest zoom at which a camera may sit that far off centre without the frame running off the artwork. |
+
+## `src/core/cutClone.js`
+
+Copying a cut, including the pixels its strokes point at.
+
+| | |
+|---|---|
+| `cloneCutContents` | id; given the shared cache so it can return the same new id for a repeated old one |
+
+## `src/core/cutOps.js`
+
+Dragging and resizing cuts on the timeline, with snapping.
+
+| | |
+|---|---|
+| `dragCut` | Edges a cut can snap to on a given track: zero, plus every other cut's start and end. */ |
+| `resizeCut` | Edges a cut can snap to on a given track: zero, plus every other cut's start and end. */ |
+
+## `src/core/cutsReducer.js`
+
+Every change the document can undergo, as named actions. Build them with these creators - a mistyped action is then a type error rather than a silent no-op.
+
+| | |
+|---|---|
+| `addCuts` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `assignPartTo` | — |
+| `clearCut` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `cutsReducer` | ── the reducer ──────────────────────────────────────────────────────────── |
+| `deleteText` | — |
+| `deleteTrack` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `insertCutsShifting` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `mergeLayerDown` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `moveCutGroup` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `moveLayers` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `moveText` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `patchCut` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `patchCuts` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `removeBatch` | — |
+| `renamePart` | — |
+| `replaceBatchCuts` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `replaceCuts` | Replace the whole document: opening a file, undo/redo, starting over. |
+| `setCutAnim` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `setCutCamera` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `setLayerAnim` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `toggleTextVisible` | — |
+| `ungroupPart` | — |
+| `updateCut` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `updateLayer` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `upsertText` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+
+## `src/core/historyOps.js`
+
+Undo and redo, and the memory budget that bounds them.
+
+| | |
+|---|---|
+| `canRedo` | — |
+| `canUndo` | Steps affordable at this snapshot size. Exported for the tests and for anyone tuning it. */ |
+| `HISTORY_LIMIT` | Steps affordable at this snapshot size. Exported for the tests and for anyone tuning it. */ |
+| `limitFor` | The undo memory budget. Raising it is a deliberate decision, not a tuning knob. |
+| `pushSnapshot` | Steps affordable at this snapshot size. Exported for the tests and for anyone tuning it. */ |
+| `step` | Steps affordable at this snapshot size. Exported for the tests and for anyone tuning it. */ |
+
+## `src/core/lassoOps.js`
+
+Lasso selection: closing the path, bounding it, lifting the pixels.
+
+| | |
+|---|---|
+| `applyResize` | Close a freehand path into a polygon. |
+| `closeLassoPath` | Close a freehand path into a polygon. |
+| `lassoBounds` | Close a freehand path into a polygon. |
+| `MIN_SELECTION_SIZE` | Close a freehand path into a polygon. |
+
+## `src/core/layerOps.js`
+
+Layers: moving, merging, resolving which one a stroke lands on.
+
+| | |
+|---|---|
+| `commitStroke` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
+| `insertFill` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
+| `isDescendantOf` | True when `folderId` is `maybeChildId` itself or an ancestor of it. |
+| `mergeDown` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
+| `moveLayer` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
+| `offsetLayers` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
+| `resolveDrawLayer` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
+
+## `src/core/mediaReducer.js`
+
+The audio and video tracks, as named actions.
+
+| | |
+|---|---|
+| `clearAudio` | — |
+| `clearMedia` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `clearVideo` | — |
+| `clearVideoCuts` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `EMPTY_MEDIA` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. |
+| `loadAudio` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `loadVideo` | — |
+| `mediaReducer` | — |
+| `moveTrack` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `resizeAudio` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `restoreMedia` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `setAudioClip` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `setAudioDuration` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `setVideoCuts` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `setVideoOpacity` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+
+## `src/core/numInput.js`
+
+Typing into a number field without the value fighting the cursor.
+
+| | |
+|---|---|
+| `clampNum` | Constrain n to the range, ignoring bounds that were not given. |
+| `commitNumber` | Constrain n to the range, ignoring bounds that were not given. |
+| `liveNumber` | Constrain n to the range, ignoring bounds that were not given. |
+
+## `src/core/partOps.js`
+
+Parts: groups of cuts made from an import or a selection.
+
+| | |
+|---|---|
+| `assignPart` | Group cuts into parts, in timeline order. |
+| `derivePartsFrom` | Group cuts into parts, in timeline order. |
+| `deriveVideoBatches` | Group cuts into parts, in timeline order. |
+| `removeVideoBatch` | Group cuts into parts, in timeline order. |
+| `renamePartIn` | Group cuts into parts, in timeline order. |
+| `ungroupPartIn` | Group cuts into parts, in timeline order. |
+
+## `src/core/pathMotion.js`
+
+Turning a drawn line into something that can be moved along smoothly.
+
+| | |
+|---|---|
+| `pathLength` | Total length along a polyline. @param {{x:number,y:number}[]} pts @returns {number} |
+| `preparePath` | Even out a drawn path before storing it. Pen points bunch up where the hand slowed, so animating along raw capture data replays the drawing speed instead of the drawn shape. |
+| `resampleByLength` | Total length along a polyline. @param {{x:number,y:number}[]} pts @returns {number} */ |
+| `smoothPath` | Total length along a polyline. @param {{x:number,y:number}[]} pts @returns {number} */ |
+| `spacingRatio` | Total length along a polyline. @param {{x:number,y:number}[]} pts @returns {number} */ |
+
+## `src/core/playbackStart.js`
+
+Where playback begins when play is pressed.
+
+| | |
+|---|---|
+| `playbackStartFrom` | — |
+
+## `src/core/probeBackoff.js`
+
+How often to re-check whether the API server is up.
+
+| | |
+|---|---|
+| `nextProbeDelay` | Delay before the next probe, given how many have failed in a row. |
+| `PROBE_BASE_MS` | — |
+| `PROBE_MAX_MS` | — |
+| `PROBE_QUICK_TRIES` | — |
+
+## `src/core/projectAssets.js`
+
+How each piece of a project is stored, and how it comes back.
+
+| | |
+|---|---|
+| `audioExt` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
+| `frameLoad` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
+| `frameStorage` | Which of the three ways a frame is saved. A legacy entry with no Blob still embeds rather than being dropped. |
+| `imageExt` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
+| `imageExtFromType` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
+| `STORE_ASSET` | A frame or media item goes out as a separate binary asset alongside a small JSON. |
+| `STORE_BLOB` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
+| `STORE_DATAURL` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
+| `videoExt` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
+
+## `src/core/projectFormat.js`
+
+Reading a saved project, including ones written by older versions.
+
+| | |
+|---|---|
+| `makeLoadProgress` | Throttled progress for a load: no bar for a small project, at most a hundred repaints for a large one. |
+| `migrateCuts` | What the app should look like after opening this project, with defaults for anything absent. */ |
+| `projectSettings` | What the app should look like after opening this project, with defaults for anything absent. |
+
+## `src/core/shortcuts.js`
+
+Key bindings, and what a key event means.
+
+| | |
+|---|---|
+| `DEFAULT_KEYS` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
+| `findConflicts` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
+| `KEY_LABELS` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
+| `keyOf` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
+| `loadKeymap` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
+| `matchShortcut` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
+| `TOOL_PREFIX` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
+| `toolFromAction` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
+
+## `src/core/timeCode.js`
+
+Formatting and parsing times.
+
+| | |
+|---|---|
+| `fmt` | Seconds as mm:ss.cc, which is what the timeline shows and what parseClock reads back. |
+| `parseClock` | Seconds as mm:ss.cc, which is what the timeline shows and what parseClock reads back. */ |
+
+## `src/core/timelineZoom.js`
+
+Timeline pixels to time, and zooming without the content sliding.
+
+| | |
+|---|---|
+| `clampPps` | Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */ |
+| `pinchZoom` | Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */ |
+| `PPS_MAX` | — |
+| `PPS_MIN` | fill the screen and scrolling becomes the only way to see anything. |
+| `scrollToHold` | Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */ |
+| `timeAtX` | Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */ |
+| `TRACK_GUTTER` | Width of the sticky track-label column. Time zero is one of these in from the left edge, so every screen-x-to-time conversion needs it. Must match `.tl-track-label` in App.css. |
+| `xAtTime` | Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */ |
+| `zoomAnchored` | Zoom about a point. Returns null at the scale limits, so the caller leaves the scroll alone rather than recomputing from an unchanged scale. |
+
+## `src/canvas/canvasUtils.js`
+
+The drawing engine: strokes, canvases, animation, video frames. The big one.
+
+| | |
+|---|---|
+| `accentSoft` | That keeps on-canvas furniture such as selection outlines and paths on the theme colour. |
+| `ANIM_DEFAULT` | — |
+| `applyEase` | The easing curves. Everything animated should go through this rather than its own. |
+| `bucketFillTransparentRegion` | — |
+| `CANVAS_W` | — |
+| `computeCutAnim` | at rest (no transform), so callers can skip the save/transform fast-path. |
+| `computeLayerAnim` | — |
+| `computeTextAnim` | — |
+| `curveToWave` | The returned amp (px) is how far that curve actually swung, and is used as the default strength. |
+| `dataURLToImageData` | — |
+| `DEFAULT_CUT_DURATION` | — |
+| `detectSceneCuts` | The presets in the order they should appear, as [group, fonts] pairs. |
+| `dilateMask` | The presets in the order they should appear, as [group, fonts] pairs. |
+| `dist` | — |
+| `drawStrokesOnCtx` | — |
+| `extractVideoFrames` | The presets in the order they should appear, as [group, fonts] pairs. |
+| `fitRect` | Letterbox rect: fit source into destination preserving aspect ratio. |
+| `flattenForCanvas` | — |
+| `flattenLayersInUiOrder` | — |
+| `FONT_PRESETS` | the app with no Japanese on screen downloads no Japanese. |
+| `fontGroups` | The presets in the order they should appear, as [group, fonts] pairs. |
+| `hexToRgb` | — |
+| `imageDataToDataURL` | — |
+| `LAYER_ANIM_DEFAULT` | — |
+| `layerKey` | cross-cut collisions and an infinite cache-rebuild loop. |
+| `morphFrames` | Filled with the A->B average ink colour; soft 1px edge. |
+| `morphPrepare` | so the caller can update progress or yield to the UI between frames. |
+| `morphSequence` | frame would be N times slower. |
+| `pointInPolygon` | — |
+| `safeArray` | Anything-to-array, for fields that older projects may not have at all. |
+| `sampleKeys` | This is tweening in the original animation sense of the word. |
+| `samplePath` | Sample a polyline path at normalized position s in [0,1]. |
+| `sampleWave` | Samples the waveform cyclically over 0..1 with linear interpolation. |
+| `sizeCanvas` | Resizes only when the size differs. Assigning `canvas.width` reallocates the backing store even when the value is unchanged - 8MB at 1920x1080, and the measured 79MB/s that ran the tab out of memory. |
+| `strokeSig` | used to invalidate the layer canvas cache without stringifying the whole array. |
+| `swayWeightAt` | bend one direction while the next bends back. |
+| `targetCanvasFor` | two shapes people actually publish. |
+| `TEXT_ANIM_DEFAULT` | - emphasis: a looping accent (pulse/shake/wave) |
+| `triwave` | Triangle wave 0->1->0 (period 2); used for ping-pong path following. |
+
+## `src/canvas/textRender.js`
+
+Measuring and drawing text objects.
+
+| | |
+|---|---|
+| `clampFontSize` | A text object as the document stores it. |
+| `drawTextObject` | A text object as the document stores it. |
+| `measureTextBox` | A text object as the document stores it. |
+| `revealLines` | A text object as the document stores it. |
+| `textFontOf` | A text object as the document stores it. |
+| `textLineHeight` | A text object as the document stores it. |
+| `textNeedsBox` | A text object as the document stores it. |
+
+## `src/hooks/useTimelineGestures.js`
+
+Every way the timeline can be pointed at, in one place.
+
+| | |
+|---|---|
+| `useTimelineGestures` | — |
+
+## `server/youtubeUrl.js`
+
+Which addresses the importer will hand to yt-dlp.
+
+| | |
+|---|---|
+| `isYouTubeUrl` | Parses rather than pattern-matches, because both obvious string checks are wrong in opposite directions. |
+| `YOUTUBE_HOSTS` | Hosts yt-dlp is allowed to be pointed at. |

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bench": "node scripts/bench.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
-    "check": "npm run typecheck && npm test && node scripts/hook-baseline.mjs && npm run build",
+    "check": "npm run typecheck && npm test && node scripts/hook-baseline.mjs && node scripts/helper-index.mjs && npm run build",
     "smoke": "node test/smoke/boot.mjs"
   },
   "dependencies": {

--- a/scripts/helper-index.mjs
+++ b/scripts/helper-index.mjs
@@ -1,0 +1,72 @@
+// Keeps HELPERS.md honest.
+//
+// This exists because of a specific, repeated mistake: writing a helper that already existed.
+// `clearLiveOverlay` was reimplemented by hand in four places while the real one sat two hundred
+// lines below them, and the timeline gutter width had seven copies. Neither was carelessness so
+// much as not knowing - a four-thousand-line component does not announce what it already has.
+//
+// A document alone would not have helped, because a document nobody updates is worse than none:
+// it teaches you to distrust it, and then you stop looking. So the index is checked. Export
+// something shared and forget to list it, and this fails - the same way the hook baseline fails
+// when stale-closure risk grows.
+//
+// It checks presence, not prose. Whether the description is any good is a review question; that
+// the entry exists at all is not.
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const INDEX = 'HELPERS.md';
+// Directories whose exports are shared vocabulary. App.jsx and the ui/ components are excluded:
+// those export React components, which are found by reading the screen rather than an index.
+const DIRS = ['src/core', 'src/canvas', 'src/hooks', 'server'];
+
+/** Exported function and const names in one module. */
+function exportsOf(source) {
+    const names = new Set();
+    for (const m of source.matchAll(/^export\s+(?:async\s+)?function\s+(\w+)/gm)) names.add(m[1]);
+    for (const m of source.matchAll(/^export\s+const\s+(\w+)\s*=/gm)) names.add(m[1]);
+    return [...names];
+}
+
+const found = [];
+for (const dir of DIRS) {
+    if (!existsSync(dir)) continue;
+    for (const file of readdirSync(dir)) {
+        if (!/\.jsx?$/.test(file)) continue;
+        const path = `${dir}/${file}`;
+        for (const name of exportsOf(readFileSync(join(dir, file), 'utf8'))) {
+            found.push({ name, path });
+        }
+    }
+}
+
+if (!existsSync(INDEX)) {
+    console.error(`${INDEX} is missing. It is the index of what already exists; see scripts/helper-index.mjs.`);
+    process.exit(1);
+}
+const index = readFileSync(INDEX, 'utf8');
+
+// A name counts as indexed when it appears as `name` in a table row. Backticks rather than a bare
+// word so that a symbol mentioned in passing in a paragraph does not count as documenting it.
+const missing = found.filter(({ name }) => !index.includes(`\`${name}\``));
+
+// The other direction: an entry left behind after the thing it describes was renamed or removed,
+// which is how an index quietly becomes fiction.
+const names = new Set(found.map(f => f.name));
+const stale = [...index.matchAll(/^\| `(\w+)`/gm)].map(m => m[1]).filter(n => !names.has(n));
+
+if (missing.length || stale.length) {
+    if (missing.length) {
+        console.error(`${missing.length} shared export(s) not in ${INDEX}:`);
+        for (const { name, path } of missing) console.error(`  ${name}  (${path})`);
+    }
+    if (stale.length) {
+        console.error(`${stale.length} entr(y/ies) in ${INDEX} name something that no longer exists:`);
+        for (const n of stale) console.error(`  ${n}`);
+    }
+    console.error(`\n${INDEX} is what stops the next person reimplementing one of these. Add the row.`);
+    process.exit(1);
+}
+
+console.log(`Helper index passed - ${found.length} shared exports, all listed in ${INDEX}`);


### PR DESCRIPTION
Asked for after noticing the pattern: **three of the last few changes were the same mistake — a helper that already existed, written again.**

| what | copies |
|---|---|
| `clearLiveOverlay` | reimplemented by hand in 4 places, while the real one sat 200 lines below them |
| timeline gutter width | 7 |
| current-cut lookup | 13, under 5 different names |

None of that was carelessness. A four-thousand-line component does not announce what it already has, and grepping for a concept only works if you guess the name it was given.

## The index

`HELPERS.md` lists **all 167 shared exports**, grouped by module, each with what it is for and — where it matters — what goes wrong without it. That second part is usually the reason the helper exists:

> `sizeCanvas` — Resizes only when the size differs. Assigning `canvas.width` reallocates the backing store even when the value is unchanged: 8MB at 1920×1080, and the measured 79MB/s that ran the tab out of memory.

Descriptions are pulled from the doc comment above each export rather than invented for the index. The traps worth calling out are written by hand.

## Why it is a script and not just a file

**A document nobody updates is worse than none** — it teaches you to distrust it, and then you stop looking.

`scripts/helper-index.mjs` runs inside `npm run check` and fails in both directions: a shared export missing from the index, or a row naming something that no longer exists. Verified both ways:

```
$ node scripts/helper-index.mjs        # after adding an unlisted export
1 shared export(s) not in HELPERS.md:
  deliberatelyUnlisted  (src/core/timeCode.js)

HELPERS.md is what stops the next person reimplementing one of these. Add the row.

$ node scripts/helper-index.mjs        # after removing it
Helper index passed - 167 shared exports, all listed in HELPERS.md
```

It checks **presence, not prose**. Whether a description is any good is a review question; that the entry exists at all is not.

`ARCHITECTURE.md` and `CONTRIBUTING.md` point at it, since those are what get read first.

## Verified

- [x] `npm run check` — 371 tests, hook baseline, helper index, build, all clean
- [x] The guard confirmed failing on an unlisted export and passing once listed
