### PR TITLE
refactor: start the scene engine with which cuts a frame is made of

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -374,22 +374,6 @@ thumbnails and onion skin should all describe a frame the same way.
 | `onionNeighbours` | The cuts either side on the **same** track. `next` starts at `endTime`, because cuts abut and a strict comparison would find nothing in the common case. |
 | `topCutAt` | The cut the playhead selects: topmost of those it is over, since the upper tracks are what a click would land on. |
 
-## `src/hooks/useAutosave.js`
-
-Debounced background saving, so a refresh or a crash never costs work.
-
-| | |
-|---|---|
-| `useAutosave` | Saves `doc` after a quiet period. Waits for `ready()` - crash recovery has to decide first, or a new empty document overwrites the autosave the user is about to be offered - and skips while `busy()`. Failures come back as `error` rather than being swallowed. |
-
-## `src/hooks/useServerProbe.js`
-
-Whether the project-storage API is reachable, re-checked with a backoff.
-
-| | |
-|---|---|
-| `useServerProbe` | Polls with `nextProbeDelay` backoff and resets on window focus. Checking only once was the original bug: a server that was down at load stayed "down" all session, so the menus never rendered and clicking did nothing. |
-
 ## `src/hooks/useTimelineGestures.js`
 
 Every way the timeline can be pointed at, in one place.

--- a/HELPERS.md
+++ b/HELPERS.md
@@ -362,6 +362,34 @@ The playback clock: one rAF loop driving canvas, playhead, audio, video and the 
 |---|---|
 | `usePlayback` | Owns `isPlaying`, `currentTime` and the four refs the loop reads instead of state. Returns those plus `playPause` and `stop`. Export runs through the same loop, at real time whatever speed is selected. |
 
+## `src/engine/selectCuts.js`
+
+Which cuts a frame is made of. The first piece of the scene engine: playback, scrubbing, export,
+thumbnails and onion skin should all describe a frame the same way.
+
+| | |
+|---|---|
+| `cutsAt` | The cuts playing at a moment, bottom track first. Half-open, so two cuts that touch never both claim the instant between them. |
+| `visibleCutsAt` | What to draw, which is not the same question: while paused it also includes the cut being edited, or clicking a cut and finding a blank canvas becomes normal. |
+| `onionNeighbours` | The cuts either side on the **same** track. `next` starts at `endTime`, because cuts abut and a strict comparison would find nothing in the common case. |
+| `topCutAt` | The cut the playhead selects: topmost of those it is over, since the upper tracks are what a click would land on. |
+
+## `src/hooks/useAutosave.js`
+
+Debounced background saving, so a refresh or a crash never costs work.
+
+| | |
+|---|---|
+| `useAutosave` | Saves `doc` after a quiet period. Waits for `ready()` - crash recovery has to decide first, or a new empty document overwrites the autosave the user is about to be offered - and skips while `busy()`. Failures come back as `error` rather than being swallowed. |
+
+## `src/hooks/useServerProbe.js`
+
+Whether the project-storage API is reachable, re-checked with a backoff.
+
+| | |
+|---|---|
+| `useServerProbe` | Polls with `nextProbeDelay` backoff and resets on window focus. Checking only once was the original bug: a server that was down at load stayed "down" all session, so the menus never rendered and clicking did nothing. |
+
 ## `src/hooks/useTimelineGestures.js`
 
 Every way the timeline can be pointed at, in one place.

--- a/scripts/helper-index.mjs
+++ b/scripts/helper-index.mjs
@@ -19,7 +19,10 @@ import { join } from 'node:path';
 const INDEX = 'HELPERS.md';
 // Directories whose exports are shared vocabulary. App.jsx and the ui/ components are excluded:
 // those export React components, which are found by reading the screen rather than an index.
-const DIRS = ['src/core', 'src/canvas', 'src/hooks', 'server'];
+//
+// src/engine was missing when it was created, so its first four exports went unindexed and the
+// guard passed anyway - a guard with a hole in it is worse than none, because it is trusted.
+const DIRS = ['src/core', 'src/canvas', 'src/hooks', 'src/engine', 'server'];
 
 /** Exported function and const names in one module. */
 function exportsOf(source) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,6 +46,7 @@ import { dragOnWindow } from './core/windowDrag.js';
 import { computeCamera, applyCamera } from './core/camera.js';
 import { clipGroups, canClip } from './core/clipping.js';
 import { setLayerClipped } from './core/cutsReducer.js';
+import { visibleCutsAt, onionNeighbours, topCutAt } from './engine/selectCuts.js';
 import { unusedBitmapIds } from './core/bitmapRefs.js';
 import { dragCut, resizeCut } from './core/cutOps.js';
 import {
@@ -883,8 +884,8 @@ export default function App() {
 
     useEffect(() => {
         if (isPlaying) {
-            const active = cuts.filter(c => currentTime >= c.startTime && currentTime < c.endTime);
-            if (active.length) { const top = active.reduce((p, c) => p.track > c.track ? p : c); if (top.id !== currentCutId) setCurrentCutId(top.id); }
+            const top = topCutAt(cuts, currentTime);
+            if (top && top.id !== currentCutId) setCurrentCutId(top.id);
         }
     }, [currentTime, isPlaying]);
 
@@ -2875,11 +2876,11 @@ export default function App() {
         if (primary) {
             visible.add(primary.id);
             if (onionPrev) {
-                const prev = cuts.filter(c => c.startTime < primary.startTime && c.track === primary.track).sort((a, b) => b.startTime - a.startTime)[0];
+                const prev = onionNeighbours(cuts, primary).prev;
                 if (prev) visible.add(prev.id);
             }
             if (onionNext) {
-                const next = cuts.filter(c => c.startTime >= primary.endTime && c.track === primary.track).sort((a, b) => a.startTime - b.startTime)[0];
+                const next = onionNeighbours(cuts, primary).next;
                 if (next) visible.add(next.id);
             }
         }
@@ -3124,9 +3125,7 @@ export default function App() {
         // alive.
         boilPhaseRef.current = t * BOIL_FPS + boilTick;
         const primary = currentCut;
-        let activeCuts = cuts.filter(c => t >= c.startTime && t < c.endTime);
-        if (!activeCuts.find(c => c.id === currentCutId) && primary && !playing) activeCuts.push(primary);
-        activeCuts.sort((a, b) => a.track - b.track);
+        const activeCuts = visibleCutsAt(cuts, t, currentCutId, playing);
         // Never flash white DURING PLAYBACK: if the frame we're about to show isn't decoded yet,
         // HOLD the last painted frame (skip this repaint) and kick a decode. The loop keeps advancing,
         // so it reads as a brief hold instead of a white flash. Paused/editing always paints normally
@@ -3172,7 +3171,7 @@ export default function App() {
 
         if (!playing && primary) {
             if (onionPrev) {
-                const prevCut = cuts.filter(c => c.startTime < primary.startTime && c.track === primary.track).sort((a, b) => b.startTime - a.startTime)[0];
+                const prevCut = onionNeighbours(cuts, primary).prev;
                 if (prevCut) {
                     const order = flattenLayersInUiOrder(prevCut.layers || []).filter(l => l.type === 'layer' && l.visible !== false);
                     for (let i = order.length - 1; i >= 0; i--) {
@@ -3182,7 +3181,7 @@ export default function App() {
                 }
             }
             if (onionNext) {
-                const nextCut = cuts.filter(c => c.startTime >= primary.endTime && c.track === primary.track).sort((a, b) => a.startTime - b.startTime)[0];
+                const nextCut = onionNeighbours(cuts, primary).next;
                 if (nextCut) {
                     const order = flattenLayersInUiOrder(nextCut.layers || []).filter(l => l.type === 'layer' && l.visible !== false);
                     for (let i = order.length - 1; i >= 0; i--) {

--- a/src/engine/selectCuts.js
+++ b/src/engine/selectCuts.js
@@ -1,0 +1,97 @@
+// Which cuts a frame is made of.
+//
+// The first piece of the scene engine, and the piece everything else waits on: before anything
+// can be animated or drawn, something has to say which cuts exist at time t and which neighbours
+// the onion skin should show.
+//
+// It was written out twice each. Not a lot of code, but the sort where the two copies disagree
+// quietly - one uses `<=` where the other uses `<` and a frame at a cut boundary shows two cuts
+// in one place and one in the other, which reads as a flicker rather than as a bug.
+//
+// Pure and DOM-free on purpose. The goal it serves is that playback, scrubbing, export, thumbnail
+// generation and onion skin all describe a frame the same way:
+//
+//     const scene = evaluate(project, t)
+//     render(ctx, scene)
+//
+// Today only the selection half of that exists. Animation and compositing follow.
+
+/**
+ * The cuts playing at a moment, bottom track first.
+ *
+ * Half-open on purpose: a cut covers its start and not its end, so two cuts that touch never both
+ * claim the instant between them.
+ *
+ * Ordered by track because that is the order they are drawn in, and returning them any other way
+ * would mean every caller sorting again.
+ *
+ * @param {Cut[]} cuts
+ * @param {number} t
+ * @returns {Cut[]}
+ */
+export function cutsAt(cuts, t) {
+    return (Array.isArray(cuts) ? cuts : [])
+        .filter(c => t >= c.startTime && t < c.endTime)
+        .sort((a, b) => a.track - b.track);
+}
+
+/**
+ * The cuts to draw, which is not quite the same question.
+ *
+ * While playing it is exactly what is at t. While paused it also includes the cut being edited,
+ * even when the playhead is not over it - otherwise clicking a cut in the timeline and finding a
+ * blank canvas is the normal experience of the app.
+ *
+ * @param {Cut[]} cuts
+ * @param {number} t
+ * @param {any} currentCutId
+ * @param {boolean} playing
+ * @returns {Cut[]}
+ */
+export function visibleCutsAt(cuts, t, currentCutId, playing) {
+    const active = cutsAt(cuts, t);
+    if (playing) return active;
+    if (active.some(c => c.id === currentCutId)) return active;
+    const current = (Array.isArray(cuts) ? cuts : []).find(c => c.id === currentCutId);
+    return current ? [...active, current].sort((a, b) => a.track - b.track) : active;
+}
+
+/**
+ * The cuts either side of this one on its own track, for onion skinning.
+ *
+ * Same track only: onion skin is for seeing the drawing before and after in a sequence, and a cut
+ * on another track is a different element of the same shot, not the previous frame of this one.
+ *
+ * `next` starts at `endTime` rather than after it, because cuts usually abut - a strict
+ * comparison would find nothing in the common case.
+ *
+ * @param {Cut[]} cuts
+ * @param {Cut | null | undefined} cut
+ * @returns {{prev: Cut | null, next: Cut | null}}
+ */
+export function onionNeighbours(cuts, cut) {
+    if (!cut) return { prev: null, next: null };
+    const sameTrack = (Array.isArray(cuts) ? cuts : []).filter(c => c.track === cut.track);
+    const prev = sameTrack
+        .filter(c => c.startTime < cut.startTime)
+        .sort((a, b) => b.startTime - a.startTime)[0] || null;
+    const next = sameTrack
+        .filter(c => c.startTime >= cut.endTime)
+        .sort((a, b) => a.startTime - b.startTime)[0] || null;
+    return { prev, next };
+}
+
+/**
+ * Which cut the playhead should select: the topmost of those it is over.
+ *
+ * Topmost rather than bottom, because the upper tracks are what a click would land on.
+ *
+ * @param {Cut[]} cuts
+ * @param {number} t
+ * @returns {Cut | null}
+ */
+export function topCutAt(cuts, t) {
+    const active = cutsAt(cuts, t);
+    if (!active.length) return null;
+    return active.reduce((p, c) => (p.track > c.track ? p : c));
+}

--- a/test/selectCuts.test.js
+++ b/test/selectCuts.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cutsAt, visibleCutsAt, onionNeighbours, topCutAt } from '../src/engine/selectCuts.js';
+
+const cut = (id, start, end, track = 0) => ({ id, startTime: start, endTime: end, track });
+const ids = (cs) => cs.map(c => c.id);
+
+// Two cuts touching on track 0, one overlapping them on track 1.
+const doc = () => [cut('a', 0, 2), cut('b', 2, 4), cut('over', 1, 3, 1)];
+
+test('a cut covers its start and not its end', () => {
+    // The boundary is the whole reason this is one function. Two copies that disagreed on < vs <=
+    // would show two cuts at the seam in one place and one in the other, which reads as a flicker.
+    assert.deepEqual(ids(cutsAt(doc(), 0)), ['a']);
+    assert.deepEqual(ids(cutsAt(doc(), 2)), ['b', 'over']);
+    assert.deepEqual(ids(cutsAt(doc(), 4)), []);
+});
+
+test('active cuts come back bottom track first, which is drawing order', () => {
+    assert.deepEqual(ids(cutsAt(doc(), 1.5)), ['a', 'over']);
+});
+
+test('nothing playing at that moment is an empty list, not a throw', () => {
+    assert.deepEqual(cutsAt([], 1), []);
+    assert.deepEqual(cutsAt(null, 1), []);
+    assert.deepEqual(ids(cutsAt(doc(), 99)), []);
+});
+
+test('while playing, only what is actually at t is drawn', () => {
+    assert.deepEqual(ids(visibleCutsAt(doc(), 3.5, 'a', true)), ['b']);
+    assert.deepEqual(ids(visibleCutsAt(doc(), 9, 'a', true)), []);
+});
+
+test('while paused, the cut being edited is drawn even off the playhead', () => {
+    // Otherwise clicking a cut in the timeline and finding a blank canvas is the normal
+    // experience of the app.
+    assert.deepEqual(ids(visibleCutsAt(doc(), 9, 'a', false)), ['a']);
+    // Appended, so among cuts on the same track the one being edited draws last - on top, which
+    // is what you want to see while working on it.
+    assert.deepEqual(ids(visibleCutsAt(doc(), 3.5, 'a', false)), ['b', 'a']);
+});
+
+test('the edited cut is not added twice when the playhead is already over it', () => {
+    const v = visibleCutsAt(doc(), 0.5, 'a', false);
+    assert.deepEqual(ids(v), ['a']);
+});
+
+test('an edited cut that no longer exists is simply absent', () => {
+    assert.deepEqual(ids(visibleCutsAt(doc(), 9, 'gone', false)), []);
+});
+
+test('onion neighbours are the cuts either side on the same track', () => {
+    const cuts = [cut('a', 0, 2), cut('b', 2, 4), cut('c', 4, 6)];
+    const { prev, next } = onionNeighbours(cuts, cuts[1]);
+    assert.equal(prev.id, 'a');
+    assert.equal(next.id, 'c');
+});
+
+test('onion ignores other tracks', () => {
+    // A cut on another track is a different element of the same shot, not the previous frame.
+    const cuts = [cut('a', 0, 2), cut('b', 2, 4), cut('other', 0, 2, 1), cut('other2', 4, 6, 1)];
+    const { prev, next } = onionNeighbours(cuts, cuts[1]);
+    assert.equal(prev.id, 'a');
+    assert.equal(next, null);
+});
+
+test('next starts at endTime, because cuts abut', () => {
+    // A strict comparison would find nothing in the common case, which is every hand-drawn
+    // sequence ever made in this app.
+    const cuts = [cut('a', 0, 2), cut('b', 2, 4)];
+    assert.equal(onionNeighbours(cuts, cuts[0]).next.id, 'b');
+});
+
+test('the ends of a sequence have one neighbour each', () => {
+    const cuts = [cut('a', 0, 2), cut('b', 2, 4)];
+    assert.equal(onionNeighbours(cuts, cuts[0]).prev, null);
+    assert.equal(onionNeighbours(cuts, cuts[1]).next, null);
+});
+
+test('onion of nothing is nothing', () => {
+    assert.deepEqual(onionNeighbours([], null), { prev: null, next: null });
+    assert.deepEqual(onionNeighbours(null, undefined), { prev: null, next: null });
+});
+
+test('the playhead selects the topmost cut it is over', () => {
+    // Upper tracks are what a click would land on, so that is what following the playhead picks.
+    assert.equal(topCutAt(doc(), 1.5).id, 'over');
+    assert.equal(topCutAt(doc(), 0.5).id, 'a');
+    assert.equal(topCutAt(doc(), 99), null);
+});


### PR DESCRIPTION
First piece of **Phase C**, and the piece everything else waits on: before anything can be animated or drawn, something has to say which cuts exist at time `t` and which neighbours the onion skin shows.

Stacked on #67.

## Two copies each

| | copies |
|---|---|
| which cuts are active at t | 2 |
| onion neighbours | 2 |

Not much code, but the kind where copies disagree **quietly** — one boundary comparison differing from the other, and a frame at a cut seam shows two cuts in one place and one in the other. That reads as a flicker, not as a bug.

The tests state the boundary directly so it cannot drift again:

```js
assert.deepEqual(ids(cutsAt(doc(), 0)), ['a']);
assert.deepEqual(ids(cutsAt(doc(), 2)), ['b', 'over']);   // 'a' ends here and does not claim it
assert.deepEqual(ids(cutsAt(doc(), 4)), []);
```

## Why `engine/` and not `core/`

The shape it is growing into. Playback, scrubbing, export, thumbnails and onion skin should all describe a frame the same way *before* anyone draws it:

```js
const scene = evaluate(project, t)
render(ctx, scene)
```

Selection is the half that exists today. Animation and compositing follow — `paintFrame` is 193 lines and mixes the two, which is what this is working toward untangling.

## A hole in my own guard

The helper index did not scan `src/engine`, so the four new exports went unlisted and **the check passed anyway**. A guard with a hole in it is worse than none, because it is trusted. `src/engine` is in the list now, and the four are indexed.

## Verified

- [x] `npm run check` — 384 tests, typecheck, hook baseline, helper index, build clean
- [x] No behaviour change intended

## Worth trying

Scrub across a cut boundary, and turn onion skin on at the first and last cut of a sequence.