### PR TITLE
fix: a cancelled pointer left its drag listeners on window forever

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -36,6 +36,14 @@ Camera moves: presets, drawn paths, and the transform they resolve to.
 | `resolveCamera` | No camera at all: the default, and what every existing project has. */ |
 | `zoomForDrift` | The smallest zoom at which a camera may sit that far off centre without the frame running off the artwork. |
 
+## `src/core/windowDrag.js`
+
+Running a drag on window listeners, so it survives the pointer leaving the element.
+
+| | |
+|---|---|
+| `dragOnWindow` | Listen for move until pointerup **or pointercancel**, then remove everything. Returns a stop function, which is also what a React effect wants as its cleanup. The cancel case is the one five hand-written copies all missed - a cancelled pointer never sends pointerup, so the move listener stayed for the session. |
+
 ## `src/core/cutClone.js`
 
 Copying a cut, including the pixels its strokes point at.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ import { migrateCuts, projectSettings, makeLoadProgress } from './core/projectFo
 import { frameStorage, frameLoad, imageExt, imageExtFromType, audioExt, videoExt } from './core/projectAssets.js';
 import { xAtTime, timeAtX, zoomAnchored, pinchZoom } from './core/timelineZoom.js';
 import { preparePath } from './core/pathMotion.js';
+import { dragOnWindow } from './core/windowDrag.js';
 // Recording a camera path reuses the pen the way a part's motion path does; the two cannot be
 // active at once, and startDraw checks this one first because a camera is a property of the cut
 // rather than of whichever layer happens to be selected.
@@ -987,9 +988,7 @@ export default function App() {
             else if (splitter.type === 'color') setColorW(Math.max(150, Math.min(520, splitter.startW + (e.clientX - splitter.startX))));
             else if (splitter.type === 'bottom') setTimelineH(Math.max(100, Math.min(600, splitter.startH + (splitter.startY - e.clientY))));
         };
-        const up = () => setSplitter(null);
-        window.addEventListener('pointermove', mv); window.addEventListener('pointerup', up);
-        return () => { window.removeEventListener('pointermove', mv); window.removeEventListener('pointerup', up); };
+        return dragOnWindow(mv, () => setSplitter(null));
     }, [splitter]);
 
     // Zoom the timeline about a screen x (cursor), keeping the time under it fixed. The scroll
@@ -1146,8 +1145,7 @@ export default function App() {
             const lv = liveRef.current;
             recordHistoryRef.current({ cuts: lv.cuts, audioData: lv.audioData, numTracks: lv.numTracks });
         };
-        window.addEventListener('pointermove', mv); window.addEventListener('pointerup', up);
-        return () => { window.removeEventListener('pointermove', mv); window.removeEventListener('pointerup', up); };
+        return dragOnWindow(mv, up);
     }, [resizingData, draggingCutData, pps, numTracks]);
 
     // Record an undo point for whatever is on screen now.
@@ -2171,9 +2169,7 @@ export default function App() {
         const sx = e.clientX, sy = e.clientY, sv = { ...view };
         panningRef.current = true;
         const mv = (ev) => { lastInteractRef.current = Date.now(); setView({ zoom: sv.zoom, x: sv.x + (ev.clientX - sx), y: sv.y + (ev.clientY - sy) }); ev.preventDefault(); };
-        const up = () => { panningRef.current = false; window.removeEventListener('pointermove', mv); window.removeEventListener('pointerup', up); };
-        window.addEventListener('pointermove', mv);
-        window.addEventListener('pointerup', up);
+        dragOnWindow(mv, () => { panningRef.current = false; });
     };
     const onAreaPointerDown = (e) => {
         if (e.pointerType !== 'touch') {
@@ -3892,15 +3888,12 @@ export default function App() {
         const grab = { dx: e.clientX - host.left, dy: e.clientY - host.top };
         setPanelDrag({ id, x: e.clientX, y: e.clientY, zone: dropZoneAt(e.clientX), ...grab });
         const mv = (ev) => setPanelDrag(d => d && ({ ...d, x: ev.clientX, y: ev.clientY, zone: dropZoneAt(ev.clientX) }));
-        const up = (ev) => {
-            window.removeEventListener('pointermove', mv); window.removeEventListener('pointerup', up);
+        dragOnWindow(mv, (ev) => {
             const zone = dropZoneAt(ev.clientX);
             setPanelDrag(null);
             setDocks(d => ({ ...d, [id]: zone }));
             if (zone === 'float') setFloatPos(p => ({ ...p, [id]: { x: Math.max(0, ev.clientX - grab.dx), y: Math.max(0, ev.clientY - grab.dy) } }));
-        };
-        window.addEventListener('pointermove', mv);
-        window.addEventListener('pointerup', up);
+        });
     };
 
     // A docked panel keeps a splitter on the side that faces the canvas.

--- a/src/core/windowDrag.js
+++ b/src/core/windowDrag.js
@@ -1,0 +1,49 @@
+// Running a drag on window listeners.
+//
+// A drag started on an element cannot listen on that element: the pointer leaves it constantly -
+// off the canvas, past the edge of the window, over another panel - and a drag that stops when
+// the pointer wanders is not a drag. So the listeners go on window, and the whole job is taking
+// them off again afterwards.
+//
+// Five places did this by hand, one of them in a helper that four others did not know about, and
+// every one of them missed the same case: `pointercancel`. A cancelled pointer - a system gesture
+// on a tablet, a palm landing, the browser deciding it owns the gesture now - never sends
+// pointerup, so the move listener stayed on window for the rest of the session. Nothing looks
+// wrong when that happens; the next drag simply has two handlers, then three.
+//
+// Every listener is added and removed here, so there is one place for that to be right.
+
+/**
+ * Listen for a drag on window until the pointer is released or cancelled.
+ *
+ * @param {(e: PointerEvent) => void} onMove
+ * @param {(e: PointerEvent) => void} [onEnd] called for a release and for a cancel alike - callers
+ *   that need to distinguish can read `e.type`, but almost none should: an interrupted drag has to
+ *   clean up the same way a finished one does
+ * @param {{addEventListener: Function, removeEventListener: Function}} [target] the event target,
+ *   for tests
+ * @returns {() => void} ends the drag early and removes the listeners; safe to call twice
+ */
+export function dragOnWindow(onMove, onEnd, target = typeof window !== 'undefined' ? window : null) {
+    if (!target) return () => { };
+
+    let done = false;
+    const stop = () => {
+        // Idempotent, because a caller that ends a drag itself would otherwise leave the listeners
+        // on until a pointerup that may never come.
+        if (done) return;
+        done = true;
+        target.removeEventListener('pointermove', move);
+        target.removeEventListener('pointerup', end);
+        target.removeEventListener('pointercancel', end);
+    };
+
+    const move = (e) => { if (!done) onMove(e); };
+    const end = (e) => { stop(); onEnd?.(e); };
+
+    target.addEventListener('pointermove', move);
+    target.addEventListener('pointerup', end);
+    target.addEventListener('pointercancel', end);
+
+    return stop;
+}

--- a/src/hooks/useTimelineGestures.js
+++ b/src/hooks/useTimelineGestures.js
@@ -16,6 +16,7 @@
 // keeps working and still ends when the button comes up somewhere else.
 
 import { timeAtX, pinchZoom } from '../core/timelineZoom.js';
+import { dragOnWindow } from '../core/windowDrag.js';
 
 const DRAG_SLOP = 5;   // mouse travel before a click becomes a marquee drag
 const TAP_SLOP = 4;    // finger travel before a tap becomes a pan
@@ -70,18 +71,6 @@ export function useTimelineGestures({
         const cur = currentTimeRef.current ?? 0;
         const target = dir > 0 ? times.find(t => t > cur + 0.02) : [...times].reverse().find(t => t < cur - 0.02);
         if (target != null) seekToTime(target);
-    };
-
-    /** Run a drag on window listeners, so it survives the pointer leaving the timeline. */
-    const dragOnWindow = (onMove, onUp) => {
-        const mv = (ev) => onMove(ev);
-        const up = (ev) => {
-            window.removeEventListener('pointermove', mv);
-            window.removeEventListener('pointerup', up);
-            onUp?.(ev);
-        };
-        window.addEventListener('pointermove', mv);
-        window.addEventListener('pointerup', up);
     };
 
     // Middle-click pan. Handled in the capture phase by the caller so it works wherever the press

--- a/test/windowDrag.test.js
+++ b/test/windowDrag.test.js
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { dragOnWindow } from '../src/core/windowDrag.js';
+
+/** A stand-in for window that remembers what is still listening. */
+function fakeTarget() {
+    const live = new Map();
+    return {
+        addEventListener: (type, fn) => { live.set(type + ':' + fn.name + live.size, { type, fn }); },
+        removeEventListener: (type, fn) => {
+            for (const [k, v] of live) if (v.type === type && v.fn === fn) live.delete(k);
+        },
+        /** @param {string} type */
+        fire(type, e = {}) {
+            for (const v of [...live.values()]) if (v.type === type) v.fn({ type, ...e });
+        },
+        types: () => [...live.values()].map(v => v.type).sort(),
+        count: () => live.size,
+    };
+}
+
+test('moves are delivered until the pointer is released', () => {
+    const t = fakeTarget();
+    const moves = [];
+    dragOnWindow(e => moves.push(e.x), undefined, t);
+
+    t.fire('pointermove', { x: 1 });
+    t.fire('pointermove', { x: 2 });
+    t.fire('pointerup');
+    t.fire('pointermove', { x: 3 });
+
+    assert.deepEqual(moves, [1, 2]);
+});
+
+test('a release removes every listener', () => {
+    const t = fakeTarget();
+    dragOnWindow(() => { }, undefined, t);
+    assert.deepEqual(t.types(), ['pointercancel', 'pointermove', 'pointerup']);
+
+    t.fire('pointerup');
+    assert.equal(t.count(), 0, 'listeners left on window after the drag ended');
+});
+
+test('a cancelled pointer removes them too', () => {
+    // The case all five hand-written copies missed. A system gesture or a palm landing sends
+    // pointercancel and never pointerup, so the move listener stayed for the rest of the session
+    // - and nothing looks wrong until the next drag has two handlers, then three.
+    const t = fakeTarget();
+    const moves = [];
+    dragOnWindow(() => moves.push(1), undefined, t);
+
+    t.fire('pointercancel');
+    assert.equal(t.count(), 0, 'a cancelled pointer leaked its listeners');
+
+    t.fire('pointermove');
+    assert.equal(moves.length, 0, 'still moving after a cancel');
+});
+
+test('onEnd runs for a release and for a cancel alike', () => {
+    for (const type of ['pointerup', 'pointercancel']) {
+        const t = fakeTarget();
+        const ends = [];
+        dragOnWindow(() => { }, e => ends.push(e.type), t);
+        t.fire(type);
+        assert.deepEqual(ends, [type]);
+    }
+});
+
+test('the returned stop ends the drag early', () => {
+    const t = fakeTarget();
+    const moves = [];
+    const stop = dragOnWindow(() => moves.push(1), undefined, t);
+
+    t.fire('pointermove');
+    stop();
+    t.fire('pointermove');
+
+    assert.equal(moves.length, 1);
+    assert.equal(t.count(), 0);
+});
+
+test('stopping twice, or after the drag ended, is harmless', () => {
+    const t = fakeTarget();
+    const stop = dragOnWindow(() => { }, undefined, t);
+    stop();
+    stop();
+    t.fire('pointerup');
+    assert.equal(t.count(), 0);
+});
+
+test('onEnd does not run again for a pointerup after an early stop', () => {
+    // Otherwise a caller that ends a drag itself would still get its cleanup run a second time
+    // when the pointer eventually comes up.
+    const t = fakeTarget();
+    let ends = 0;
+    const stop = dragOnWindow(() => { }, () => { ends++; }, t);
+    stop();
+    t.fire('pointerup');
+    assert.equal(ends, 0);
+});
+
+test('two drags at once do not remove each other listeners', () => {
+    const t = fakeTarget();
+    const a = [], b = [];
+    dragOnWindow(() => a.push(1), undefined, t);
+    dragOnWindow(() => b.push(1), undefined, t);
+    assert.equal(t.count(), 6);
+
+    t.fire('pointermove');
+    assert.deepEqual([a.length, b.length], [1, 1]);
+
+    t.fire('pointerup');
+    assert.equal(t.count(), 0);
+});
+
+test('with no target at all it does nothing rather than throwing', () => {
+    const stop = dragOnWindow(() => { }, undefined, null);
+    assert.equal(typeof stop, 'function');
+    stop();
+});


### PR DESCRIPTION
A drag started on an element cannot listen on that element — the pointer leaves it constantly, and a drag that stops when the pointer wanders is not a drag. So the listeners go on `window`, and the whole job is taking them off again.

**Five places did this by hand**, one of them a helper inside `useTimelineGestures` that the other four did not know existed.

## The bug all five shared

Every one removed the listeners on `pointerup`. **None handled `pointercancel`.**

A cancelled pointer — a system gesture on a tablet, a palm landing, the browser deciding it owns the gesture — never sends `pointerup`. The move handler then stays on `window` for the rest of the session, and **nothing looks wrong when it does**: the next drag simply runs two handlers, then three.

On a tablet with an S Pen, which is what this app is for, cancellation is not an edge case.

## What it is now

`dragOnWindow` owns every add and remove, listens for `pointercancel` too, and returns a stop function — which is also exactly what the two React effects wanted as their cleanup, so those got *shorter*:

```js
// before: add two listeners, then a cleanup that removes the same two
// after:
return dragOnWindow(mv, () => setSplitter(null));
```

```
hand-written window.addEventListener('pointermove'):  5  ->  0
```

## Tests

9, against a fake target that remembers what is still listening — so "did it clean up" is an assertion rather than a hope:

```js
t.fire('pointercancel');
assert.equal(t.count(), 0, 'a cancelled pointer leaked its listeners');
```

Also covered: stopping twice, stopping before the pointer comes up (and `onEnd` not firing twice), and two simultaneous drags not tearing down each other's handlers.

## Verified

- [x] `npm run check` — 380 tests, typecheck, hook baseline, helper index, build all clean

## Worth trying

Drag a panel by its header, drag a splitter, middle-click-pan the canvas, and drag a cut on the timeline. All four should behave as before. On the tablet, start a drag and trigger a system gesture — that is the case that used to leak.
