### PR TITLE
deps: Capacitor 7 to 8, verified by building the APK

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -37,10 +37,13 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
-      # Capacitor 7 with AGP 8.7 needs JDK 21; 17 fails at the Gradle configuration stage.
+      # Capacitor 8's CLI refuses to run below Node 22 - the first attempt at this upgrade
+      # compiled everything and then died in `cap sync`, which is a long way to find out.
+      #
+      # Capacitor with AGP 8.13 needs JDK 21; 17 fails at the Gradle configuration stage.
       - uses: actions/setup-java@v6
         with:
           distribution: temurin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       # npm ci needs the lockfile to match package.json exactly, which is the point: a dependency
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.google.gms:google-services:4.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,16 +1,16 @@
 ext {
-    minSdkVersion = 23
-    compileSdkVersion = 35
-    targetSdkVersion = 35
-    androidxActivityVersion = '1.9.2'
-    androidxAppCompatVersion = '1.7.0'
-    androidxCoordinatorLayoutVersion = '1.2.0'
-    androidxCoreVersion = '1.15.0'
-    androidxFragmentVersion = '1.8.4'
-    coreSplashScreenVersion = '1.0.1'
-    androidxWebkitVersion = '1.12.1'
+    minSdkVersion = 24
+    compileSdkVersion = 36
+    targetSdkVersion = 36
+    androidxActivityVersion = '1.11.0'
+    androidxAppCompatVersion = '1.7.1'
+    androidxCoordinatorLayoutVersion = '1.3.0'
+    androidxCoreVersion = '1.17.0'
+    androidxFragmentVersion = '1.8.9'
+    coreSplashScreenVersion = '1.2.0'
+    androidxWebkitVersion = '1.14.0'
     junitVersion = '4.13.2'
-    androidxJunitVersion = '1.2.1'
-    androidxEspressoCoreVersion = '3.6.1'
-    cordovaAndroidVersion = '10.1.1'
+    androidxJunitVersion = '1.3.0'
+    androidxEspressoCoreVersion = '3.7.0'
+    cordovaAndroidVersion = '14.0.1'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "easy-mv-maker",
       "version": "1.0.0",
       "dependencies": {
-        "@capacitor/android": "^7.0.0",
-        "@capacitor/core": "^7.0.0",
+        "@capacitor/android": "^8.5.1",
+        "@capacitor/core": "^8.5.1",
         "express": "^5.2.1",
         "lucide-react": "^1.37.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       },
       "devDependencies": {
-        "@capacitor/cli": "^7.0.0",
+        "@capacitor/cli": "^8.5.1",
         "@vitejs/plugin-react": "^6.1.1",
         "concurrently": "^10.0.5",
         "eslint": "^10.9.1",
@@ -269,18 +269,18 @@
       }
     },
     "node_modules/@capacitor/android": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-7.6.8.tgz",
-      "integrity": "sha512-N5LXe1ls+TA0mq+RhtyDdP1JISzAAI+OuLGL3G7OWQxfQQOZYkiEjEJMYqMV6JR421IqpRsYj08JOfC0PFC3NA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.5.1.tgz",
+      "integrity": "sha512-o8fUIPDSEASeXHHrDz26WU7OlyiRb+QqtI9KFdnLS1jUL77o5iGrvegibaZX8rWpiCyDJ6jlUhhhHlfeq3ou9A==",
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^7.6.0"
+        "@capacitor/core": "^8.5.0"
       }
     },
     "node_modules/@capacitor/cli": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-7.6.8.tgz",
-      "integrity": "sha512-sJYLoSS1wVHjDPwRc0grtNZcQZnkQc7TJKoVZdHL2HI5TPCq+27WBrMAo0mXvQQSH2axPYCz5cyRrcqqakOvxQ==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.5.1.tgz",
+      "integrity": "sha512-LKQFSyLg1QbTN6CGDoFqeRtAlj8C3c9OymP8OuhwlmkbSQwh9i1HQjwUCaNyVem2XkY9rv0v2UOfVlgoxH5pAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -300,6 +300,7 @@
         "semver": "^7.6.3",
         "tar": "^7.5.3",
         "tslib": "^2.8.1",
+        "xcode": "^3.0.1",
         "xml2js": "^0.6.2"
       },
       "bin": {
@@ -307,7 +308,7 @@
         "capacitor": "bin/capacitor"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@capacitor/cli/node_modules/semver": {
@@ -324,9 +325,9 @@
       }
     },
     "node_modules/@capacitor/core": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.6.8.tgz",
-      "integrity": "sha512-x1xfxvNcTSnj6OoYaAB0n0a0HRvi5f2YjcVnMLxpMhbHDgGDAzzN9z8cnPCYV+SKTvqGF1hezHm82Op32XaAGg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.5.1.tgz",
+      "integrity": "sha512-IOQ7ynG1qgrJ/RLuCO3WgyRGmkmmG/cdStRR4ftU2dWEN1FdtLrnI/XpZmZuUsOEHEnzBRJY/PmRH8eTLiXfhA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -1777,6 +1778,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bplist-creator": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
+      "integrity": "sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stream-buffers": "2.2.x"
       }
     },
     "node_modules/bplist-parser": {
@@ -4390,6 +4401,31 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-plist": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.3.1.tgz",
+      "integrity": "sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bplist-creator": "0.1.0",
+        "bplist-parser": "0.3.1",
+        "plist": "^3.0.5"
+      }
+    },
+    "node_modules/simple-plist/node_modules/bplist-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
+      "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -4458,6 +4494,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/string_decoder": {
@@ -4766,6 +4812,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4935,6 +4992,20 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xcode": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
+      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "simple-plist": "^1.1.0",
+        "uuid": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/xml2js": {
       "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     "smoke": "node test/smoke/boot.mjs"
   },
   "dependencies": {
-    "@capacitor/android": "^7.0.0",
-    "@capacitor/core": "^7.0.0",
+    "@capacitor/android": "^8.5.1",
+    "@capacitor/core": "^8.5.1",
     "express": "^5.2.1",
     "lucide-react": "^1.37.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@capacitor/cli": "^7.0.0",
+    "@capacitor/cli": "^8.5.1",
     "@vitejs/plugin-react": "^6.1.1",
     "concurrently": "^10.0.5",
     "eslint": "^10.9.1",


### PR DESCRIPTION
The other half of #62. Like vite, the three packages have to move together — core, cli and android — and Dependabot offering them separately produced PRs that could not install.

## The numbers are not guesses

A Capacitor major moves the Android toolchain with it. These come from the **project template shipped inside `@capacitor/cli` 8** — what a fresh project would get:

| | from | to |
|---|---|---|
| compileSdk / targetSdk | 35 | **36** |
| minSdk | 23 | 24 |
| AGP | 8.7.2 | 8.13.0 |
| Gradle | 8.11.1 | 8.14.3 |
| Node (CI) | 20 | **22** |
| androidx set | | matched to template |

compileSdk had to move: Capacitor 8's own library is built against 36, and an app cannot compile against a lower SDK than its dependency.

## The Node bump was found the hard way

The first build compiled everything and then died:

```
[fatal] The Capacitor CLI requires NodeJS >=22.0.0
```

That is exactly the class of thing that cannot be checked here — the Android SDK lives in CI, not on this machine — which is why this PR was not opened until the workflow had actually run.

All three workflow Node pins moved together, not only the one that broke. Two Node versions across workflows is how a build passes in one place and fails in another for reasons nobody thinks to look for.

## Verified by building it

```
Sync Capacitor            ✓
Assemble debug APK        ✓
artifact: easy-mv-maker-deps-capacitor-8-6be1134   3,957,063 bytes
```

Plus `npm run check` (405 tests, typecheck, hook baseline, helper index, build) and `npx cap sync` locally.

## Still on you

**Installing it.** That is #4 — the APK builds, and whether it runs on the tablet is the part CI cannot answer. The artifact above is downloadable from the run if you want to try it before this merges.
