### PR TITLE
fix: the service worker served last week's app forever

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -20,6 +20,11 @@
  *
  * CACHE_NAME must be bumped whenever this file's behaviour changes, so the activate handler
  * clears what the old rules cached.
+ *
+ * There is deliberately no message handler. An earlier draft had one so a page could tell a
+ * waiting worker to take over, but nothing ever sent that message - and CodeQL was right to flag
+ * a postMessage listener with no origin check. install already calls skipWaiting, so an update
+ * takes over on the next load without being asked.
  */
 
 const CACHE_NAME = 'mv-maker-cache-v2';
@@ -105,10 +110,4 @@ self.addEventListener('fetch', (event) => {
             return new Response('Offline', { status: 503, headers: { 'Content-Type': 'text/plain' } });
         }
     })());
-});
-
-// Lets the page tell a waiting worker to take over immediately, rather than the user having to
-// close every tab before an update lands.
-self.addEventListener('message', (event) => {
-    if (event.data === 'skip-waiting') self.skipWaiting();
 });

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,49 +1,114 @@
-/* Minimal SW for installability + basic offline caching. */
-const CACHE_NAME = 'mv-maker-cache-v1';
+/* Service worker: installable, works offline, and does not serve last week's app.
+ *
+ * The previous version was cache-first for everything, with a cache name that never changed. That
+ * combination means a browser which has visited once never sees a new deployment again: the
+ * cached index.html is returned before the network is consulted, it names the bundle hash from
+ * the day it was cached, and that bundle is in the cache too. The activate handler does delete
+ * caches whose name differs from the current one - but the name was a constant, so nothing was
+ * ever deleted. A feature could ship, deploy green, and simply not be there.
+ *
+ * What makes this safe to get wrong twice is that everything looks fine from the outside. The
+ * deployment succeeds, the commit is right, and the bug lives entirely in the visitor's browser.
+ *
+ * The fix is to split by what the URL promises:
+ *
+ *   /assets/*   content-hashed by Vite, so the name changes whenever the bytes do. Cache-first
+ *               is not just safe here, it is the point - these can be kept forever.
+ *   everything  network-first, cache as a fallback. index.html has a fixed name and changing
+ *   else       contents, which is exactly the case cache-first cannot serve.
+ *   /api/*      never touched; it must reach the live server.
+ *
+ * CACHE_NAME must be bumped whenever this file's behaviour changes, so the activate handler
+ * clears what the old rules cached.
+ */
+
+const CACHE_NAME = 'mv-maker-cache-v2';
+
+// The app shell, so a cold offline start has something to open.
+const SHELL = ['/', '/index.html', '/manifest.webmanifest', '/icon.svg'];
+
+/**
+ * How a request should be served. Split out and named so the rule can be read - and tested -
+ * without a browser.
+ *
+ * @param {string} pathname
+ * @param {string} [mode] the request's `mode`; navigations must never come from cache first
+ * @returns {'bypass' | 'cache-first' | 'network-first'}
+ */
+function cacheStrategy(pathname, mode) {
+    // The project-storage API is live data. Serving a cached project list would be worse than
+    // failing, because it looks like the server answered.
+    if (pathname.startsWith('/api')) return 'bypass';
+    // Typing a URL or reloading. Always the network first, or a reload can never recover.
+    if (mode === 'navigate') return 'network-first';
+    // Vite writes a content hash into these names, so a given URL's bytes never change.
+    if (pathname.startsWith('/assets/')) return 'cache-first';
+    return 'network-first';
+}
 
 self.addEventListener('install', (event) => {
-  event.waitUntil((async () => {
-    const cache = await caches.open(CACHE_NAME);
-    await cache.addAll([
-      '/',
-      '/index.html',
-      '/manifest.webmanifest',
-      '/icon.svg',
-    ]);
-    self.skipWaiting();
-  })());
+    event.waitUntil((async () => {
+        const cache = await caches.open(CACHE_NAME);
+        // Individually, so one missing file does not fail the whole install the way addAll does.
+        await Promise.all(SHELL.map(u => cache.add(u).catch(() => { })));
+        self.skipWaiting();
+    })());
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil((async () => {
-    const keys = await caches.keys();
-    await Promise.all(keys.map((k) => (k === CACHE_NAME ? Promise.resolve() : caches.delete(k))));
-    self.clients.claim();
-  })());
+    event.waitUntil((async () => {
+        const keys = await caches.keys();
+        await Promise.all(keys.map(k => (k === CACHE_NAME ? Promise.resolve() : caches.delete(k))));
+        await self.clients.claim();
+    })());
 });
 
 self.addEventListener('fetch', (event) => {
-  const req = event.request;
-  if (req.method !== 'GET') return;
-  const url = new URL(req.url);
-  if (url.origin !== self.location.origin) return;
-  // Never cache the project-storage API — it must always hit the live server.
-  if (url.pathname.startsWith('/api')) return;
+    const req = event.request;
+    if (req.method !== 'GET') return;
 
-  event.respondWith((async () => {
-    const cache = await caches.open(CACHE_NAME);
-    const cached = await cache.match(req, { ignoreSearch: true });
-    if (cached) return cached;
-    try {
-      const res = await fetch(req);
-      // Cache successful same-origin GETs for offline.
-      if (res && res.ok) cache.put(req, res.clone());
-      return res;
-    } catch {
-      // Fallback to app shell.
-      const shell = await cache.match('/index.html');
-      return shell || new Response('Offline', { status: 503, headers: { 'Content-Type': 'text/plain' } });
+    const url = new URL(req.url);
+    if (url.origin !== self.location.origin) return;
+
+    const strategy = cacheStrategy(url.pathname, req.mode);
+    if (strategy === 'bypass') return;
+
+    if (strategy === 'cache-first') {
+        event.respondWith((async () => {
+            const cache = await caches.open(CACHE_NAME);
+            const hit = await cache.match(req);
+            if (hit) return hit;
+            const res = await fetch(req);
+            if (res && res.ok) cache.put(req, res.clone());
+            return res;
+        })());
+        return;
     }
-  })());
+
+    // Network first: what is on the server wins, and the cache is only what to fall back on when
+    // there is no server to ask.
+    event.respondWith((async () => {
+        const cache = await caches.open(CACHE_NAME);
+        try {
+            const res = await fetch(req);
+            if (res && res.ok) cache.put(req, res.clone());
+            return res;
+        } catch {
+            const hit = await cache.match(req, { ignoreSearch: true });
+            if (hit) return hit;
+            // A navigation with nothing cached for that exact URL still gets the app shell, so
+            // deep links work offline.
+            if (req.mode === 'navigate') {
+                const shell = await cache.match('/index.html');
+                if (shell) return shell;
+            }
+            return new Response('Offline', { status: 503, headers: { 'Content-Type': 'text/plain' } });
+        }
+    })());
 });
 
+// Lets the page tell a waiting worker to take over immediately, rather than the user having to
+// close every tab before an update lands.
+self.addEventListener('message', (event) => {
+    if (event.data === 'skip-waiting') self.skipWaiting();
+});

--- a/test/serviceWorker.test.js
+++ b/test/serviceWorker.test.js
@@ -1,0 +1,94 @@
+// The service worker's caching rule, tested without a browser.
+//
+// Worth testing because getting it wrong is invisible from every angle that is normally checked:
+// the build passes, the deployment is green, the commit is right, and the app is still last
+// week's - the bug lives entirely in a visitor's browser. It shipped that way once.
+//
+// sw.js is a classic worker script rather than a module, so it cannot be imported. It is read and
+// run in a sandbox with a fake `self`, which also checks that the file parses and that its
+// listeners register.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+function loadWorker() {
+    const listeners = {};
+    const sandbox = {
+        self: {
+            addEventListener: (type, fn) => { listeners[type] = fn; },
+            location: { origin: 'https://example.test' },
+            skipWaiting: () => { },
+            clients: { claim: async () => { } },
+        },
+        caches: { open: async () => ({}), keys: async () => [], delete: async () => true },
+        fetch: async () => ({ ok: true, clone: () => ({}) }),
+        URL,
+        Response: class { },
+        Promise,
+    };
+    sandbox.globalThis = sandbox;
+    vm.createContext(sandbox);
+    vm.runInContext(readFileSync('public/sw.js', 'utf8'), sandbox);
+    return { listeners, strategy: vm.runInContext('cacheStrategy', sandbox), sandbox };
+}
+
+test('the worker parses and registers the handlers it needs', () => {
+    const { listeners } = loadWorker();
+    for (const type of ['install', 'activate', 'fetch']) {
+        assert.equal(typeof listeners[type], 'function', `no ${type} handler`);
+    }
+});
+
+test('a navigation always asks the network first', () => {
+    // The regression that shipped: a cached index.html was served ahead of the network, so it
+    // kept naming the bundle hash from the day it was cached and the app never updated.
+    const { strategy } = loadWorker();
+    assert.equal(strategy('/', 'navigate'), 'network-first');
+    assert.equal(strategy('/index.html', 'navigate'), 'network-first');
+    assert.equal(strategy('/anything/deep', 'navigate'), 'network-first');
+});
+
+test('index.html is network-first even when it is not a navigation', () => {
+    const { strategy } = loadWorker();
+    assert.equal(strategy('/index.html', 'no-cors'), 'network-first');
+    assert.equal(strategy('/', undefined), 'network-first');
+});
+
+test('content-hashed assets are cache-first, because their names change with their bytes', () => {
+    const { strategy } = loadWorker();
+    assert.equal(strategy('/assets/index-C4SQoZ_1.js', 'no-cors'), 'cache-first');
+    assert.equal(strategy('/assets/index-abc123.css', 'no-cors'), 'cache-first');
+});
+
+test('the API is never served from cache', () => {
+    // A stale project list is worse than an error, because it looks like the server answered.
+    const { strategy } = loadWorker();
+    assert.equal(strategy('/api/projects', 'cors'), 'bypass');
+    assert.equal(strategy('/api/projects/p_1/asset/x', 'cors'), 'bypass');
+    assert.equal(strategy('/api/youtube-audio', 'cors'), 'bypass');
+});
+
+test('an /assets navigation is still a navigation', () => {
+    // Ordering inside the rule: if the hashed-asset check came first, a navigation to an asset
+    // path would be served from cache and could not be reloaded out of a bad state.
+    const { strategy } = loadWorker();
+    assert.equal(strategy('/assets/index-abc.js', 'navigate'), 'network-first');
+});
+
+test('everything else falls back to network-first', () => {
+    const { strategy } = loadWorker();
+    for (const p of ['/manifest.webmanifest', '/icon.svg', '/sw.js', '/favicon.ico']) {
+        assert.equal(strategy(p, 'no-cors'), 'network-first', p);
+    }
+});
+
+test('the cache name is not the one whose entries have to be thrown away', () => {
+    // activate deletes every cache except CACHE_NAME, so the name has to change when the rules
+    // do - otherwise nothing written under the old rules is ever removed.
+    const src = readFileSync('public/sw.js', 'utf8');
+    const m = src.match(/const CACHE_NAME = '([^']+)'/);
+    assert.ok(m, 'CACHE_NAME not found');
+    assert.notEqual(m[1], 'mv-maker-cache-v1', 'still the name whose cache-first entries must go');
+});


### PR DESCRIPTION
Reported as the camera feature being absent from the deployed site. **I said it was somewhere other than where they were looking. It was not.** This is why.

## What was wrong

`public/sw.js` was **cache-first for every request**, with a cache name that **never changed**.

Those two together mean a browser that has visited once never sees a new deployment again:

1. The cached `index.html` is returned before the network is consulted.
2. It names the bundle hash from the day it was cached.
3. That bundle is in the cache too.

The `activate` handler *does* delete caches whose name differs from the current one — but the name was a constant, so nothing was ever deleted.

A feature could ship, deploy green, and simply not be there. **Nothing visible from the outside is wrong**: the build passes, the deployment succeeds, the commit is right, and the bug lives entirely in the visitor's browser. That is what let it stand.

## The rule now

Split by what the URL promises:

| | | |
|---|---|---|
| `/assets/*` | cache-first | Content-hashed by Vite — the name changes whenever the bytes do, so caching forever is the *point*, not a risk |
| navigations | network-first | Or a reload cannot recover from a bad state |
| everything else | network-first | `index.html` is a fixed name with changing contents — exactly what cache-first cannot serve |
| `/api/*` | untouched | A stale project list is worse than an error; it looks like the server answered |

`CACHE_NAME` is bumped, which is what makes the existing `activate` handler clear what the old rules cached. **Existing installs recover on their next visit** — no manual cache clearing.

## Tests

8 of them. `sw.js` is a classic worker script and cannot be imported, so they read it and run it in a `node:vm` sandbox with a fake `self` — which also checks that it parses and registers its handlers.

Worth testing precisely because the rule being wrong is invisible to every check that normally runs. One test asserts the ordering trap directly:

```js
// if the hashed-asset check came first, a navigation to an asset path
// would be served from cache and could not be reloaded out of a bad state
assert.equal(strategy('/assets/index-abc.js', 'navigate'), 'network-first');
```

And one guards the thing that made it permanent:

```js
assert.notEqual(m[1], 'mv-maker-cache-v1', 'still the name whose cache-first entries must go');
```

## Verified

- [x] `npm run check` — 379 tests, typecheck, hook baseline, helper index, build all clean

## Worth trying

After this deploys: open the site, **reload once**, and the camera should appear under a cut's ⚙. If it still does not, that is a different bug and I want to know.
