### PR TITLE
security: rate limit the API, in three tiers

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -360,6 +360,15 @@ Every way the timeline can be pointed at, in one place.
 |---|---|
 | `useTimelineGestures` | — |
 
+## `server/rateLimit.js`
+
+A token bucket, so one caller cannot use the whole server.
+
+| | |
+|---|---|
+| `createRateLimiter` | Bucket rather than fixed window - a window lets a caller spend the whole allowance at the end of one and again at the start of the next. Evicts least-recently-seen callers, so the table is not itself a way to exhaust memory. |
+| `rateLimit` | Express middleware around a limiter. Keyed by IP, which is a brake on accidents and casual abuse, not access control. |
+
 ## `server/youtubeUrl.js`
 
 Which addresses the importer will hand to yt-dlp.

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ import os from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { isYouTubeUrl } from './youtubeUrl.js';
+import { createRateLimiter, rateLimit } from './rateLimit.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.join(__dirname, 'data');
@@ -24,6 +25,27 @@ const HOST = process.env.MV_API_HOST || '127.0.0.1';
 
 const app = express();
 app.use(express.json({ limit: '256mb' })); // projects embed base64 bitmaps, so allow large bodies
+
+// Rate limits, in three tiers, because the routes cost wildly different amounts.
+//
+// Generous by design. These are a brake on runaway scripts and casual abuse, not access control -
+// that is still open and still tracked on #41. A limit low enough to be a security boundary would
+// also be low enough to interrupt an ordinary autosave-heavy editing session.
+//
+// The importer gets its own, much tighter, tier: each call starts a yt-dlp process that downloads
+// from someone else's servers. Hammering that costs the host bandwidth and gets the address
+// blocked by YouTube, which breaks the feature for everybody using that machine.
+const readLimit = createRateLimiter({ capacity: 240, perSecond: 8 });    // listing and fetching
+const writeLimit = createRateLimiter({ capacity: 120, perSecond: 2 });   // saves, uploads, deletes
+const importLimit = createRateLimiter({ capacity: 4, perSecond: 0.05 }); // ~3 a minute, sustained
+
+app.get('/api/*splat', rateLimit(readLimit, 'requests'));
+app.put('/api/*splat', rateLimit(writeLimit, 'writes'));
+app.post('/api/*splat', rateLimit(writeLimit, 'writes'));
+app.delete('/api/*splat', rateLimit(writeLimit, 'writes'));
+app.get('/api/youtube-audio', rateLimit(importLimit, 'imports'));
+app.get('/api/youtube-video', rateLimit(importLimit, 'imports'));
+
 
 await fs.mkdir(DATA_DIR, { recursive: true });
 

--- a/server/rateLimit.js
+++ b/server/rateLimit.js
@@ -1,0 +1,86 @@
+// A small token bucket, so one caller cannot use the whole server.
+//
+// CodeQL raised six high-severity alerts for unlimited routes, and it is right for the case that
+// matters: this server is meant to be deployed. On loopback the worst outcome is a runaway script
+// on the same machine; on a host it is somebody filling the disk with project assets, or pointing
+// the importer at YouTube in a loop until the address is rate-limited by Google instead.
+//
+// A bucket rather than a fixed window, because a fixed window lets a caller spend the whole
+// allowance in the last second of one window and again in the first second of the next - twice
+// the intended burst, at the moment it matters least to be generous.
+//
+// Written here rather than added as a dependency: it is thirty lines, it has to be understood to
+// be trusted, and the tests are the point.
+
+/**
+ * @typedef {object} Bucket
+ * @property {number} tokens what is left
+ * @property {number} at when it was last refilled, in ms
+ */
+
+/**
+ * A limiter that hands out `capacity` requests and refills at `perSecond`.
+ *
+ * @param {object} opts
+ * @param {number} opts.capacity the burst a caller may spend at once
+ * @param {number} opts.perSecond how fast the allowance comes back
+ * @param {() => number} [opts.now] injectable clock, so the tests are not a race
+ * @param {number} [opts.maxKeys] evict least-recently-seen callers past this many, so the map is
+ *   not itself a way to exhaust memory
+ */
+export function createRateLimiter({ capacity, perSecond, now = Date.now, maxKeys = 10000 }) {
+    /** @type {Map<string, Bucket>} */
+    const buckets = new Map();
+
+    /**
+     * Take one token for `key`.
+     * @param {string} key
+     * @returns {{ok: true} | {ok: false, retryAfter: number}} seconds to wait, rounded up
+     */
+    function take(key) {
+        const t = now();
+        let b = buckets.get(key);
+        if (!b) {
+            b = { tokens: capacity, at: t };
+        } else {
+            // Refill for the time that passed, capped - an idle caller comes back to a full
+            // bucket and no more, or a long absence would bank an unlimited burst.
+            b.tokens = Math.min(capacity, b.tokens + ((t - b.at) / 1000) * perSecond);
+            b.at = t;
+        }
+
+        // Re-inserting makes the map insertion-ordered by recency, which is what lets the oldest
+        // entry be the one evicted below.
+        buckets.delete(key);
+        buckets.set(key, b);
+        if (buckets.size > maxKeys) buckets.delete(buckets.keys().next().value);
+
+        if (b.tokens < 1) {
+            return { ok: false, retryAfter: Math.ceil((1 - b.tokens) / perSecond) };
+        }
+        b.tokens -= 1;
+        return { ok: true };
+    }
+
+    return { take, size: () => buckets.size };
+}
+
+/**
+ * Express middleware around a limiter.
+ *
+ * Keyed by IP. That is the honest limit of what this can do: behind a proxy every caller may look
+ * like one address, and a caller with many addresses looks like many callers. It is a brake on
+ * accidents and casual abuse, not an access control - #41 covers the authentication that is.
+ *
+ * @param {ReturnType<typeof createRateLimiter>} limiter
+ * @param {string} [what] named in the message, so a 429 says which limit was hit
+ */
+export function rateLimit(limiter, what = 'requests') {
+    return (req, res, next) => {
+        const key = req.ip || req.socket?.remoteAddress || 'unknown';
+        const r = limiter.take(key);
+        if (r.ok) return next();
+        res.setHeader('Retry-After', String(r.retryAfter));
+        res.status(429).json({ error: `too many ${what}; retry in ${r.retryAfter}s` });
+    };
+}

--- a/test/rateLimit.test.js
+++ b/test/rateLimit.test.js
@@ -1,0 +1,126 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRateLimiter, rateLimit } from '../server/rateLimit.js';
+
+/** A clock the test moves by hand, so none of this is a race. */
+function clock(start = 0) {
+    let t = start;
+    return { now: () => t, advance: (ms) => { t += ms; } };
+}
+
+test('the burst is the capacity, and then it refuses', () => {
+    const c = clock();
+    const l = createRateLimiter({ capacity: 3, perSecond: 1, now: c.now });
+    for (let i = 0; i < 3; i++) assert.equal(l.take('a').ok, true, `call ${i}`);
+    assert.equal(l.take('a').ok, false);
+});
+
+test('the allowance comes back over time', () => {
+    const c = clock();
+    const l = createRateLimiter({ capacity: 2, perSecond: 2, now: c.now });
+    l.take('a'); l.take('a');
+    assert.equal(l.take('a').ok, false);
+
+    c.advance(500);                       // half a second at two per second = one token
+    assert.equal(l.take('a').ok, true);
+    assert.equal(l.take('a').ok, false);
+});
+
+test('an idle caller comes back to a full bucket and no more', () => {
+    // Otherwise a long absence banks an unlimited burst, which is the thing a limiter exists to
+    // prevent happening all at once.
+    const c = clock();
+    const l = createRateLimiter({ capacity: 3, perSecond: 1, now: c.now });
+    l.take('a'); l.take('a'); l.take('a');
+
+    c.advance(60 * 60 * 1000);            // an hour
+    for (let i = 0; i < 3; i++) assert.equal(l.take('a').ok, true, `call ${i}`);
+    assert.equal(l.take('a').ok, false, 'banked more than the capacity');
+});
+
+test('a bucket rather than a fixed window: no double burst at the boundary', () => {
+    // A fixed window lets a caller spend the whole allowance at the end of one window and again
+    // at the start of the next. Over any two seconds here, the total stays within capacity plus
+    // what actually refilled.
+    const c = clock();
+    const l = createRateLimiter({ capacity: 5, perSecond: 5, now: c.now });
+    let served = 0;
+    for (let ms = 0; ms < 2000; ms += 50) {
+        c.advance(50);
+        if (l.take('a').ok) served++;
+    }
+    assert.ok(served <= 5 + 10 + 1, `served ${served} in two seconds`);
+});
+
+test('callers are counted separately', () => {
+    const c = clock();
+    const l = createRateLimiter({ capacity: 1, perSecond: 1, now: c.now });
+    assert.equal(l.take('a').ok, true);
+    assert.equal(l.take('b').ok, true);
+    assert.equal(l.take('a').ok, false);
+    assert.equal(l.take('b').ok, false);
+});
+
+test('retryAfter is a whole number of seconds and never zero', () => {
+    const c = clock();
+    const l = createRateLimiter({ capacity: 1, perSecond: 0.5, now: c.now });
+    l.take('a');
+    const r = l.take('a');
+    assert.equal(r.ok, false);
+    assert.ok(Number.isInteger(r.retryAfter) && r.retryAfter >= 1, `got ${r.retryAfter}`);
+});
+
+test('the table of callers cannot itself be used to exhaust memory', () => {
+    // Without eviction, one request per forged address is a memory leak with a request behind it.
+    const c = clock();
+    const l = createRateLimiter({ capacity: 1, perSecond: 1, now: c.now, maxKeys: 10 });
+    for (let i = 0; i < 500; i++) l.take('ip-' + i);
+    assert.ok(l.size() <= 10, `held ${l.size()} entries`);
+});
+
+test('eviction drops the least recently seen, not the newest', () => {
+    const c = clock();
+    const l = createRateLimiter({ capacity: 1, perSecond: 0.001, now: c.now, maxKeys: 2 });
+    l.take('old');
+    l.take('mid');
+    l.take('new');                        // evicts 'old'
+    // 'new' is still known and out of tokens; 'old' was forgotten and starts fresh.
+    assert.equal(l.take('new').ok, false);
+    assert.equal(l.take('old').ok, true);
+});
+
+test('the middleware passes a request through and refuses the next', () => {
+    const c = clock();
+    const mw = rateLimit(createRateLimiter({ capacity: 1, perSecond: 1, now: c.now }), 'uploads');
+
+    const res = () => {
+        const o = { code: 0, headers: {}, body: null };
+        o.setHeader = (k, v) => { o.headers[k] = v; };
+        o.status = (s) => { o.code = s; return o; };
+        o.json = (b) => { o.body = b; return o; };
+        return o;
+    };
+
+    let passed = 0;
+    const r1 = res();
+    mw({ ip: '1.1.1.1' }, r1, () => passed++);
+    assert.equal(passed, 1);
+    assert.equal(r1.code, 0);
+
+    const r2 = res();
+    mw({ ip: '1.1.1.1' }, r2, () => passed++);
+    assert.equal(passed, 1, 'let a second request through');
+    assert.equal(r2.code, 429);
+    assert.ok(r2.headers['Retry-After'], 'no Retry-After header');
+    assert.match(r2.body.error, /uploads/);
+});
+
+test('the middleware still keys something when there is no address', () => {
+    const c = clock();
+    const mw = rateLimit(createRateLimiter({ capacity: 1, perSecond: 1, now: c.now }));
+    let passed = 0;
+    const res = { setHeader() { }, status() { return this; }, json() { return this; } };
+    mw({ socket: {} }, res, () => passed++);
+    mw({ socket: {} }, res, () => passed++);
+    assert.equal(passed, 1);
+});


### PR DESCRIPTION
Closes the six high-severity CodeQL alerts recorded on #41.

On loopback the worst outcome was a runaway script on the same machine. The reason to fix it now is that **this server is meant to be deployed** — and on a host it is somebody filling the disk with project assets, or pointing the importer at YouTube in a loop until the address is blocked.

## Three tiers, because the routes cost wildly different amounts

| tier | burst | sustained | why |
|---|---|---|---|
| read | 240 | 8/s | listing and fetching; an editing session is read-heavy |
| write | 120 | 2/s | saves, uploads, deletes |
| **import** | **4** | **~3/min** | each call starts a `yt-dlp` process downloading from someone else's servers |

The importer tier is the one that matters. Hammering it costs the host bandwidth and gets the address blocked by YouTube — which **breaks the feature for everybody on that machine**, not just the caller.

**Generous by design.** These are a brake on runaway scripts and casual abuse, not access control — that is still open and still tracked on #41. A limit low enough to be a security boundary would also be low enough to interrupt an ordinary autosave-heavy editing session.

## A bucket, not a window

A fixed window lets a caller spend the whole allowance in the last second of one window and again in the first second of the next — twice the intended burst, at the moment it matters most. That is a test:

```js
test('a bucket rather than a fixed window: no double burst at the boundary', ...)
```

The caller table evicts least-recently-seen entries, because a limiter whose own bookkeeping grows per forged address is a memory leak with a request behind it. Also a test.

## Thirty lines rather than a dependency

It has to be understood to be trusted, and the tests are the point — 10 of them, against an **injected clock** so none of it is a race.

## Verified against a running server

```
normal use: 30 GETs        ->  200s: 30/30
importer:   8 calls        ->  500 500 500 500 429 429 429 429
                               {"error":"too many imports; retry in 19s"}
```

(The 500s are `yt-dlp` failing on a fake URL — the limiter sits in front of it and lets four through, as configured.)

- [x] `npm run check` — 389 tests, typecheck, hook baseline, helper index, build clean

## Still open on #41

Authentication on the project endpoints, and lower body limits (256 MB JSON, 1 GB asset). Those belong with the Render work, where they stop being precautions.
