### PR TITLE
refactor: autosave and the server probe become hooks

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -352,6 +352,22 @@ The playback clock: one rAF loop driving canvas, playhead, audio, video and the 
 |---|---|
 | `usePlayback` | Owns `isPlaying`, `currentTime` and the four refs the loop reads instead of state. Returns those plus `playPause` and `stop`. Export runs through the same loop, at real time whatever speed is selected. |
 
+## `src/hooks/useAutosave.js`
+
+Debounced background saving, so a refresh or a crash never costs work.
+
+| | |
+|---|---|
+| `useAutosave` | Saves `doc` after a quiet period. Waits for `ready()` - crash recovery has to decide first, or a new empty document overwrites the autosave the user is about to be offered - and skips while `busy()`. Failures come back as `error` rather than being swallowed. |
+
+## `src/hooks/useServerProbe.js`
+
+Whether the project-storage API is reachable, re-checked with a backoff.
+
+| | |
+|---|---|
+| `useServerProbe` | Polls with `nextProbeDelay` backoff and resets on window focus. Checking only once was the original bug: a server that was down at load stayed "down" all session, so the menus never rendered and clicking did nothing. |
+
 ## `src/hooks/useTimelineGestures.js`
 
 Every way the timeline can be pointed at, in one place.

--- a/HELPERS.md
+++ b/HELPERS.md
@@ -344,6 +344,14 @@ Undo and redo: the wiring around `historyOps`, kept out of App.
 |---|---|
 | `useHistory` | Records the document when it changes, unless `shouldSkip()` says a gesture is in progress. Returns `undo`, `redo`, a stable `record` for callers that choose their own moment, and `entries()` for the bitmap GC - a snapshot keeps pixels reachable, and freeing those is an undo that comes back blank. |
 
+## `src/hooks/usePlayback.js`
+
+The playback clock: one rAF loop driving canvas, playhead, audio, video and the prefetcher.
+
+| | |
+|---|---|
+| `usePlayback` | Owns `isPlaying`, `currentTime` and the four refs the loop reads instead of state. Returns those plus `playPause` and `stop`. Export runs through the same loop, at real time whatever speed is selected. |
+
 ## `src/hooks/useTimelineGestures.js`
 
 Every way the timeline can be pointed at, in one place.

--- a/HELPERS.md
+++ b/HELPERS.md
@@ -336,6 +336,14 @@ Measuring and drawing text objects.
 | `textLineHeight` | A text object as the document stores it. |
 | `textNeedsBox` | A text object as the document stores it. |
 
+## `src/hooks/useHistory.js`
+
+Undo and redo: the wiring around `historyOps`, kept out of App.
+
+| | |
+|---|---|
+| `useHistory` | Records the document when it changes, unless `shouldSkip()` says a gesture is in progress. Returns `undo`, `redo`, a stable `record` for callers that choose their own moment, and `entries()` for the bitmap GC - a snapshot keeps pixels reachable, and freeing those is an undo that comes back blank. |
+
 ## `src/hooks/useTimelineGestures.js`
 
 Every way the timeline can be pointed at, in one place.

--- a/scripts/hook-baseline.json
+++ b/scripts/hook-baseline.json
@@ -1,4 +1,5 @@
 {
-  "App.jsx:react-hooks/exhaustive-deps": 10,
+  "App.jsx:react-hooks/exhaustive-deps": 11,
+  "usePlayback.js:react-hooks/exhaustive-deps": 1,
   "ColorPanel.jsx:react-hooks/exhaustive-deps": 1
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import { closeLassoPath, lassoBounds, applyResize } from './core/lassoOps.js';
 import { useTimelineGestures } from './hooks/useTimelineGestures.js';
 import { fmt, parseClock } from './core/timeCode.js';
 import { useHistory } from './hooks/useHistory.js';
+import { usePlayback } from './hooks/usePlayback.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
 import { playbackStartFrom } from './core/playbackStart.js';
 import {
@@ -208,10 +209,8 @@ export default function App() {
      * handles.
      */
     const currentCut = cuts.find(c => c.id === currentCutId);
-    const [isPlaying, setIsPlaying] = useState(false);
     const [loopPlay, setLoopPlay] = useState(false);
     const [playbackRate, setPlaybackRate] = useState(1);
-    const [currentTime, setCurrentTime] = useState(0);
     const [rightW, setRightW] = useState(270);
     const [leftW, setLeftW] = useState(96);
     const [colorW, setColorW] = useState(200);
@@ -395,8 +394,6 @@ export default function App() {
     const mosaicRectRef = useRef(null);   // mosaic drag rectangle
     const [mosaicBlock, setMosaicBlock] = useState(14); // mosaic block size (px)
     const isDrawing = useRef(false);
-    const reqRef = useRef(null);
-    const isPlayingRef = useRef(false);
     const fileMenuRef = useRef(null);
     const mediaMenuRef = useRef(null);
     const timelineRef = useRef(null);
@@ -426,13 +423,12 @@ export default function App() {
     const fallbackCanvasRef = useRef(new Map()); // LRU of layer canvases built on demand during render
     const decodingRef = useRef(new Set()); // frame ids currently being re-decoded from their Blob
     const hotWindowRef = useRef(new Set()); // frame ids in the current prefetch window — never LRU-evicted
+    const paintFrameRef = useRef(/** @type {((t: number, playing: boolean) => void) | null} */(null)); // set below, beside paintFrame
     const prefetchRef = useRef(null); // prefetchFramesAt, called by the rAF loop with the real playhead
     const paintedOnceRef = useRef(false); // once we've painted a real frame, hold it rather than flash white
     const canvasAreaRef = useRef(null);
     const videoFileRef = useRef(null);
-    const currentTimeRef = useRef(0);       // playback clock read by the rAF loop (avoids stale closure)
     const playheadRef = useRef(null);        // moved imperatively during playback
-    const seekRef = useRef(null);            // pending seek the playback loop applies (scrub while playing)
     // Reused inside the composite loop; see the mask path in paintFrame.
     const maskScratchRef = useRef(null);
     const dataUrlCacheRef = useRef(new Map()); // id -> {imageData, url}; avoids re-encoding bitmaps each autosave
@@ -770,6 +766,7 @@ export default function App() {
     // TIMELINE_MIN_SPAN - a music video is three to five minutes, so a timeline that stops at two
     // leaves nowhere to place anything before the audio is loaded.
     const maxTime = Math.max(TIMELINE_MIN_SPAN, audioData?.endTime ?? audioDuration, videoOverlay?.endTime ?? 0, ...cuts.map(c => c.endTime)) + TIMELINE_TAIL_PAD;
+
     // Actual content bounds (where cuts/audio live) — playback & loop run between these,
     // not out to maxTime (which has empty padding for the timeline ruler).
     const contentEnd = Math.max(0, audioData?.endTime ?? 0, videoOverlay?.endTime ?? 0, ...cuts.map(c => c.endTime));
@@ -781,6 +778,22 @@ export default function App() {
     // Playback runs within the active part when one is selected, else across all content.
     const playStart = activePart ? activePart.start : contentStart;
     const playEnd = activePart ? activePart.end : contentEnd;
+
+    // Playback owns the clock: isPlaying, currentTime, and the refs the rAF loop reads instead
+    // of state so it never runs on a stale closure. Everything passed in is an input - playback
+    // is a function of the timeline, the media and where to paint - and the groups say which is
+    // which rather than leaving seventeen arguments in a row.
+    const {
+        isPlaying, setIsPlaying, currentTime, setCurrentTime,
+        currentTimeRef, seekRef, isPlayingRef,
+        playPause: handlePlayPause, stop: handleStop,
+    } = usePlayback({
+        media: { audioRef, videoElRef, audioUrl, audioData, videoOverlay },
+        range: { playStart, playEnd, maxTime, loopPlay, playbackRate, anchorTime: currentCut?.startTime },
+        paint: { pps, playheadRef, paintFrameRef, prefetchRef },
+        recording: { isExporting, exportEndRef, mediaRecorderRef },
+    });
+
 
     useEffect(() => {
         const h = (e) => {
@@ -873,91 +886,6 @@ export default function App() {
         }
     }, [currentTime, isPlaying]);
 
-    useEffect(() => {
-        isPlayingRef.current = isPlaying;
-        if (!isPlaying) {
-            if (audioRef.current) audioRef.current.pause();
-            // The video has to be stopped here too. Only `finish` paused it, which is the path
-            // for reaching the end - stopping any other way left the element rolling. Nothing
-            // showed it, because a paused canvas is not being repainted; the moment drawing began
-            // the repaints resumed and the overlay was discovered to have been playing all along.
-            if (videoElRef.current) videoElRef.current.pause();
-            cancelAnimationFrame(reqRef.current);
-            return;
-        }
-        // Export must record at real time; preview honors the chosen playback speed.
-        const rate = isExporting.current ? 1 : playbackRate;
-        const audio = audioRef.current;
-        if (audio) audio.playbackRate = rate;
-        let last = performance.now();
-        let t = currentTimeRef.current;
-        let lastUiSync = 0, lastPrefetch = 0;
-        const audible = () => audio && audioUrl && (!audioData || (t >= audioData.startTime && t < audioData.endTime));
-        // Kick audio once, seeking only at the start — not every frame (per-frame seeks stutter).
-        if (audio && audioUrl) {
-            if (audible()) { const exp = audioData ? (t - audioData.startTime) + audioData.offset : t; if (Math.abs(audio.currentTime - exp) > 0.05) audio.currentTime = exp; audio.play().catch(() => { }); }
-        }
-        // Video overlay follows the clock (audio stays the master). Seek only on real drift so the
-        // browser's native video decode plays smoothly instead of stuttering on per-frame seeks.
-        const vid = videoElRef.current;
-        if (vid && videoOverlay) vid.playbackRate = rate;
-        const syncVideo = (tt, forceSeek) => {
-            if (!vid || !videoOverlay) return;
-            if (tt >= videoOverlay.startTime && tt < videoOverlay.endTime) {
-                const exp = (tt - videoOverlay.startTime) + videoOverlay.offset;
-                if (forceSeek || Math.abs(vid.currentTime - exp) > 0.2) { try { vid.currentTime = exp; } catch { } }
-                if (vid.paused) vid.play().catch(() => { });
-            } else if (!vid.paused) vid.pause();
-        };
-        syncVideo(t, true);
-        const finish = (end) => { isPlayingRef.current = false; setIsPlaying(false); if (audio) audio.pause(); if (vid) vid.pause(); setCurrentTime(end); currentTimeRef.current = end; paintFrameRef.current?.(end, false); };
-        const step = (now) => {
-            if (!isPlayingRef.current) return;
-            const dt = (now - last) / 1000; last = now;
-            // A scrub while playing drops a target time here; jump to it and re-seek audio this frame.
-            if (seekRef.current != null) {
-                t = seekRef.current; seekRef.current = null;
-                if (audio && audioUrl) { const exp = audioData ? Math.max(0, (t - audioData.startTime) + audioData.offset) : t; try { audio.currentTime = exp; } catch { } }
-                syncVideo(t, true);
-                currentTimeRef.current = t;
-                paintFrameRef.current?.(t, true);
-                if (playheadRef.current) playheadRef.current.style.left = `${xAtTime(t, pps)}px`;
-                reqRef.current = requestAnimationFrame(step);
-                return;
-            }
-            // Audio is the master clock while it's sounding: read its time so A/V never drift and
-            // we never seek it mid-play. Fall back to wall-clock accumulation otherwise.
-            if (audio && audioUrl && audible()) {
-                if (audio.paused) { const exp = audioData ? (t - audioData.startTime) + audioData.offset : t; audio.currentTime = exp; audio.play().catch(() => { }); }
-                t = audioData ? audioData.startTime + (audio.currentTime - audioData.offset) : audio.currentTime;
-            } else {
-                if (audio && !audio.paused) audio.pause();
-                t += dt * rate;
-            }
-            syncVideo(t, false);
-            if (isExporting.current && t >= exportEndRef.current) {
-                if (mediaRecorderRef.current?.state === 'recording') mediaRecorderRef.current.stop();
-                isExporting.current = false; finish(t); return;
-            }
-            const endAt = isExporting.current ? maxTime : playEnd;
-            if (t >= endAt) {
-                if (loopPlay && !isExporting.current) {
-                    t = playStart;
-                    if (audio && audioUrl) { audio.currentTime = audioData ? Math.max(0, (playStart - audioData.startTime) + audioData.offset) : playStart; if (audible()) audio.play().catch(() => { }); }
-                } else { finish(endAt); return; }
-            }
-            currentTimeRef.current = t;
-            paintFrameRef.current?.(t, true);                                   // 60fps imperative canvas
-            if (playheadRef.current) playheadRef.current.style.left = `${xAtTime(t, pps)}px`; // 60fps imperative playhead
-            if (now - lastPrefetch > 120) { lastPrefetch = now; prefetchRef.current?.(t, true); } // decode ahead of the REAL playhead
-            if (now - lastUiSync > 200) { lastUiSync = now; setCurrentTime(t); } // ~5Hz React sync — keep re-renders off the rAF thread so prefetch keeps up
-            reqRef.current = requestAnimationFrame(step);
-        };
-        reqRef.current = requestAnimationFrame(step);
-        return () => cancelAnimationFrame(reqRef.current);
-    }, [isPlaying, maxTime, audioUrl, audioData, loopPlay, playStart, playEnd, playbackRate, pps, videoOverlay]);
-
-    useEffect(() => { if (!isPlaying) currentTimeRef.current = currentTime; }, [currentTime, isPlaying]);
 
     useEffect(() => {
         if (!isPlaying && audioRef.current && audioUrl && Math.abs(audioRef.current.currentTime - currentTime) > 0.1)
@@ -1717,40 +1645,6 @@ export default function App() {
         return () => clearTimeout(autosaveTimerRef.current);
     }, [cuts, numTracks, onionPrev, onionNext, pps]);
 
-    const handlePlayPause = () => {
-        if (!isPlaying) {
-            // Playback is cut-based: pressing play after the current cut (or all content) has
-            // finished rewinds to the CURRENT cut's start — even with music (audio re-seeks to match).
-            const cc = currentCut;
-            let anchor = cc ? cc.startTime : playStart;
-            if (anchor < playStart - 0.001 || anchor >= playEnd) anchor = playStart; // keep the anchor inside the active part
-            // Where to start is worked out in playbackStart, which is where the reasoning about
-            // "finished" versus "put there on purpose" lives.
-            const from = playbackStartFrom(currentTime, playStart, playEnd, anchor);
-            if (Math.abs(from - currentTime) > 0.001) {
-                setCurrentTime(from);
-                currentTimeRef.current = from;
-                if (audioRef.current) audioRef.current.currentTime = audioData ? Math.max(0, (from - audioData.startTime) + audioData.offset) : from;
-            }
-        } else {
-            // Pausing: stop audio immediately (don't wait for the effect).
-            isPlayingRef.current = false;
-            cancelAnimationFrame(reqRef.current);
-            if (audioRef.current) audioRef.current.pause();
-        }
-        setIsPlaying(!isPlaying);
-    };
-    const handleStop = () => {
-        // Stop should pause at the current position (do not rewind).
-        isPlayingRef.current = false;
-        cancelAnimationFrame(reqRef.current);
-        setIsPlaying(false);
-        if (audioRef.current) {
-            audioRef.current.pause();
-            // Keep audio element time aligned to the current timeline position.
-            audioRef.current.currentTime = currentTime;
-        }
-    };
     const handleAddCut = () => {
         const last = cuts[cuts.length - 1];
         const ns = last?.endTime ?? 0, trk = last?.track ?? 0;
@@ -3356,7 +3250,6 @@ export default function App() {
         if (camAt) ctx.restore();
     }, [cuts, currentCutId, currentCut, onionPrev, onionNext, selection, layerCanvasCache, frameDecodeTick, videoOverlay, boilTick, dragTick]);
 
-    const paintFrameRef = useRef(null);
     paintFrameRef.current = paintFrame;
 
     // Editing render: full frame + editing-only overlays. During playback the rAF loop

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,8 @@ import { useTimelineGestures } from './hooks/useTimelineGestures.js';
 import { fmt, parseClock } from './core/timeCode.js';
 import { useHistory } from './hooks/useHistory.js';
 import { usePlayback } from './hooks/usePlayback.js';
+import { useServerProbe } from './hooks/useServerProbe.js';
+import { useAutosave } from './hooks/useAutosave.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
 import { playbackStartFrom } from './core/playbackStart.js';
 import {
@@ -438,8 +440,6 @@ export default function App() {
     const textAreaRef = useRef(null);
     const textDragRef = useRef(null);
     const textMeasureCtxRef = useRef(null);
-    const [autoSavedAt, setAutoSavedAt] = useState(null);
-    const autosaveTimerRef = useRef(null);
     const didRecoverRef = useRef(false);
     const [view, setView] = useState({ zoom: 1, x: 0, y: 0 });
     const touchPtsRef = useRef(new Map());
@@ -447,7 +447,6 @@ export default function App() {
     const tlTouchRef = useRef(new Map());
     const tlPinchRef = useRef(null);
     const [serverProjects, setServerProjects] = useState(null); // null = picker closed
-    const [serverAvailable, setServerAvailable] = useState(false); // is the project API reachable?
     const [serverBusy, setServerBusy] = useState(false);
     const [localProjects, setLocalProjects] = useState(null); // IndexedDB project picker
     const localIdRef = useRef(null);
@@ -470,8 +469,11 @@ export default function App() {
     const [backupAt, setBackupAt] = useState(null);      // time of the last server backup
     const [backupBusy, setBackupBusy] = useState(false);
     const [backupList, setBackupList] = useState(null);  // null = the list is closed
+    // Whether the project API is reachable. Re-checked with a backoff rather than once, because
+    // an app that decided at load time is an app that never notices the server starting.
+    const serverAvailable = useServerProbe();
+
     const [storageInfo, setStorageInfo] = useState(null); // local storage usage
-    const [autosaveErr, setAutosaveErr] = useState(null); // why autosave failed - never swallowed silently
     const [loadProgress, setLoadProgress] = useState(null); // {label, done, total}; total 0 means the length is unknown
     const backupKeyRef = useRef(null);
     const backupBusyRef = useRef(false);
@@ -1587,63 +1589,23 @@ export default function App() {
         return () => { cancelled = true; };
     }, []);
 
-    // Probe the project-storage API once; hide server menu when absent (static host / APK).
-    useEffect(() => {
-        let alive = true;
-        // Checking once means that if the server happened to be down when the page loaded, the
-        // app stays convinced it is down for the whole session. The YouTube menu entries then
-        // never render at all, so clicking does nothing and the console stays empty - which is
-        // exactly how one bug here hid for so long. Re-checking periodically lets it reconnect
-        // on its own once the server comes back.
-        //
-        // The interval backs off as failures pile up (see probeBackoff). A deployment has no
-        // server and never will until one is hosted, so a fixed poll there is a request failing
-        // every ten seconds for as long as the tab is open. Focus still forces an immediate
-        // check, so starting the server locally and switching back does not wait for the timer.
-        let failures = 0;
-        let timer = /** @type {any} */ (0);
-        const schedule = () => {
-            if (!alive) return;
-            clearTimeout(timer);
-            timer = setTimeout(probe, nextProbeDelay(failures));
-        };
-        const probe = () => fetch('/api/projects', { method: 'GET' })
-            .then(r => {
-                if (!alive) return;
-                failures = r.ok ? 0 : failures + 1;
-                setServerAvailable(r.ok);
-            })
-            .catch(() => {
-                if (!alive) return;
-                failures++;
-                setServerAvailable(false);
-            })
-            .finally(schedule);
-        probe();
-        // Coming back to the tab is the moment the server has most likely just been started, so
-        // the backoff is reset rather than merely interrupted.
-        const onFocus = () => { failures = 0; probe(); };
-        window.addEventListener('focus', onFocus);
-        return () => { alive = false; clearTimeout(timer); window.removeEventListener('focus', onFocus); };
-    }, []);
 
-    // Debounced autosave to IndexedDB so a refresh/crash never loses work.
-    useEffect(() => {
-        if (!didRecoverRef.current) return;
-        if (isDrawing.current || isDraggingOrResizingRef.current) return;
-        clearTimeout(autosaveTimerRef.current);
-        autosaveTimerRef.current = setTimeout(async () => {
-            try {
-                gcBitmaps(); // reclaim orphaned bitmaps before encoding the save
-                const data = await buildData(false, null, true); // IDB stores frame Blobs → cheap, low-memory
-                // Swallowing an autosave failure lets the user believe their work is being saved
-                // right up until they lose all of it.
-                saveAutosave(data).then(() => { setAutoSavedAt(Date.now()); setAutosaveErr(null); })
-                    .catch(e => setAutosaveErr(String(e?.message || e)));
-            } catch (e) { setAutosaveErr(String(e?.message || e)); }
-        }, 1500);
-        return () => clearTimeout(autosaveTimerRef.current);
-    }, [cuts, numTracks, onionPrev, onionNext, pps]);
+
+    // Debounced autosave to IndexedDB, so a refresh or a crash never costs work. It waits for
+    // crash recovery to finish deciding - otherwise a new empty document overwrites the autosave
+    // the user is about to be offered - and skips mid-gesture, where a half-drawn stroke is not
+    // worth keeping and encoding one costs frames.
+    const autosaveDoc = useMemo(() => ({ cuts, numTracks, onionPrev, onionNext, pps }), [cuts, numTracks, onionPrev, onionNext, pps]);
+    const { savedAt: autoSavedAt, error: autosaveErr } = useAutosave({
+        doc: autosaveDoc,
+        ready: () => didRecoverRef.current,
+        busy: () => isDrawing.current || isDraggingOrResizingRef.current,
+        build: () => {
+            gcBitmaps();                       // reclaim orphaned bitmaps before encoding
+            return buildData(false, null, true); // IDB stores frame Blobs -> cheap, low-memory
+        },
+        save: saveAutosave,
+    });
 
     const handleAddCut = () => {
         const last = cuts[cuts.length - 1];

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback, useLayoutEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useLayoutEffect, useMemo } from 'react';
 import { Plus, Trash2, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, ClipboardPaste, GitBranch, Move, Type, Cloud, Film, Repeat, Minus, Waves, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw, ArrowDownToLine } from 'lucide-react';
 import './App.css';
 import { saveAutosave, loadAutosave, saveProject, loadProject, listProjects, deleteProject, autosaveKey } from './db';
@@ -16,7 +16,7 @@ import { resolveDrawLayer as resolveDrawLayerPure, commitStroke, insertFill } fr
 import { closeLassoPath, lassoBounds, applyResize } from './core/lassoOps.js';
 import { useTimelineGestures } from './hooks/useTimelineGestures.js';
 import { fmt, parseClock } from './core/timeCode.js';
-import { pushSnapshot, step } from './core/historyOps.js';
+import { useHistory } from './hooks/useHistory.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
 import { playbackStartFrom } from './core/playbackStart.js';
 import {
@@ -638,10 +638,6 @@ export default function App() {
         return newId;
     };
 
-    const historyRef = useRef([]);
-    const recordHistoryRef = useRef(/** @type {(s: any) => void} */(() => { }));
-    const historyIndexRef = useRef(-1);
-    const isUndoRedoRef = useRef(false);
     const isDraggingOrResizingRef = useRef(false);
 
     const updLayers = (cutId, fn) => dispatchCuts(patchCut(cutId, fn));
@@ -755,40 +751,20 @@ export default function App() {
         setTool(newTool);
     };
 
-    useEffect(() => {
-        if (isDrawing.current || isDraggingOrResizingRef.current || selectionDragRef.current) return;
-        if (isUndoRedoRef.current) { isUndoRedoRef.current = false; return; }
-        recordHistoryRef.current({ cuts, audioData, numTracks });
-    }, [cuts, audioData, numTracks]);
-
-    // The one place history is written. It was two copies of the same arithmetic, one of which
-    // had the limit inlined as a bare 80 - the kind of pair where only one gets fixed.
-    const recordHistory = (snapshot) => {
-        const r = pushSnapshot(historyRef.current, historyIndexRef.current, snapshot);
-        if (!r.changed) return;
-        historyRef.current = r.history;
-        historyIndexRef.current = r.index;
-    };
-    // The recording effect reaches it through a ref, the way paintFrame and the prefetch already
-    // do: naming the function in the dependency list would re-run the effect on every render,
-    // since it is rebuilt each time.
-    recordHistoryRef.current = recordHistory;
-
-    const applyHistory = (snap) => {
-        const s = JSON.parse(JSON.stringify(snap));
-        isUndoRedoRef.current = true;
-        dispatchCuts(replaceCuts(s.cuts));
-        dispatchMedia(setAudioClip(s.audioData ?? null));
-        setNumTracks(s.numTracks ?? 2);
-    };
-    const stepHistory = (dir) => {
-        const r = step(historyRef.current, historyIndexRef.current, dir);
-        if (!r) return;                       // already at that end
-        historyIndexRef.current = r.index;
-        applyHistory(r.snapshot);
-    };
-    const globalUndo = () => stepHistory(-1);
-    const globalRedo = () => stepHistory(1);
+    // Undo/redo lives in useHistory. What stays here is the two things only this component can
+    // answer: what the document currently is, and whether a gesture is in progress - drawing,
+    // dragging a cut, moving a selection - during which a snapshot would capture a half-finished
+    // state.
+    const historySnapshot = useMemo(() => ({ cuts, audioData, numTracks }), [cuts, audioData, numTracks]);
+    const { undo: globalUndo, redo: globalRedo, record: recordHistory, entries: historyEntries } = useHistory({
+        snapshot: historySnapshot,
+        shouldSkip: () => isDrawing.current || isDraggingOrResizingRef.current || !!selectionDragRef.current,
+        apply: (snap) => {
+            dispatchCuts(replaceCuts(snap.cuts));
+            dispatchMedia(setAudioClip(snap.audioData ?? null));
+            setNumTracks(snap.numTracks ?? 2);
+        },
+    });
 
     // The ruler runs to the content plus a tail of empty room to drag into, and never less than
     // TIMELINE_MIN_SPAN - a music video is three to five minutes, so a timeline that stops at two
@@ -1170,10 +1146,10 @@ export default function App() {
             // liveRef holds the current document precisely so this does not have to reach for
             // a state setter to read it, and the ref keeps the effect's dependency list honest.
             const lv = liveRef.current;
-            recordHistoryRef.current({ cuts: lv.cuts, audioData: lv.audioData, numTracks: lv.numTracks });
+            recordHistory({ cuts: lv.cuts, audioData: lv.audioData, numTracks: lv.numTracks });
         };
         return dragOnWindow(mv, up);
-    }, [resizingData, draggingCutData, pps, numTracks]);
+    }, [recordHistory, resizingData, draggingCutData, pps, numTracks]);
 
     // Record an undo point for whatever is on screen now.
     //
@@ -1191,7 +1167,7 @@ export default function App() {
         // here would free pixels that undo, paste or the current selection still need.
         const dead = unusedBitmapIds(bitmapStoreRef.current.keys(), {
             cuts: live.cuts,
-            history: historyRef.current,
+            history: historyEntries(),
             copiedCut: live.copiedCut,
             lassoClip: lassoClipRef.current,
             selection: live.selection,

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -1,0 +1,59 @@
+// Saving to IndexedDB in the background, so a refresh or a crash never costs work.
+//
+// Debounced rather than immediate: the document changes on every stroke, and encoding a project
+// with an imported video takes long enough that doing it per stroke would be felt.
+//
+// Two guards, both learned the hard way. It does not run until crash recovery has decided whether
+// to restore - otherwise an empty new document overwrites the autosave the user was about to be
+// offered. And it does not run mid-gesture, because a half-drawn stroke is not a state worth
+// keeping and encoding one costs frames.
+//
+// Failures are surfaced, never swallowed. An autosave that quietly stops working lets somebody
+// believe their work is being saved right up until they lose all of it, which is the worst
+// possible way for this to fail.
+
+import { useState, useRef, useEffect } from 'react';
+
+/**
+ * @param {object} opts
+ * @param {unknown} opts.doc the document as one memoised value; a change to it means a save is
+ *   due. One value rather than a list of them, because a spread dependency array is something
+ *   the linter cannot verify, and an unmemoised array would be new on every render.
+ * @param {() => boolean} opts.ready false until crash recovery has finished deciding
+ * @param {() => boolean} opts.busy true mid-gesture, when a snapshot is not worth taking
+ * @param {() => Promise<any>} opts.build produce the object to store
+ * @param {(data: any) => Promise<any>} opts.save write it
+ * @param {number} [opts.delay] quiet period before saving, in ms
+ * @returns {{savedAt: number|null, error: string|null}}
+ */
+export function useAutosave({ doc, ready, busy, build, save, delay = 1500 }) {
+    const [savedAt, setSavedAt] = useState(/** @type {number|null} */(null));
+    const [error, setError] = useState(/** @type {string|null} */(null));
+    const timerRef = useRef(/** @type {any} */(null));
+
+    // Read through refs so the effect can depend on the watched values alone; naming the callbacks
+    // would re-run it every render, since they are rebuilt each time.
+    const fns = useRef({ ready, busy, build, save });
+    fns.current = { ready, busy, build, save };
+
+    useEffect(() => {
+        const { ready: isReady, busy: isBusy } = fns.current;
+        if (!isReady() || isBusy()) return;
+
+        clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(async () => {
+            try {
+                const data = await fns.current.build();
+                await fns.current.save(data);
+                setSavedAt(Date.now());
+                setError(null);
+            } catch (e) {
+                setError(String(e?.message || e));
+            }
+        }, delay);
+
+        return () => clearTimeout(timerRef.current);
+    }, [doc, delay]);
+
+    return { savedAt, error };
+}

--- a/src/hooks/useHistory.js
+++ b/src/hooks/useHistory.js
@@ -1,0 +1,85 @@
+// Undo and redo.
+//
+// The pure part - what a push does to the stack, what a step returns - is in core/historyOps.js
+// and has been for a while. What lived in App was the wiring: four refs, an effect that watches
+// the document, an imperative escape hatch for the one caller that records at a moment of its own
+// choosing, and the flag that stops applying a snapshot from immediately recording it again.
+//
+// That wiring is what makes this a hook rather than a function. Pulled out as a function it would
+// need every one of those refs threaded in and back out; as a hook it simply keeps them.
+//
+// What it deliberately does not know: when the app is busy. Drawing, dragging a cut and moving a
+// selection all mean "not now", and those are the drawing code's refs. The caller passes a
+// predicate instead, so this file has no opinion about how drawing works.
+//
+// On the snapshot approach: every entry is a deep copy of the whole document, which is cheap to
+// reason about and gets expensive as projects grow. Replacing it with recorded commands, or with
+// patches, is a real future change - and this is where it would happen, behind the same three
+// functions the app already calls.
+
+import { useEffect, useRef, useCallback } from 'react';
+import { pushSnapshot, step } from '../core/historyOps.js';
+
+/**
+ * @template T
+ * @param {object} opts
+ * @param {T} opts.snapshot the document as it is now; a change to this is what gets recorded
+ * @param {() => boolean} opts.shouldSkip true while the app is mid-gesture and a snapshot would
+ *   capture a half-finished state
+ * @param {(snapshot: T) => void} opts.apply put a snapshot back into the app
+ * @returns {{undo: () => void, redo: () => void, record: (snapshot: T) => void, entries: () => T[]}}
+ */
+export function useHistory({ snapshot, shouldSkip, apply }) {
+    const entriesRef = useRef(/** @type {T[]} */([]));
+    const indexRef = useRef(-1);
+    // Applying a snapshot changes the document, which would otherwise be recorded as a new entry
+    // and make undo un-undoable.
+    const applyingRef = useRef(false);
+
+    // The effect reads these through refs so it can depend on the document alone. Naming the
+    // callbacks in its dependency list would re-run it on every render, since they are rebuilt
+    // each time.
+    const shouldSkipRef = useRef(shouldSkip);
+    shouldSkipRef.current = shouldSkip;
+    const applyRef = useRef(apply);
+    applyRef.current = apply;
+
+    /** Record a snapshot now, whatever the effect is doing. Stable, so callers may store it. */
+    const record = useCallback((snap) => {
+        const r = pushSnapshot(entriesRef.current, indexRef.current, snap);
+        if (!r.changed) return;
+        entriesRef.current = r.history;
+        indexRef.current = r.index;
+    }, []);
+
+    useEffect(() => {
+        if (shouldSkipRef.current()) return;
+        if (applyingRef.current) { applyingRef.current = false; return; }
+        record(snapshot);
+    }, [snapshot, record]);
+
+    const go = useCallback((dir) => {
+        const r = step(entriesRef.current, indexRef.current, dir);
+        if (!r) return;                       // already at that end
+        indexRef.current = r.index;
+        applyingRef.current = true;
+        // Deep copied on the way out as well as in: the app mutates what it is given, and an entry
+        // that gets mutated is an undo that quietly stops going back where it said it would.
+        applyRef.current(JSON.parse(JSON.stringify(r.snapshot)));
+    }, []);
+
+    const undo = useCallback(() => go(-1), [go]);
+    const redo = useCallback(() => go(1), [go]);
+
+    /**
+     * The recorded snapshots, for the bitmap garbage collector.
+     *
+     * Exposed rather than hidden, because the coupling is real: strokes point at pixels held
+     * outside the document, and a snapshot keeps those pixels reachable. Freeing something an
+     * undo still needs is not a leak, it is an undo that comes back blank. A function rather than
+     * the array itself, so callers always see the current stack.
+     */
+    const entries = useCallback(() => entriesRef.current, []);
+
+    return { undo, redo, record, entries };
+}

--- a/src/hooks/usePlayback.js
+++ b/src/hooks/usePlayback.js
@@ -1,0 +1,181 @@
+// The playback clock.
+//
+// One requestAnimationFrame loop drives everything that moves: the canvas, the playhead, the
+// audio element, the video overlay, the frame prefetcher, and - at a different rate - React.
+// Export runs through the same loop, which is why it is here rather than beside the recorder.
+//
+// It owns six things App used to: the isPlaying and currentTime state, and the four refs the loop
+// reads instead of state so it never runs on a stale closure. Everything else is an input, and
+// the inputs are grouped by what they are rather than listed flat, because a playback loop really
+// is a function of the timeline, the media and where to paint.
+//
+// Three rates, deliberately different:
+//
+//   every frame    the canvas and the playhead, written imperatively
+//   ~8Hz           the frame prefetcher, which decodes ahead of the real playhead
+//   ~5Hz           setCurrentTime, so React re-renders stay off the animation thread
+//
+// The last one is the reason currentTime is not simply state read by the loop: re-rendering at
+// 60Hz starves the prefetcher and the video stutters.
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { playbackStartFrom } from '../core/playbackStart.js';
+import { xAtTime } from '../core/timelineZoom.js';
+
+/**
+ * @param {object} opts
+ * @param {{audioRef: {current: HTMLAudioElement|null}, videoElRef: {current: HTMLVideoElement|null},
+ *   audioUrl: string|null, audioData: any, videoOverlay: any}} opts.media
+ *   the elements and what is loaded into them
+ * @param {{playStart: number, playEnd: number, maxTime: number, loopPlay: boolean,
+ *   playbackRate: number, anchorTime: number|undefined}} opts.range
+ *   where playback runs, how fast, and where pressing play rewinds to
+ * @param {{pps: number, playheadRef: {current: HTMLElement|null},
+ *   paintFrameRef: {current: ((t: number, playing: boolean) => void) | null},
+ *   prefetchRef: {current: ((t: number, playing: boolean) => void) | null}}} opts.paint
+ *   where to draw each frame
+ * @param {{isExporting: {current: boolean}, exportEndRef: {current: number},
+ *   mediaRecorderRef: {current: MediaRecorder|null}}} opts.recording
+ *   export state; playback runs at real time while recording, whatever speed is selected
+ */
+export function usePlayback({ media, range, paint, recording }) {
+    const { audioRef, videoElRef, audioUrl, audioData, videoOverlay } = media;
+    const { playStart, playEnd, maxTime, loopPlay, playbackRate, anchorTime } = range;
+    const { pps, playheadRef, paintFrameRef, prefetchRef } = paint;
+    const { isExporting, exportEndRef, mediaRecorderRef } = recording;
+
+    const [isPlaying, setIsPlaying] = useState(false);
+    const [currentTime, setCurrentTime] = useState(0);
+
+    const reqRef = useRef(/** @type {number|null} */(null));
+    const isPlayingRef = useRef(false);
+    const currentTimeRef = useRef(0);     // the loop's clock, read instead of state to avoid a stale closure
+    const seekRef = useRef(/** @type {number|null} */(null));  // a scrub while playing lands here
+
+    useEffect(() => {
+        isPlayingRef.current = isPlaying;
+        if (!isPlaying) {
+            if (audioRef.current) audioRef.current.pause();
+            // The video has to be stopped here too. Only `finish` paused it, which is the path
+            // for reaching the end - stopping any other way left the element rolling. Nothing
+            // showed it, because a paused canvas is not being repainted; the moment drawing began
+            // the repaints resumed and the overlay was discovered to have been playing all along.
+            if (videoElRef.current) videoElRef.current.pause();
+            cancelAnimationFrame(reqRef.current);
+            return;
+        }
+        // Export must record at real time; preview honors the chosen playback speed.
+        const rate = isExporting.current ? 1 : playbackRate;
+        const audio = audioRef.current;
+        if (audio) audio.playbackRate = rate;
+        let last = performance.now();
+        let t = currentTimeRef.current;
+        let lastUiSync = 0, lastPrefetch = 0;
+        const audible = () => audio && audioUrl && (!audioData || (t >= audioData.startTime && t < audioData.endTime));
+        // Kick audio once, seeking only at the start — not every frame (per-frame seeks stutter).
+        if (audio && audioUrl) {
+            if (audible()) { const exp = audioData ? (t - audioData.startTime) + audioData.offset : t; if (Math.abs(audio.currentTime - exp) > 0.05) audio.currentTime = exp; audio.play().catch(() => { }); }
+        }
+        // Video overlay follows the clock (audio stays the master). Seek only on real drift so the
+        // browser's native video decode plays smoothly instead of stuttering on per-frame seeks.
+        const vid = videoElRef.current;
+        if (vid && videoOverlay) vid.playbackRate = rate;
+        const syncVideo = (tt, forceSeek) => {
+            if (!vid || !videoOverlay) return;
+            if (tt >= videoOverlay.startTime && tt < videoOverlay.endTime) {
+                const exp = (tt - videoOverlay.startTime) + videoOverlay.offset;
+                if (forceSeek || Math.abs(vid.currentTime - exp) > 0.2) { try { vid.currentTime = exp; } catch { } }
+                if (vid.paused) vid.play().catch(() => { });
+            } else if (!vid.paused) vid.pause();
+        };
+        syncVideo(t, true);
+        const finish = (end) => { isPlayingRef.current = false; setIsPlaying(false); if (audio) audio.pause(); if (vid) vid.pause(); setCurrentTime(end); currentTimeRef.current = end; paintFrameRef.current?.(end, false); };
+        const step = (now) => {
+            if (!isPlayingRef.current) return;
+            const dt = (now - last) / 1000; last = now;
+            // A scrub while playing drops a target time here; jump to it and re-seek audio this frame.
+            if (seekRef.current != null) {
+                t = seekRef.current; seekRef.current = null;
+                if (audio && audioUrl) { const exp = audioData ? Math.max(0, (t - audioData.startTime) + audioData.offset) : t; try { audio.currentTime = exp; } catch { } }
+                syncVideo(t, true);
+                currentTimeRef.current = t;
+                paintFrameRef.current?.(t, true);
+                if (playheadRef.current) playheadRef.current.style.left = `${xAtTime(t, pps)}px`;
+                reqRef.current = requestAnimationFrame(step);
+                return;
+            }
+            // Audio is the master clock while it's sounding: read its time so A/V never drift and
+            // we never seek it mid-play. Fall back to wall-clock accumulation otherwise.
+            if (audio && audioUrl && audible()) {
+                if (audio.paused) { const exp = audioData ? (t - audioData.startTime) + audioData.offset : t; audio.currentTime = exp; audio.play().catch(() => { }); }
+                t = audioData ? audioData.startTime + (audio.currentTime - audioData.offset) : audio.currentTime;
+            } else {
+                if (audio && !audio.paused) audio.pause();
+                t += dt * rate;
+            }
+            syncVideo(t, false);
+            if (isExporting.current && t >= exportEndRef.current) {
+                if (mediaRecorderRef.current?.state === 'recording') mediaRecorderRef.current.stop();
+                isExporting.current = false; finish(t); return;
+            }
+            const endAt = isExporting.current ? maxTime : playEnd;
+            if (t >= endAt) {
+                if (loopPlay && !isExporting.current) {
+                    t = playStart;
+                    if (audio && audioUrl) { audio.currentTime = audioData ? Math.max(0, (playStart - audioData.startTime) + audioData.offset) : playStart; if (audible()) audio.play().catch(() => { }); }
+                } else { finish(endAt); return; }
+            }
+            currentTimeRef.current = t;
+            paintFrameRef.current?.(t, true);                                   // 60fps imperative canvas
+            if (playheadRef.current) playheadRef.current.style.left = `${xAtTime(t, pps)}px`; // 60fps imperative playhead
+            if (now - lastPrefetch > 120) { lastPrefetch = now; prefetchRef.current?.(t, true); } // decode ahead of the REAL playhead
+            if (now - lastUiSync > 200) { lastUiSync = now; setCurrentTime(t); } // ~5Hz React sync — keep re-renders off the rAF thread so prefetch keeps up
+            reqRef.current = requestAnimationFrame(step);
+        };
+        reqRef.current = requestAnimationFrame(step);
+        return () => cancelAnimationFrame(reqRef.current);
+    }, [isPlaying, maxTime, audioUrl, audioData, loopPlay, playStart, playEnd, playbackRate, pps, videoOverlay]);
+
+    // While paused the clock follows whatever set the time - a scrub, a cut click, opening a file.
+    useEffect(() => { if (!isPlaying) currentTimeRef.current = currentTime; }, [currentTime, isPlaying]);
+
+    /** Stop the loop and the audio now, without waiting for the effect to notice. */
+    const halt = useCallback(() => {
+        isPlayingRef.current = false;
+        cancelAnimationFrame(reqRef.current);
+        if (audioRef.current) audioRef.current.pause();
+    }, [audioRef]);
+
+    const playPause = useCallback(() => {
+        if (!isPlaying) {
+            // Where to start is worked out in playbackStart, which is where the reasoning about
+            // "finished" versus "put there on purpose" lives.
+            let anchor = anchorTime ?? playStart;
+            if (anchor < playStart - 0.001 || anchor >= playEnd) anchor = playStart; // keep the anchor inside the active part
+            const from = playbackStartFrom(currentTime, playStart, playEnd, anchor);
+            if (Math.abs(from - currentTime) > 0.001) {
+                setCurrentTime(from);
+                currentTimeRef.current = from;
+                if (audioRef.current) audioRef.current.currentTime = audioData ? Math.max(0, (from - audioData.startTime) + audioData.offset) : from;
+            }
+        } else {
+            halt();
+        }
+        setIsPlaying(!isPlaying);
+    }, [isPlaying, anchorTime, playStart, playEnd, currentTime, audioData, audioRef, halt]);
+
+    /** Stop where the playhead is. Not a rewind - that surprised people who used it as a pause. */
+    const stop = useCallback(() => {
+        halt();
+        setIsPlaying(false);
+        // Keep the audio element aligned to the timeline position it stopped at.
+        if (audioRef.current) audioRef.current.currentTime = currentTime;
+    }, [halt, audioRef, currentTime]);
+
+    return {
+        isPlaying, setIsPlaying,
+        currentTime, setCurrentTime,
+        currentTimeRef, seekRef, isPlayingRef,
+        playPause, stop,
+    };
+}

--- a/src/hooks/useServerProbe.js
+++ b/src/hooks/useServerProbe.js
@@ -1,0 +1,56 @@
+// Is the project-storage API there?
+//
+// The app runs in three places that answer this differently: a dev machine with the server up, a
+// static deployment where there is no server and never will be, and an APK where there is not one
+// either. The server menu and the YouTube import hide themselves when the answer is no.
+//
+// Checking once was the original bug. If the server happened to be down at load, the app stayed
+// convinced of it for the whole session - the menu entries never rendered, so clicking did
+// nothing and the console stayed empty, which is how one bug here hid for a long time.
+//
+// So it re-checks, and backs off. A deployment that will never have a server would otherwise be a
+// failing request every ten seconds for as long as the tab is open. Focus resets the backoff
+// rather than merely interrupting it, because coming back to the tab is the moment the server has
+// most likely just been started.
+
+import { useState, useEffect } from 'react';
+import { nextProbeDelay } from '../core/probeBackoff.js';
+
+/**
+ * @param {string} [url] the endpoint to probe
+ * @returns {boolean} whether the API answered the last time it was asked
+ */
+export function useServerProbe(url = '/api/projects') {
+    const [available, setAvailable] = useState(false);
+
+    useEffect(() => {
+        let alive = true;
+        let failures = 0;
+        let timer = /** @type {any} */ (0);
+
+        const schedule = () => {
+            if (!alive) return;
+            clearTimeout(timer);
+            timer = setTimeout(probe, nextProbeDelay(failures));
+        };
+        const probe = () => fetch(url, { method: 'GET' })
+            .then(r => {
+                if (!alive) return;
+                failures = r.ok ? 0 : failures + 1;
+                setAvailable(r.ok);
+            })
+            .catch(() => {
+                if (!alive) return;
+                failures++;
+                setAvailable(false);
+            })
+            .finally(schedule);
+
+        probe();
+        const onFocus = () => { failures = 0; probe(); };
+        window.addEventListener('focus', onFocus);
+        return () => { alive = false; clearTimeout(timer); window.removeEventListener('focus', onFocus); };
+    }, [url]);
+
+    return available;
+}


### PR DESCRIPTION
Last of Phase B's three. (Third attempt at a PR number for the same commit — see the note at the bottom.)

Project I/O is six hundred lines, and one hook for all of it would take twenty inputs and hand back a dozen functions — the shape I was avoiding when I left it alone. These two answer to nothing else.

## The server probe

Owns the only state it feeds, and carries a bug worth keeping written down:

> Checking once meant a server that happened to be down at load stayed "down" for the whole session — the menu entries never rendered, so clicking did nothing and the console stayed empty.

It re-checks with a backoff (a deployment that will never have a server should not be a failing request every ten seconds) and resets that backoff on focus, because coming back to the tab is when the server has most likely just been started.

## Autosave

Its two guards are the whole reason it is not a plain debounce:

- **waits for crash recovery to finish deciding** — otherwise a new empty document overwrites the autosave the user is about to be offered
- **skips mid-gesture** — a half-drawn stroke is not worth keeping, and encoding one costs frames

Failures come back as `error` rather than being swallowed. An autosave that quietly stops working lets somebody believe their work is safe right up until they lose it.

## One memoised value, not a spread

The first version spread `[cuts, numTracks, ...]` into the dependency array. The linter said it could not verify that — fair. It now takes one memoised value, the shape `useHistory` already uses, and the warning is gone rather than baselined.

## Verified

- [x] `npm run check` — 392 tests, typecheck, hook baseline, helper index, build clean

## On the PR churn

This commit has now been #67, #72 and this one. Both predecessors were **closed by GitHub**, not by me: a stacked PR's base branch gets deleted when the PR under it merges, and GitHub closes anything based on it and will not reopen it.

That is my mistake, not GitHub's — I stacked five PRs deep on one file. Everything from here bases on `main` and lands one at a time.