### PR TITLE
refactor: autosave and the server probe become hooks

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -352,6 +352,22 @@ The playback clock: one rAF loop driving canvas, playhead, audio, video and the 
 |---|---|
 | `usePlayback` | Owns `isPlaying`, `currentTime` and the four refs the loop reads instead of state. Returns those plus `playPause` and `stop`. Export runs through the same loop, at real time whatever speed is selected. |
 
+## `src/hooks/useAutosave.js`
+
+Debounced background saving, so a refresh or a crash never costs work.
+
+| | |
+|---|---|
+| `useAutosave` | Saves `doc` after a quiet period. Waits for `ready()` - crash recovery has to decide first, or a new empty document overwrites the autosave the user is about to be offered - and skips while `busy()`. Failures come back as `error` rather than being swallowed. |
+
+## `src/hooks/useServerProbe.js`
+
+Whether the project-storage API is reachable, re-checked with a backoff.
+
+| | |
+|---|---|
+| `useServerProbe` | Polls with `nextProbeDelay` backoff and resets on window focus. Checking only once was the original bug: a server that was down at load stayed "down" all session, so the menus never rendered and clicking did nothing. |
+
 ## `src/hooks/useTimelineGestures.js`
 
 Every way the timeline can be pointed at, in one place.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,8 @@ import { useTimelineGestures } from './hooks/useTimelineGestures.js';
 import { fmt, parseClock } from './core/timeCode.js';
 import { useHistory } from './hooks/useHistory.js';
 import { usePlayback } from './hooks/usePlayback.js';
+import { useServerProbe } from './hooks/useServerProbe.js';
+import { useAutosave } from './hooks/useAutosave.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
 import { playbackStartFrom } from './core/playbackStart.js';
 import {
@@ -438,8 +440,6 @@ export default function App() {
     const textAreaRef = useRef(null);
     const textDragRef = useRef(null);
     const textMeasureCtxRef = useRef(null);
-    const [autoSavedAt, setAutoSavedAt] = useState(null);
-    const autosaveTimerRef = useRef(null);
     const didRecoverRef = useRef(false);
     const [view, setView] = useState({ zoom: 1, x: 0, y: 0 });
     const touchPtsRef = useRef(new Map());
@@ -447,7 +447,6 @@ export default function App() {
     const tlTouchRef = useRef(new Map());
     const tlPinchRef = useRef(null);
     const [serverProjects, setServerProjects] = useState(null); // null = picker closed
-    const [serverAvailable, setServerAvailable] = useState(false); // is the project API reachable?
     const [serverBusy, setServerBusy] = useState(false);
     const [localProjects, setLocalProjects] = useState(null); // IndexedDB project picker
     const localIdRef = useRef(null);
@@ -470,8 +469,11 @@ export default function App() {
     const [backupAt, setBackupAt] = useState(null);      // time of the last server backup
     const [backupBusy, setBackupBusy] = useState(false);
     const [backupList, setBackupList] = useState(null);  // null = the list is closed
+    // Whether the project API is reachable. Re-checked with a backoff rather than once, because
+    // an app that decided at load time is an app that never notices the server starting.
+    const serverAvailable = useServerProbe();
+
     const [storageInfo, setStorageInfo] = useState(null); // local storage usage
-    const [autosaveErr, setAutosaveErr] = useState(null); // why autosave failed - never swallowed silently
     const [loadProgress, setLoadProgress] = useState(null); // {label, done, total}; total 0 means the length is unknown
     const backupKeyRef = useRef(null);
     const backupBusyRef = useRef(false);
@@ -1587,63 +1589,23 @@ export default function App() {
         return () => { cancelled = true; };
     }, []);
 
-    // Probe the project-storage API once; hide server menu when absent (static host / APK).
-    useEffect(() => {
-        let alive = true;
-        // Checking once means that if the server happened to be down when the page loaded, the
-        // app stays convinced it is down for the whole session. The YouTube menu entries then
-        // never render at all, so clicking does nothing and the console stays empty - which is
-        // exactly how one bug here hid for so long. Re-checking periodically lets it reconnect
-        // on its own once the server comes back.
-        //
-        // The interval backs off as failures pile up (see probeBackoff). A deployment has no
-        // server and never will until one is hosted, so a fixed poll there is a request failing
-        // every ten seconds for as long as the tab is open. Focus still forces an immediate
-        // check, so starting the server locally and switching back does not wait for the timer.
-        let failures = 0;
-        let timer = /** @type {any} */ (0);
-        const schedule = () => {
-            if (!alive) return;
-            clearTimeout(timer);
-            timer = setTimeout(probe, nextProbeDelay(failures));
-        };
-        const probe = () => fetch('/api/projects', { method: 'GET' })
-            .then(r => {
-                if (!alive) return;
-                failures = r.ok ? 0 : failures + 1;
-                setServerAvailable(r.ok);
-            })
-            .catch(() => {
-                if (!alive) return;
-                failures++;
-                setServerAvailable(false);
-            })
-            .finally(schedule);
-        probe();
-        // Coming back to the tab is the moment the server has most likely just been started, so
-        // the backoff is reset rather than merely interrupted.
-        const onFocus = () => { failures = 0; probe(); };
-        window.addEventListener('focus', onFocus);
-        return () => { alive = false; clearTimeout(timer); window.removeEventListener('focus', onFocus); };
-    }, []);
 
-    // Debounced autosave to IndexedDB so a refresh/crash never loses work.
-    useEffect(() => {
-        if (!didRecoverRef.current) return;
-        if (isDrawing.current || isDraggingOrResizingRef.current) return;
-        clearTimeout(autosaveTimerRef.current);
-        autosaveTimerRef.current = setTimeout(async () => {
-            try {
-                gcBitmaps(); // reclaim orphaned bitmaps before encoding the save
-                const data = await buildData(false, null, true); // IDB stores frame Blobs → cheap, low-memory
-                // Swallowing an autosave failure lets the user believe their work is being saved
-                // right up until they lose all of it.
-                saveAutosave(data).then(() => { setAutoSavedAt(Date.now()); setAutosaveErr(null); })
-                    .catch(e => setAutosaveErr(String(e?.message || e)));
-            } catch (e) { setAutosaveErr(String(e?.message || e)); }
-        }, 1500);
-        return () => clearTimeout(autosaveTimerRef.current);
-    }, [cuts, numTracks, onionPrev, onionNext, pps]);
+
+    // Debounced autosave to IndexedDB, so a refresh or a crash never costs work. It waits for
+    // crash recovery to finish deciding - otherwise a new empty document overwrites the autosave
+    // the user is about to be offered - and skips mid-gesture, where a half-drawn stroke is not
+    // worth keeping and encoding one costs frames.
+    const autosaveDoc = useMemo(() => ({ cuts, numTracks, onionPrev, onionNext, pps }), [cuts, numTracks, onionPrev, onionNext, pps]);
+    const { savedAt: autoSavedAt, error: autosaveErr } = useAutosave({
+        doc: autosaveDoc,
+        ready: () => didRecoverRef.current,
+        busy: () => isDrawing.current || isDraggingOrResizingRef.current,
+        build: () => {
+            gcBitmaps();                       // reclaim orphaned bitmaps before encoding
+            return buildData(false, null, true); // IDB stores frame Blobs -> cheap, low-memory
+        },
+        save: saveAutosave,
+    });
 
     const handleAddCut = () => {
         const last = cuts[cuts.length - 1];

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -1,0 +1,59 @@
+// Saving to IndexedDB in the background, so a refresh or a crash never costs work.
+//
+// Debounced rather than immediate: the document changes on every stroke, and encoding a project
+// with an imported video takes long enough that doing it per stroke would be felt.
+//
+// Two guards, both learned the hard way. It does not run until crash recovery has decided whether
+// to restore - otherwise an empty new document overwrites the autosave the user was about to be
+// offered. And it does not run mid-gesture, because a half-drawn stroke is not a state worth
+// keeping and encoding one costs frames.
+//
+// Failures are surfaced, never swallowed. An autosave that quietly stops working lets somebody
+// believe their work is being saved right up until they lose all of it, which is the worst
+// possible way for this to fail.
+
+import { useState, useRef, useEffect } from 'react';
+
+/**
+ * @param {object} opts
+ * @param {unknown} opts.doc the document as one memoised value; a change to it means a save is
+ *   due. One value rather than a list of them, because a spread dependency array is something
+ *   the linter cannot verify, and an unmemoised array would be new on every render.
+ * @param {() => boolean} opts.ready false until crash recovery has finished deciding
+ * @param {() => boolean} opts.busy true mid-gesture, when a snapshot is not worth taking
+ * @param {() => Promise<any>} opts.build produce the object to store
+ * @param {(data: any) => Promise<any>} opts.save write it
+ * @param {number} [opts.delay] quiet period before saving, in ms
+ * @returns {{savedAt: number|null, error: string|null}}
+ */
+export function useAutosave({ doc, ready, busy, build, save, delay = 1500 }) {
+    const [savedAt, setSavedAt] = useState(/** @type {number|null} */(null));
+    const [error, setError] = useState(/** @type {string|null} */(null));
+    const timerRef = useRef(/** @type {any} */(null));
+
+    // Read through refs so the effect can depend on the watched values alone; naming the callbacks
+    // would re-run it every render, since they are rebuilt each time.
+    const fns = useRef({ ready, busy, build, save });
+    fns.current = { ready, busy, build, save };
+
+    useEffect(() => {
+        const { ready: isReady, busy: isBusy } = fns.current;
+        if (!isReady() || isBusy()) return;
+
+        clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(async () => {
+            try {
+                const data = await fns.current.build();
+                await fns.current.save(data);
+                setSavedAt(Date.now());
+                setError(null);
+            } catch (e) {
+                setError(String(e?.message || e));
+            }
+        }, delay);
+
+        return () => clearTimeout(timerRef.current);
+    }, [doc, delay]);
+
+    return { savedAt, error };
+}

--- a/src/hooks/useServerProbe.js
+++ b/src/hooks/useServerProbe.js
@@ -1,0 +1,56 @@
+// Is the project-storage API there?
+//
+// The app runs in three places that answer this differently: a dev machine with the server up, a
+// static deployment where there is no server and never will be, and an APK where there is not one
+// either. The server menu and the YouTube import hide themselves when the answer is no.
+//
+// Checking once was the original bug. If the server happened to be down at load, the app stayed
+// convinced of it for the whole session - the menu entries never rendered, so clicking did
+// nothing and the console stayed empty, which is how one bug here hid for a long time.
+//
+// So it re-checks, and backs off. A deployment that will never have a server would otherwise be a
+// failing request every ten seconds for as long as the tab is open. Focus resets the backoff
+// rather than merely interrupting it, because coming back to the tab is the moment the server has
+// most likely just been started.
+
+import { useState, useEffect } from 'react';
+import { nextProbeDelay } from '../core/probeBackoff.js';
+
+/**
+ * @param {string} [url] the endpoint to probe
+ * @returns {boolean} whether the API answered the last time it was asked
+ */
+export function useServerProbe(url = '/api/projects') {
+    const [available, setAvailable] = useState(false);
+
+    useEffect(() => {
+        let alive = true;
+        let failures = 0;
+        let timer = /** @type {any} */ (0);
+
+        const schedule = () => {
+            if (!alive) return;
+            clearTimeout(timer);
+            timer = setTimeout(probe, nextProbeDelay(failures));
+        };
+        const probe = () => fetch(url, { method: 'GET' })
+            .then(r => {
+                if (!alive) return;
+                failures = r.ok ? 0 : failures + 1;
+                setAvailable(r.ok);
+            })
+            .catch(() => {
+                if (!alive) return;
+                failures++;
+                setAvailable(false);
+            })
+            .finally(schedule);
+
+        probe();
+        const onFocus = () => { failures = 0; probe(); };
+        window.addEventListener('focus', onFocus);
+        return () => { alive = false; clearTimeout(timer); window.removeEventListener('focus', onFocus); };
+    }, [url]);
+
+    return available;
+}


### PR DESCRIPTION
Reopening as a new PR: #67's base branch was deleted when its predecessor merged, which closed it, and GitHub will not reopen a PR whose base is gone. Same branch, same commit.

Third of the three, **taken in pieces**. Project I/O is six hundred lines, and one hook for all of it would take twenty inputs and hand back a dozen functions — the shape I was avoiding when I left it alone. These two answer to nothing else.

## The server probe

Owns the only state it feeds, and carries a bug worth keeping written down:

> Checking once meant a server that happened to be down at load stayed "down" for the whole session — the menu entries never rendered, so clicking did nothing and the console stayed empty.

It re-checks with a backoff (a deployment that will never have a server should not be a failing request every ten seconds) and resets that backoff on focus, because coming back to the tab is when the server has most likely just been started.

## Autosave

Its two guards are the whole reason it is not a plain debounce:

- **waits for crash recovery to finish deciding** — otherwise a new empty document overwrites the autosave the user is about to be offered
- **skips mid-gesture** — a half-drawn stroke is not worth keeping, and encoding one costs frames

Failures come back as `error` rather than being swallowed. An autosave that quietly stops working lets somebody believe their work is safe right up until they lose it.

## One memoised value, not a spread

The first version spread `[cuts, numTracks, ...]` into the dependency array. That works, and the linter said it could not verify it — fair. It now takes one memoised value, the shape `useHistory` already uses, and the warning is gone rather than baselined.

## Verified

- [x] `npm run check` — 392 tests, typecheck, hook baseline, helper index, build clean