### PR TITLE
perf: stop allocating a full-size canvas per frame to mask a layer

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -293,6 +293,7 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `FONT_PRESETS` | the app with no Japanese on screen downloads no Japanese. |
 | `fontGroups` | The presets in the order they should appear, as [group, fonts] pairs. |
 | `hexToRgb` | — |
+| `imageDataCanvas` | A canvas holding an ImageData, ready to draw. `putImageData` ignores the transform, composite mode and alpha, so anything that scales or blends ImageData needs this. Reused - valid until the next call. |
 | `imageDataToDataURL` | — |
 | `LAYER_ANIM_DEFAULT` | — |
 | `layerKey` | cross-cut collisions and an infinite cache-rebuild loop. |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,7 @@ import {
     layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas,
     flattenForCanvas, flattenLayersInUiOrder, strokeSig, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, swayWeightAt, morphPrepare,
     accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
-    targetCanvasFor,
+    targetCanvasFor, imageDataCanvas,
 } from './canvas/canvasUtils';
 
 const PEN_TYPES = [
@@ -407,6 +407,8 @@ export default function App() {
     const currentTimeRef = useRef(0);       // playback clock read by the rAF loop (avoids stale closure)
     const playheadRef = useRef(null);        // moved imperatively during playback
     const seekRef = useRef(null);            // pending seek the playback loop applies (scrub while playing)
+    // Reused inside the composite loop; see the mask path in paintFrame.
+    const maskScratchRef = useRef(null);
     const dataUrlCacheRef = useRef(new Map()); // id -> {imageData, url}; avoids re-encoding bitmaps each autosave
     const liveRef = useRef({}); // latest {cuts, copiedCut, selection} for safe bitmap GC from effects
     const selectionDragRef = useRef(null);
@@ -3309,25 +3311,21 @@ export default function App() {
                 } else {
                     const mx = Math.round(selection.x);
                     const my = Math.round(selection.y);
-                    const tmp = document.createElement('canvas');
-                    tmp.width = CANVAS_W;
-                    tmp.height = CANVAS_H;
+                    // Reused rather than allocated. This runs inside the composite loop, so a
+                    // fresh canvas here is 8MB per masked layer per frame - sixty times a second
+                    // while playing, which is the shape of allocation that took a tab out once.
+                    const tmp = maskScratchRef.current || (maskScratchRef.current = document.createElement('canvas'));
                     const tctx = tmp.getContext('2d');
+                    if (!sizeCanvas(tmp, CANVAS_W, CANVAS_H)) tctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+                    tctx.setTransform(1, 0, 0, 1, 0, 0);
+                    tctx.globalAlpha = 1.0;
+                    tctx.globalCompositeOperation = 'source-over';
                     tctx.drawImage(layerCanvas, 0, 0);
                     tctx.globalCompositeOperation = 'destination-out';
-                    tctx.globalAlpha = 1.0;
-                    if (mb) {
-                        tctx.drawImage(mb, mx, my);
-                    } else {
-                        const mtmp = document.createElement('canvas');
-                        mtmp.width = mi.width;
-                        mtmp.height = mi.height;
-                        const mctx = mtmp.getContext('2d');
-                        mctx.putImageData(mi, 0, 0);
-                        tctx.drawImage(mtmp, mx, my);
-                    }
+                    // imageDataCanvas is a different shared canvas from this one, so nesting them
+                    // is safe - which is why they are separate helpers rather than slots of one.
+                    tctx.drawImage(mb || imageDataCanvas(mi), mx, my);
                     tctx.globalCompositeOperation = 'source-over';
-                    tctx.globalAlpha = 1.0;
                     ctx.drawImage(tmp, 0, 0);
                 }
                 ctx.restore();
@@ -3396,16 +3394,8 @@ export default function App() {
             const tw = Math.max(1, Math.round(selection.tw));
             const th = Math.max(1, Math.round(selection.th));
 
-            if (bmp) {
-                ctx.drawImage(bmp, tx, ty, tw, th);
-            } else if (img) {
-                const tmp = document.createElement('canvas');
-                tmp.width = img.width;
-                tmp.height = img.height;
-                const tctx = tmp.getContext('2d');
-                tctx.putImageData(img, 0, 0);
-                ctx.drawImage(tmp, tx, ty, tw, th);
-            }
+            if (bmp) ctx.drawImage(bmp, tx, ty, tw, th);
+            else if (img) ctx.drawImage(imageDataCanvas(img), tx, ty, tw, th);
 
             ctx.save();
             ctx.strokeStyle = accentSoft();

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -586,6 +586,37 @@ export function sizeCanvas(cnv, w, h) {
     return true;
 }
 
+// Drawing an ImageData somewhere other than where it starts.
+//
+// putImageData ignores the transform, the composite mode and the alpha - it writes pixels at
+// literal coordinates - so anything that needs to scale, blend or place ImageData has to go
+// through a canvas first. That is four lines, and it appeared four times.
+//
+// The canvas is reused. Each of those sites ran per stroke or per frame, and one of them is a
+// full video frame: allocating a canvas per call is the same trap sizeCanvas exists for.
+//
+// The contract is that the result is used immediately. It is valid until the next call, which is
+// enough for "put it in a canvas, draw it, done" and is what all four sites do. Holding one
+// across another call would hand you somebody else's pixels.
+let _imgCanvas = null;
+
+/**
+ * A canvas holding this ImageData, ready to be drawn.
+ *
+ * @param {ImageData} img
+ * @returns {HTMLCanvasElement} valid until the next call
+ */
+export function imageDataCanvas(img) {
+    if (!_imgCanvas) _imgCanvas = document.createElement('canvas');
+    sizeCanvas(_imgCanvas, img.width, img.height);
+    const cx = _imgCanvas.getContext('2d');
+    cx.setTransform(1, 0, 0, 1, 0, 0);
+    cx.globalAlpha = 1;
+    cx.globalCompositeOperation = 'source-over';
+    cx.putImageData(img, 0, 0);
+    return _imgCanvas;
+}
+
 // One scratch canvas, reused. Marker and pencil each need a full-size temporary layer to
 // composite through, and creating one per stroke meant a fresh 8MB allocation per stroke on every
 // repaint - with boiling redrawing ten times a second, that is gigabytes a second for a layer
@@ -648,13 +679,7 @@ export function drawStrokesOnCtx(ctx, strokes, clear = true, bitmapStore = null,
             if (bmp) {
                 ctx.drawImage(bmp, s.x, s.y);
             } else if (img || legacyImg) {
-                const src = img || legacyImg;
-                const tmp = document.createElement('canvas');
-                tmp.width = src.width;
-                tmp.height = src.height;
-                const tctx = tmp.getContext('2d');
-                tctx.putImageData(src, 0, 0);
-                ctx.drawImage(tmp, s.x, s.y);
+                ctx.drawImage(imageDataCanvas(img || legacyImg), s.x, s.y);
             }
             ctx.globalCompositeOperation = 'source-over';
             ctx.globalAlpha = 1.0;
@@ -670,12 +695,7 @@ export function drawStrokesOnCtx(ctx, strokes, clear = true, bitmapStore = null,
                 else ctx.drawImage(bmp, s.x, s.y);
             } else if (img) {
                 if (typeof s.w === 'number' && typeof s.h === 'number' && (s.w !== img.width || s.h !== img.height)) {
-                    const tmp = document.createElement('canvas');
-                    tmp.width = img.width;
-                    tmp.height = img.height;
-                    const tctx = tmp.getContext('2d');
-                    tctx.putImageData(img, 0, 0);
-                    ctx.drawImage(tmp, s.x, s.y, s.w, s.h);
+                    ctx.drawImage(imageDataCanvas(img), s.x, s.y, s.w, s.h);
                 } else {
                     ctx.putImageData(img, s.x, s.y);
                 }


### PR DESCRIPTION
`putImageData` ignores the transform, the composite mode and the alpha — it writes pixels at literal coordinates — so anything that needs to scale, blend or place ImageData has to go through a canvas first. That is four lines, and it appeared **four times**.

## One of the four is expensive

It sits **inside the composite loop**, so a masked layer allocated a canvas the full size of the artwork on every frame: **8MB at 1920×1080, sixty times a second while playing.**

That is the same shape of allocation as the boiling-phase resize that ran a tab out of memory, and it was three lines away from `sizeCanvas`, which exists because of it.

## Two reused canvases, not one

`takeScratch` already documents why a single shared scratch works for marker and pencil — *every use is sequential and never nested*. The mask path is exactly the case that breaks it: it holds a full-size compose target **while** putting a mask through a second canvas.

Keeping them as separate helpers rather than slots of one pool means the nesting is safe **by construction** rather than by remembering:

```js
// imageDataCanvas is a different shared canvas from this one, so nesting them
// is safe - which is why they are separate helpers rather than slots of one.
tctx.drawImage(mb || imageDataCanvas(mi), mx, my);
```

## While in there

The mask path reset `globalAlpha` twice and never reset the transform — which a fresh canvas never needed and a reused one does.

## Verified

- [x] `npm run check` — 371 tests, typecheck, hook baseline, helper index, build all clean

## Worth trying

Lasso a region and move it around during playback. It should look the same, and the tab should stop growing while it does.
