### PR TITLE
ci: group the rest of the peer-dependent packages for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,17 @@ updates:
       # run: react-dom 19 against react 18, and @capacitor/android 8 against @capacitor/core 7.
       # Both were correctly rejected by CI, but they were never mergeable, and reviewing a broken
       # pull request costs the same as reviewing a real one.
+      # The react group has to include what peers on react, not just react itself. Grouping
+      # react + react-dom was not enough: bumping them to 19 produced a pull request that could
+      # not install, because lucide-react 0.x peers at react <=18. Anything that declares a react
+      # peer belongs here.
       react:
-        patterns: ['react', 'react-dom', '@types/react*']
+        patterns: ['react', 'react-dom', '@types/react*', 'lucide-react']
       capacitor:
         patterns: ['@capacitor/*']
+      # Same shape again: @vitejs/plugin-react 6 requires vite 7, so on its own it is unmergeable.
+      vite:
+        patterns: ['vite', '@vitejs/*', 'vite-plugin-*']
     commit-message:
       prefix: 'chore(deps)'
 


### PR DESCRIPTION
Two more unmergeable Dependabot PRs, both the same shape as the pair fixed last time: **half of a peer-bound set, bumped on its own.**

| PR | why it cannot install |
|---|---|
| #47 react + react-dom → 19 | `lucide-react@0.368` peers at react ≤18, and sits in its own PR (#48) |
| #50 @vitejs/plugin-react → 6 | requires vite 7; vite was not offered alongside it |

Grouping react with react-dom was not enough — **the group has to include what peers on react, not just react itself.** `lucide-react` joins it, and vite gets a group of its own.

CI rejected both, which is the system working. But they were never mergeable, and reviewing a broken PR costs the same as reviewing a real one.

## What happens to the two

- **#47** should become mergeable once #48 (lucide-react 1.x, green) lands — 1.x supports react 19. Rebasing it after that rather than closing it.
- **#50** stays closed until Dependabot offers vite and the plugin together, which this grouping makes it do.

## Verified

- [x] `dependabot.yml` parses