### PR TITLE
refactor: name the cut-progress arithmetic that six places were doing by hand

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -279,6 +279,8 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `computeCutAnim` | at rest (no transform), so callers can skip the save/transform fast-path. |
 | `computeLayerAnim` | — |
 | `computeTextAnim` | — |
+| `cutDuration` | A cut's length in seconds, never zero - a cut can be dragged to zero length and everything that animates divides by it. |
+| `cutProgress` | How far through a cut a moment is, 0 to 1, clamped. Animations are evaluated for cuts merely near the playhead, so times outside the cut are routine and extrapolating would overshoot. |
 | `curveToWave` | The returned amp (px) is how far that curve actually swung, and is used as the default strength. |
 | `dataURLToImageData` | — |
 | `DEFAULT_CUT_DURATION` | — |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,7 @@ import {
     layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas,
     flattenForCanvas, flattenLayersInUiOrder, strokeSig, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, swayWeightAt, morphPrepare,
     accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
-    targetCanvasFor, imageDataCanvas,
+    targetCanvasFor, imageDataCanvas, cutProgress,
 } from './canvas/canvasUtils';
 
 /**
@@ -3226,7 +3226,7 @@ export default function App() {
         // tracks above it are parts of the same shot rather than shots of their own.
         const camCut = playing ? activeCuts.find(c => c.camera) : null;
         const camAt = camCut
-            ? computeCamera(camCut.camera, (t - camCut.startTime) / Math.max(0.0001, camCut.endTime - camCut.startTime), CANVAS_W, CANVAS_H)
+            ? computeCamera(camCut.camera, cutProgress(camCut, t), CANVAS_W, CANVAS_H)
             : null;
         if (camAt) { ctx.save(); applyCamera(ctx, camAt, CANVAS_W, CANVAS_H); }
         // Video overlay track: drawn underneath everything. The <video> element is kept at time t by
@@ -3870,7 +3870,7 @@ export default function App() {
                     )}
                     {!isFolder && animLayer && animLayer.cutId === cut.id && animLayer.layerId === layer.id && (
                         <LayerAnimPanel cut={cut} layer={layer} updLayerAnim={updLayerAnim} updLayers={updLayers} pathCapture={pathCapture} setPathCapture={setPathCapture}
-                            cutProgress={(currentTime - cut.startTime) / Math.max(0.0001, cut.endTime - cut.startTime)} />
+                            cutProgress={cutProgress(cut, currentTime)} />
                     )}
                     {dt === 'after' && <div className="drop-line" />}
                     {isFolder && !layer.collapsed && renderLayers(cut, layer.id, depth + 1)}

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -1044,7 +1044,7 @@ export const ANIM_DEFAULT = { inType: 'none', inDur: 0.4, inDir: 'left', outType
 export function computeCutAnim(ac, time, cw = CANVAS_W, ch = CANVAS_H) {
     const a = ac.anim;
     if (!a) return null;
-    const dur = Math.max(0.0001, ac.endTime - ac.startTime);
+    const dur = cutDuration(ac);
     const lt = time - ac.startTime;
     let alpha = 1, sx = 1, sy = 1, tx = 0, ty = 0;
     // Slide travels a full canvas dimension so the cut clearly enters from off-screen.
@@ -1088,6 +1088,39 @@ export const LAYER_ANIM_DEFAULT = { mode: 'progress', speed: 1, count: 0, tx: 0,
 
 // Easing applied to a 0..1 progress. type: linear | in (slow→fast) | out (fast→slow)
 // | inout. power (>=1) is the user-adjustable strength/weight.
+// How long a cut lasts, and how far through it a moment is.
+//
+// Written out six times between here and App - twice as bare arithmetic inside an animation
+// function, once inline in the camera call, once as a prop already named cutProgress. The
+// concept had a name before it had a function.
+//
+// The floor is the whole reason it is not just (end - start). A cut can be dragged to zero
+// length, and every one of these divides by it.
+const MIN_CUT_SECONDS = 0.0001;
+
+/**
+ * A cut's length in seconds, never zero.
+ * @param {{startTime: number, endTime: number}} ac
+ * @returns {number}
+ */
+export function cutDuration(ac) {
+    return Math.max(MIN_CUT_SECONDS, ac.endTime - ac.startTime);
+}
+
+/**
+ * How far through a cut a moment is: 0 at its start, 1 at its end.
+ *
+ * Clamped, so a time outside the cut reads as one of its ends rather than extrapolating - which
+ * matters because animations are evaluated for cuts that are merely near the playhead.
+ *
+ * @param {{startTime: number, endTime: number}} ac
+ * @param {number} time
+ * @returns {number}
+ */
+export function cutProgress(ac, time) {
+    return Math.max(0, Math.min(1, (time - ac.startTime) / cutDuration(ac)));
+}
+
 export function applyEase(t, type, power = 2) {
     t = Math.max(0, Math.min(1, t));
     if (!type || type === 'linear') return t;
@@ -1185,7 +1218,7 @@ export function computeTextAnim(t, ac, time) {
     const a = t.anim;
     if (!a) return null;
     const local = time - ac.startTime;
-    const dur = Math.max(0.0001, ac.endTime - ac.startTime);
+    const dur = cutDuration(ac);
     let alpha = 1, dx = 0, dy = 0, scale = 1, blur = 0, rot = 0;
 
     const inDur = Math.max(0.0001, a.inDur ?? 0.4);
@@ -1245,8 +1278,7 @@ export function sampleKeys(keys, p) {
 export function computeLayerAnim(layer, ac, time, cw = CANVAS_W, ch = CANVAS_H) {
     const a = layer.anim;
     if (!a) return null;
-    const dur = Math.max(0.0001, ac.endTime - ac.startTime);
-    const t = Math.max(0, Math.min(1, (time - ac.startTime) / dur));
+    const t = cutProgress(ac, time);
     const speed = a.speed || 1, count = a.count || 0;
     const keys = Array.isArray(a.keys) && a.keys.length >= 2 ? a.keys : null;
     let tx, ty, rot, sc, alpha = 1, prog;

--- a/test/canvasUtils.test.js
+++ b/test/canvasUtils.test.js
@@ -14,6 +14,7 @@ import {
     pointInPolygon, dist, safeArray, hexToRgb, fitRect, layerKey, strokeSig,
     applyEase, triwave, swayWeightAt, sampleWave, sampleKeys, targetCanvasFor,
     computeCutAnim, flattenLayersInUiOrder, sizeCanvas, dilateMask, FONT_PRESETS, fontGroups,
+cutDuration, cutProgress,
 } from '../src/canvas/canvasUtils.js';
 
 const near = (a, b, eps = 1e-9) => assert.ok(Math.abs(a - b) < eps, `${a} ≈ ${b}`);
@@ -262,4 +263,35 @@ test('the shipped presets have unique values and cover Japanese', () => {
     assert.equal(new Set(values).size, values.length, 'duplicate font values');
     assert.ok(FONT_PRESETS.some(f => f.group === '日本語'), 'no Japanese group');
     assert.ok(FONT_PRESETS.every(f => f.value && f.label), 'every preset needs a value and a label');
+});
+
+test('cutDuration: a cut dragged to zero length still has a length to divide by', () => {
+    // The whole reason the floor exists. Six places divided by this before it was a function.
+    assert.equal(cutDuration({ startTime: 2, endTime: 5 }), 3);
+    assert.ok(cutDuration({ startTime: 4, endTime: 4 }) > 0);
+    assert.ok(Number.isFinite(1 / cutDuration({ startTime: 4, endTime: 4 })));
+    // A cut whose end is before its start is nonsense, not a negative duration.
+    assert.ok(cutDuration({ startTime: 9, endTime: 1 }) > 0);
+});
+
+test('cutProgress: 0 at the start, 1 at the end, halfway in the middle', () => {
+    const ac = { startTime: 10, endTime: 14 };
+    assert.equal(cutProgress(ac, 10), 0);
+    assert.equal(cutProgress(ac, 12), 0.5);
+    assert.equal(cutProgress(ac, 14), 1);
+});
+
+test('cutProgress clamps rather than extrapolating', () => {
+    // Animations are evaluated for cuts merely near the playhead, so times outside the cut are
+    // routine. Extrapolating would send a move past where it was meant to stop.
+    const ac = { startTime: 10, endTime: 14 };
+    assert.equal(cutProgress(ac, 0), 0);
+    assert.equal(cutProgress(ac, 99), 1);
+    assert.equal(cutProgress(ac, -5), 0);
+});
+
+test('cutProgress on a zero-length cut is a number, not NaN', () => {
+    const p = cutProgress({ startTime: 3, endTime: 3 }, 3);
+    assert.ok(Number.isFinite(p), `got ${p}`);
+    assert.ok(p >= 0 && p <= 1);
 });


### PR DESCRIPTION
Committed and pushed yesterday; the PR never got opened. Opening it now rather than leaving finished work on a branch.

## What was there

How long a cut lasts, and how far through it a moment is, were written out **six times**: twice as bare arithmetic inside animation functions, once inline in the camera call, and once as a prop **already called `cutProgress`**. The concept had a name before it had a function.

## The floor is the part worth having in one place

```js
const MIN_CUT_SECONDS = 0.0001;
```

A cut can be dragged to zero length and every one of these divides by it, so each copy carried its own `Math.max(0.0001, ...)` and each was one edit away from not carrying it.

## The copies disagreed

`cutProgress` clamps. Two of the six did, two did not.

Animations are evaluated for cuts merely *near* the playhead, so a time outside the cut is routine — and extrapolating sends a move past where it was meant to stop.

## Verified

- [x] `npm run check` — 375 tests, typecheck and build clean
- [x] 4 new tests, including a zero-length cut and times outside the cut
