### PR TITLE
feat: clip a layer to the one below it

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -36,6 +36,15 @@ Camera moves: presets, drawn paths, and the transform they resolve to.
 | `resolveCamera` | No camera at all: the default, and what every existing project has. */ |
 | `zoomForDrift` | The smallest zoom at which a camera may sit that far off centre without the frame running off the artwork. |
 
+## `src/core/clipping.js`
+
+Clipping: a layer that only shows where the layer beneath it has paint.
+
+| | |
+|---|---|
+| `canClip` | Whether the clip toggle would do anything. False only for the bottom layer, which has nothing to clip to. |
+| `clipGroups` | Which layers clip to which base. A run of clipped layers all attach to the same base, and a clipped layer with nothing below it draws normally rather than vanishing. |
+
 ## `src/core/windowDrag.js`
 
 Running a drag on window listeners, so it survives the pointer leaving the element.
@@ -87,6 +96,7 @@ Every change the document can undergo, as named actions. Build them with these c
 | `setCutAnim` | Replace the whole document: opening a file, undo/redo, starting over. */ |
 | `setCutCamera` | Replace the whole document: opening a file, undo/redo, starting over. */ |
 | `setLayerAnim` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `setLayerClipped` | Clip a layer to the one below, or stop. No rev bump - it changes how the layer is composited, not what is drawn on it. |
 | `toggleTextVisible` | — |
 | `ungroupPart` | — |
 | `updateCut` | Replace the whole document: opening a file, undo/redo, starting over. */ |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useLayoutEffect, useMemo } from 'react';
-import { Plus, Trash2, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, ClipboardPaste, GitBranch, Move, Type, Cloud, Film, Repeat, Minus, Waves, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw, ArrowDownToLine } from 'lucide-react';
+import { Plus, Trash2, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, ClipboardPaste, GitBranch, Move, Type, Cloud, Film, Repeat, Minus, Waves, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw, ArrowDownToLine, CornerDownRight } from 'lucide-react';
 import './App.css';
 import { saveAutosave, loadAutosave, saveProject, loadProject, listProjects, deleteProject, autosaveKey } from './db';
 import { CutAnimPanel, LayerAnimPanel, JitterPanel } from './ui/AnimPanels';
@@ -44,6 +44,8 @@ import { dragOnWindow } from './core/windowDrag.js';
 // rather than of whichever layer happens to be selected.
 
 import { computeCamera, applyCamera } from './core/camera.js';
+import { clipGroups, canClip } from './core/clipping.js';
+import { setLayerClipped } from './core/cutsReducer.js';
 import { unusedBitmapIds } from './core/bitmapRefs.js';
 import { dragCut, resizeCut } from './core/cutOps.js';
 import {
@@ -3056,6 +3058,64 @@ export default function App() {
         return cnv;
     };
 
+
+    // A clipping group, flattened into one canvas.
+    //
+    // Clipping is "show only where the layer below has paint", and the way to get that from a 2D
+    // context is `destination-in`: stack the clipped layers, then keep only the pixels that
+    // overlap the base's alpha.
+    //
+    // It has to happen before the per-layer transform rather than after. A clipped layer is paint
+    // *on* the base - shading inside a shape - so it moves with the base; masking after each
+    // layer had been transformed separately would let the shadow slide out of the thing it is
+    // shading. The clipped layers' own part animations are therefore ignored, which is the same
+    // choice every drawing app makes and the reason the group is composited as a unit.
+    //
+    // Two scratch canvases and one composite pass per group, and only for groups that actually
+    // have something clipped to them - a stack with no clipping does not allocate anything.
+    const clipScratchRef = useRef(null);
+    const clipPaintRef = useRef(null);
+    const flattenClipGroup = (cutId, group) => {
+        const baseCanvas = ensureLayerCanvas(cutId, group.base);
+        if (!baseCanvas || group.clipped.length === 0) return baseCanvas;
+
+        // Every clipped layer has to be ready, or the group would flash without its shading while
+        // one frame is still decoding.
+        // A layer being dragged is drawn by the overlay with the original hidden, and a clipped
+        // one is no different - leaving it in the group would draw it twice and trail a ghost.
+        const drag = layerDragRef.current;
+        const dragging = (id) => !!drag && drag.cutId === cutId && drag.layerIds.includes(id);
+
+        const parts = [];
+        for (let k = group.clipped.length - 1; k >= 0; k--) {   // bottom-to-top within the group
+            if (dragging(group.clipped[k].id)) continue;
+            const c = ensureLayerCanvas(cutId, group.clipped[k]);
+            if (!c) return baseCanvas;
+            parts.push(c);
+        }
+        if (parts.length === 0) return baseCanvas;
+
+        const paint = clipPaintRef.current || (clipPaintRef.current = document.createElement('canvas'));
+        sizeCanvas(paint, CANVAS_W, CANVAS_H);
+        const pctx = paint.getContext('2d');
+        pctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+        pctx.globalCompositeOperation = 'source-over';
+        for (const c of parts) pctx.drawImage(c, 0, 0);
+
+        // Keep only what lands on the base.
+        pctx.globalCompositeOperation = 'destination-in';
+        pctx.drawImage(baseCanvas, 0, 0);
+        pctx.globalCompositeOperation = 'source-over';
+
+        const out = clipScratchRef.current || (clipScratchRef.current = document.createElement('canvas'));
+        sizeCanvas(out, CANVAS_W, CANVAS_H);
+        const octx = out.getContext('2d');
+        octx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+        octx.drawImage(baseCanvas, 0, 0);
+        octx.drawImage(paint, 0, 0);
+        return out;
+    };
+
     const paintFrame = useCallback((t, playing) => {
         const canvas = canvasRef.current; if (!canvas) return;
         const ctx = canvas.getContext('2d');
@@ -3134,7 +3194,11 @@ export default function App() {
         }
 
         activeCuts.forEach(ac => {
-            const order = flattenLayersInUiOrder(ac.layers || []).filter(l => l.type === 'layer' && l.visible !== false);
+            const visible = flattenLayersInUiOrder(ac.layers || []).filter(l => l.type === 'layer' && l.visible !== false);
+            // A clipped layer draws as part of the group below it rather than on its own, so the
+            // loop walks groups. With nothing clipped this is one group per layer and the code
+            // below behaves exactly as it did.
+            const order = clipGroups(visible).map(g => ({ ...g.base, __clip: g }));
             // Cut-level animation (enter/exit/deform) applies only during playback/export,
             // so editing stays at rest. Transform about the canvas centre.
             const anim = playing ? computeCutAnim(ac, t, CANVAS_W, CANVAS_H) : null;
@@ -3148,7 +3212,7 @@ export default function App() {
             // Draw bottom -> top so the topmost layer (UI top) is visually on top.
             for (let i = order.length - 1; i >= 0; i--) {
                 const l = order[i];
-                const layerCanvas = ensureLayerCanvas(ac.id, l);
+                const layerCanvas = flattenClipGroup(ac.id, l.__clip);
                 if (!layerCanvas) continue; // frame still decoding (part-scoped memory); will repaint when ready
 
                 // Per-layer ("part") transform nests inside the cut transform.
@@ -3716,6 +3780,24 @@ export default function App() {
                                 <Waves size={11} />
                             </button>
                         )}
+                        {!isFolder && (() => {
+                            // Shown even where it cannot apply, greyed out: hiding it would make
+                            // the row's controls shift position as layers are reordered, which is
+                            // worse than a disabled button.
+                            const clippable = canClip(flattenLayersInUiOrder(cut.layers || []).filter(l => l.type === 'layer'), layer.id);
+                            return (
+                                <button className="icon-btn" disabled={!clippable && !layer.clipped}
+                                    style={{ color: layer.clipped ? 'var(--accent-pale)' : undefined, opacity: (clippable || layer.clipped) ? 1 : 0.3 }}
+                                    title={layer.clipped
+                                        ? tr('클리핑 해제 (지금은 아래 레이어가 그려진 곳에만 보입니다)')
+                                        : clippable
+                                            ? tr('아래 레이어에 클리핑 — 아래 레이어가 그려진 곳에만 보이게 합니다')
+                                            : tr('맨 아래 레이어는 클리핑할 대상이 없습니다')}
+                                    onClick={e => { e.stopPropagation(); dispatchCuts(setLayerClipped(cut.id, layer.id, !layer.clipped)); }}>
+                                    <CornerDownRight size={11} />
+                                </button>
+                            );
+                        })()}
                         {!isFolder && (
                             <button className="icon-btn" title={tr('아래 레이어와 병합')}
                                 onClick={e => { e.stopPropagation(); dispatchCuts(mergeLayerDown(cut.id, layer.id, flattenLayersInUiOrder)); }}>

--- a/src/core/clipping.js
+++ b/src/core/clipping.js
@@ -1,0 +1,59 @@
+// Clipping: a layer that only shows where the layer beneath it has paint.
+//
+// The everyday use is shading. Draw the flat colours on one layer, clip a shadow layer to it, and
+// the shadow cannot escape the shape no matter how carelessly it is brushed. Every drawing app
+// has this and it is the main reason to have layers at all.
+//
+// Two rules decide what clips to what, and both come from how people actually stack them:
+//
+//   - a run of clipped layers all attach to the same base, the first unclipped layer below them,
+//     so shadow + highlight + line-tint over one set of flats behaves as one group
+//   - a clipped layer with nothing below it draws normally
+//
+// That second rule is a choice. Clipping to nothing is, strictly, clipping to an empty shape,
+// which would make the layer vanish - and a layer that disappears when it reaches the bottom of
+// the stack looks like a bug, not like a rule. Drawing it is the answer that can be understood
+// without reading this file.
+//
+// The grouping is here, on its own, because the compositing it feeds is the part of the renderer
+// where per-layer animation, sway and masking already interleave. Working out *what* clips to
+// *what* should not have to happen in there.
+
+/**
+ * Split layers into the groups the renderer composites.
+ *
+ * @param {{id: any, clipped?: boolean}[]} order layers in UI order, topmost first - the same order
+ *   flattenLayersInUiOrder produces
+ * @returns {{base: any, clipped: any[]}[]} groups in UI order, topmost first. `clipped` is in UI
+ *   order too, so a caller drawing bottom-to-top walks it backwards, exactly as it does `order`.
+ */
+export function clipGroups(order) {
+    const groups = [];
+    const list = Array.isArray(order) ? order : [];
+
+    // Walking upwards, because a clipped layer's base is below it: reverse, collect, reverse back.
+    for (let i = list.length - 1; i >= 0; i--) {
+        const layer = list[i];
+        const attaches = layer?.clipped && groups.length > 0;
+        if (attaches) groups[groups.length - 1].clipped.unshift(layer);
+        else groups.push({ base: layer, clipped: [] });
+    }
+
+    return groups.reverse();
+}
+
+/**
+ * Whether this layer's clip toggle would do anything.
+ *
+ * The bottom layer has nothing to clip to, so the control is shown but inert - hiding it instead
+ * would make the row jump around as layers are reordered.
+ *
+ * @param {{id: any}[]} order layers in UI order, topmost first
+ * @param {any} layerId
+ * @returns {boolean}
+ */
+export function canClip(order, layerId) {
+    const list = Array.isArray(order) ? order : [];
+    const i = list.findIndex(l => l?.id === layerId);
+    return i >= 0 && i < list.length - 1;
+}

--- a/src/core/cutsReducer.js
+++ b/src/core/cutsReducer.js
@@ -45,6 +45,14 @@ export const clearCut = (cutId) => ({ type: 'clearCut', cutId });
 
 /** Change fields on one layer. */
 export const updateLayer = (cutId, layerId, patch) => ({ type: 'updateLayer', cutId, layerId, patch });
+/**
+ * Clip a layer to the one below it, or stop clipping.
+ *
+ * No rev bump: clipping changes how the layer is composited, not what is drawn on it, so its own
+ * cached canvas is still correct. What has to be invalidated is the frame, and paintFrame already
+ * re-runs when cuts change.
+ */
+export const setLayerClipped = (cutId, layerId, clipped) => ({ type: 'setLayerClipped', cutId, layerId, clipped });
 /** Merge into a layer's animation, over the defaults. */
 export const setLayerAnim = (cutId, layerId, patch) => ({ type: 'setLayerAnim', cutId, layerId, patch });
 /** Flatten a layer into the one below it. */
@@ -120,6 +128,11 @@ export function cutsReducer(cuts, action) {
 
         case 'updateLayer':
             return mapCut(list, action.cutId, c => mapLayer(c, action.layerId, l => ({ ...l, ...action.patch })));
+        case 'setLayerClipped':
+            return mapCut(list, action.cutId, c => ({
+                ...c,
+                layers: c.layers.map(l => (l.id === action.layerId ? { ...l, clipped: !!action.clipped } : l)),
+            }));
         case 'setLayerAnim':
             return mapCut(list, action.cutId, c => mapLayer(c, action.layerId,
                 l => ({ ...l, anim: { ...LAYER_ANIM_DEFAULT, ...l.anim, ...action.patch } })));

--- a/test/clipping.test.js
+++ b/test/clipping.test.js
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { clipGroups, canClip } from '../src/core/clipping.js';
+
+/** Layers in UI order, topmost first. A trailing `*` marks one as clipped. */
+const layers = (...spec) => spec.map(s => ({ id: s.replace('*', ''), clipped: s.endsWith('*') }));
+const shape = (groups) => groups.map(g => `${g.base.id}<${g.clipped.map(c => c.id).join(',')}`);
+
+test('nothing clipped means one group per layer, in the same order', () => {
+    assert.deepEqual(shape(clipGroups(layers('a', 'b', 'c'))), ['a<', 'b<', 'c<']);
+});
+
+test('a clipped layer attaches to the layer below it', () => {
+    // b is below a in UI order, so a clipped to b is the everyday case: shading over flats.
+    assert.deepEqual(shape(clipGroups(layers('a*', 'b', 'c'))), ['b<a', 'c<']);
+});
+
+test('a run of clipped layers all attach to the same base', () => {
+    // Shadow, highlight and line-tint over one set of flats behave as one group, rather than
+    // each clipping to the one beneath it.
+    assert.deepEqual(shape(clipGroups(layers('a*', 'b*', 'c*', 'd', 'e'))), ['d<a,b,c', 'e<']);
+});
+
+test('the clipped list stays in UI order, so a caller can walk it the same way', () => {
+    const [group] = clipGroups(layers('top*', 'mid*', 'base'));
+    assert.deepEqual(group.clipped.map(l => l.id), ['top', 'mid']);
+    assert.equal(group.base.id, 'base');
+});
+
+test('an unclipped layer ends the run', () => {
+    assert.deepEqual(shape(clipGroups(layers('a*', 'b', 'c*', 'd'))), ['b<a', 'd<c']);
+});
+
+test('a clipped layer at the very bottom draws normally', () => {
+    // Clipping to nothing is clipping to an empty shape, which would make it vanish. A layer that
+    // disappears on reaching the bottom of the stack reads as a bug, not as a rule.
+    assert.deepEqual(shape(clipGroups(layers('a', 'b*'))), ['a<', 'b<']);
+    assert.deepEqual(shape(clipGroups(layers('a*'))), ['a<']);
+});
+
+test('every layer appears exactly once, whatever the arrangement', () => {
+    // The property that matters for the renderer: grouping must not drop or duplicate a layer.
+    for (const spec of [
+        ['a', 'b', 'c'], ['a*', 'b*', 'c*'], ['a*', 'b', 'c*'], ['a', 'b*', 'c'],
+        ['a*', 'b', 'c', 'd*', 'e*'], ['a'], [],
+    ]) {
+        const order = layers(...spec);
+        const seen = clipGroups(order).flatMap(g => [g.base, ...g.clipped]).map(l => l.id);
+        assert.deepEqual(seen.slice().sort(), order.map(l => l.id).sort(), spec.join(' '));
+        assert.equal(seen.length, new Set(seen).size, `duplicate in ${spec.join(' ')}`);
+    }
+});
+
+test('groups come back in UI order, topmost first', () => {
+    // The renderer walks them backwards to draw bottom-to-top, the same as it walks the layers.
+    assert.deepEqual(shape(clipGroups(layers('a', 'b*', 'c', 'd'))), ['a<', 'c<b', 'd<']);
+});
+
+test('junk in does not throw', () => {
+    assert.deepEqual(clipGroups(null), []);
+    assert.deepEqual(clipGroups(undefined), []);
+    assert.deepEqual(clipGroups([]), []);
+});
+
+test('canClip: everything except the bottom layer', () => {
+    const order = layers('a', 'b', 'c');
+    assert.equal(canClip(order, 'a'), true);
+    assert.equal(canClip(order, 'b'), true);
+    assert.equal(canClip(order, 'c'), false);
+    assert.equal(canClip(order, 'nope'), false);
+    assert.equal(canClip([], 'a'), false);
+});

--- a/test/clipping.test.js
+++ b/test/clipping.test.js
@@ -2,8 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { clipGroups, canClip } from '../src/core/clipping.js';
 
-/** Layers in UI order, topmost first. A trailing `*` marks one as clipped. */
-const layers = (...spec) => spec.map(s => ({ id: s.replace('*', ''), clipped: s.endsWith('*') }));
+/**
+ * Layers in UI order, topmost first. A trailing `*` marks one as clipped.
+ *
+ * Anchored to the end rather than a bare replace, which removes the first `*` wherever it sits
+ * and would quietly mangle an id that contained one. CodeQL flags the bare form as incomplete
+ * sanitization, and it is right that the anchored version is what was meant.
+ */
+const layers = (...spec) => spec.map(s => ({ id: s.replace(/\*$/, ''), clipped: s.endsWith('*') }));
 const shape = (groups) => groups.map(g => `${g.base.id}<${g.clipped.map(c => c.id).join(',')}`);
 
 test('nothing clipped means one group per layer, in the same order', () => {

--- a/test/cutsReducer.test.js
+++ b/test/cutsReducer.test.js
@@ -13,6 +13,7 @@ import {
     assignPartTo, renamePart, ungroupPart, removeBatch,
     insertCutsShifting, deleteTrack, moveCutGroup, replaceBatchCuts,
     patchCut, patchCuts, setCutCamera,
+    setLayerClipped,
 } from '../src/core/cutsReducer.js';
 
 const layer = (id, extra = {}) => ({ id, type: 'layer', parentId: null, visible: true, strokes: [], ...extra });
@@ -282,4 +283,24 @@ test('setCutCamera: leaves other cuts alone', () => {
     const s = cutsReducer([cut(1), cut(2)], setCutCamera(2, { preset: 'panLeft' }));
     assert.equal(s[0].camera, undefined);
     assert.equal(s[1].camera.preset, 'panLeft');
+});
+
+test('setLayerClipped: turns clipping on and off', () => {
+    let s = cutsReducer([cut(1)], setLayerClipped(1, 'L1', true));
+    assert.equal(s[0].layers[0].clipped, true);
+    s = cutsReducer(s, setLayerClipped(1, 'L1', false));
+    assert.equal(s[0].layers[0].clipped, false);
+});
+
+test('setLayerClipped: coerces, so a stray value cannot make clipped truthy-but-odd', () => {
+    const s = cutsReducer([cut(1)], setLayerClipped(1, 'L1', undefined));
+    assert.equal(s[0].layers[0].clipped, false);
+});
+
+test('setLayerClipped: leaves other layers and other cuts alone', () => {
+    const doc2 = [cut(1, { layers: [layer('L1'), layer('L2')] }), cut(2)];
+    const s = cutsReducer(doc2, setLayerClipped(1, 'L2', true));
+    assert.equal(s[0].layers[0].clipped, undefined);
+    assert.equal(s[0].layers[1].clipped, true);
+    assert.equal(s[1].layers[0].clipped, undefined);
 });


### PR DESCRIPTION
Closes #22. The merge half landed earlier; this is the clipping half, deferred at the time because it has to happen inside the compositing loop where per-layer animation, sway and masking already interleave.

The everyday use is shading: flats on one layer, a shadow clipped to it, and **the shadow cannot escape the shape** however carelessly it is brushed.

## What clips to what

Two rules, both from how people actually stack layers:

- **A run of clipped layers all attach to the same base.** Shadow, highlight and line-tint over one set of flats behave as one group, rather than each clipping to the one beneath it.
- **A clipped layer with nothing below it draws normally.** Clipping to nothing is clipping to an empty shape, and a layer that vanishes on reaching the bottom of the stack reads as a bug rather than as a rule.

That grouping is pure, and lives in `core/clipping.js` with 10 tests — including the property the renderer depends on: **every layer appears in exactly one group, whatever the arrangement.**

## The compositing decision worth recording

`destination-in`: stack the clipped layers, keep only what overlaps the base's alpha, draw the base and then that.

It happens **before** the per-layer transform rather than after. A clipped layer is paint *on* the base, so it moves with the base — masking after each layer had been transformed separately would let a shadow slide out of the thing it is shading. The clipped layers' own part animations are therefore ignored, which is what every drawing app does and the reason a group composites as a unit.

Two details that came out of this file's history:

- Nothing is allocated for a stack with no clipping.
- The two scratch canvases are reused through `sizeCanvas` — reassigning `canvas.width` reallocates 8MB even when the value is unchanged, which is how this file ran a tab out of memory once already.
- A clipped layer **being dragged** is left out of its group, or it would be drawn twice (group + drag overlay) and trail a ghost.

## The control

On the layer row, next to merge-down. Shown **greyed out** on the bottom layer rather than hidden, so the controls do not shift position as layers are reordered.

## Verified

- [x] `npm run check` — 384 tests, typecheck and build clean
- [x] Boot smoke passes against the built bundle

## Worth trying

1. Two layers. Draw a filled shape on the lower one, scribble on the upper one, press the clip button (⤷) on the upper — the scribble should be trimmed to the shape.
2. Clip **two** layers to one base; both should trim to the same shape, not to each other.
3. Clip the bottom layer — the button should be greyed out and do nothing.
4. Hide the base layer; the clipped layers should go with it.
5. A stack with nothing clipped should look **exactly** as it did.
