### PR TITLE
refactor: evaluate the frame once, then draw it

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -362,6 +362,14 @@ The playback clock: one rAF loop driving canvas, playhead, audio, video and the 
 |---|---|
 | `usePlayback` | Owns `isPlaying`, `currentTime` and the four refs the loop reads instead of state. Returns those plus `playPause` and `stop`. Export runs through the same loop, at real time whatever speed is selected. |
 
+## `src/engine/evaluateFrame.js`
+
+What the frame looks like at time t, before anything is drawn.
+
+| | |
+|---|---|
+| `evaluateFrame` | Resolves the document to a scene: which cuts, their animation, their layer groups, their texts, and the camera. Pure and canvas-free. The renderer walks the result instead of working it out mid-draw, which is what removed `computeCutAnim` being called twice per cut per frame. |
+
 ## `src/engine/selectCuts.js`
 
 Which cuts a frame is made of. The first piece of the scene engine: playback, scrubbing, export,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,7 +46,8 @@ import { dragOnWindow } from './core/windowDrag.js';
 import { computeCamera, applyCamera } from './core/camera.js';
 import { clipGroups, canClip } from './core/clipping.js';
 import { setLayerClipped } from './core/cutsReducer.js';
-import { visibleCutsAt, onionNeighbours, topCutAt } from './engine/selectCuts.js';
+import { onionNeighbours, topCutAt } from './engine/selectCuts.js';
+import { evaluateFrame } from './engine/evaluateFrame.js';
 import { unusedBitmapIds } from './core/bitmapRefs.js';
 import { dragCut, resizeCut } from './core/cutOps.js';
 import {
@@ -3125,7 +3126,11 @@ export default function App() {
         // alive.
         boilPhaseRef.current = t * BOIL_FPS + boilTick;
         const primary = currentCut;
-        const activeCuts = visibleCutsAt(cuts, t, currentCutId, playing);
+        // Everything about *what* this frame is - which cuts, their animation, their layer
+        // groups, their texts, the camera - is worked out once, before anything is drawn.
+        // The two passes below then read the same answer instead of each recomputing it.
+        const scene = evaluateFrame(cuts, t, { playing, currentCutId, cw: CANVAS_W, ch: CANVAS_H });
+        const activeCuts = scene.cuts.map(e => e.cut);
         // Never flash white DURING PLAYBACK: if the frame we're about to show isn't decoded yet,
         // HOLD the last painted frame (skip this repaint) and kick a decode. The loop keeps advancing,
         // so it reads as a brief hold instead of a white flash. Paused/editing always paints normally
@@ -3149,10 +3154,7 @@ export default function App() {
         //
         // A shot belongs to the cut on the lowest active track: that is the base scene, and the
         // tracks above it are parts of the same shot rather than shots of their own.
-        const camCut = playing ? activeCuts.find(c => c.camera) : null;
-        const camAt = camCut
-            ? computeCamera(camCut.camera, cutProgress(camCut, t), CANVAS_W, CANVAS_H)
-            : null;
+        const camAt = scene.camera;
         if (camAt) { ctx.save(); applyCamera(ctx, camAt, CANVAS_W, CANVAS_H); }
         // Video overlay track: drawn underneath everything. The <video> element is kept at time t by
         // the playback loop (playing) or a paused-seek effect.
@@ -3192,15 +3194,7 @@ export default function App() {
             }
         }
 
-        activeCuts.forEach(ac => {
-            const visible = flattenLayersInUiOrder(ac.layers || []).filter(l => l.type === 'layer' && l.visible !== false);
-            // A clipped layer draws as part of the group below it rather than on its own, so the
-            // loop walks groups. With nothing clipped this is one group per layer and the code
-            // below behaves exactly as it did.
-            const order = clipGroups(visible).map(g => ({ ...g.base, __clip: g }));
-            // Cut-level animation (enter/exit/deform) applies only during playback/export,
-            // so editing stays at rest. Transform about the canvas centre.
-            const anim = playing ? computeCutAnim(ac, t, CANVAS_W, CANVAS_H) : null;
+        scene.cuts.forEach(({ cut: ac, anim, groups }) => {
             ctx.save();
             if (anim) {
                 ctx.globalAlpha = anim.alpha;
@@ -3209,13 +3203,14 @@ export default function App() {
                 ctx.translate(-CANVAS_W / 2, -CANVAS_H / 2);
             }
             // Draw bottom -> top so the topmost layer (UI top) is visually on top.
-            for (let i = order.length - 1; i >= 0; i--) {
-                const l = order[i];
-                const layerCanvas = flattenClipGroup(ac.id, l.__clip);
+            for (let i = groups.length - 1; i >= 0; i--) {
+                const group = groups[i];
+                const l = group.base;
+                const layerCanvas = flattenClipGroup(ac.id, group);
                 if (!layerCanvas) continue; // frame still decoding (part-scoped memory); will repaint when ready
 
                 // Per-layer ("part") transform nests inside the cut transform.
-                const la = playing ? computeLayerAnim(l, ac, t, CANVAS_W, CANVAS_H) : null;
+                const la = group.anim;
                 ctx.save();
                 if (la) {
                     if (la.alpha != null && la.alpha < 1) ctx.globalAlpha *= la.alpha; // keyframe opacity
@@ -3288,23 +3283,17 @@ export default function App() {
         });
 
         // Text objects live outside paint layers ("text layer").
-        activeCuts.forEach(ac => {
-            const anim = playing ? computeCutAnim(ac, t, CANVAS_W, CANVAS_H) : null;
+        scene.cuts.forEach(({ anim, texts }) => {
             ctx.save();
             if (anim) {
                 ctx.translate(CANVAS_W / 2 + anim.tx, CANVAS_H / 2 + anim.ty);
                 ctx.scale(anim.sx, anim.sy);
                 ctx.translate(-CANVAS_W / 2, -CANVAS_H / 2);
             }
-            const t2 = t; // the loop below names its text object t, shadowing the time t
-            for (const t of safeArray(ac.texts)) {
-                if (!t || t.visible === false) continue;
-                // Text animation only applies during playback, like cut animation.
-                const ta = playing ? computeTextAnim(t, ac, t2) : null;
-                if (ta && ta.alpha <= 0.001) continue;
-                drawTextObject(ctx, t, {
+            for (const { text, anim: ta } of texts) {
+                drawTextObject(ctx, text, {
                     anim: ta,
-                    box: textNeedsBox(t, ta) ? measureTextBox(t) : null,
+                    box: textNeedsBox(text, ta) ? measureTextBox(text) : null,
                     alpha: anim ? anim.alpha : 1,
                 });
             }

--- a/src/canvas/textRender.js
+++ b/src/canvas/textRender.js
@@ -8,6 +8,9 @@
  * simply does not have that key and every read below already has a default.
  *
  * @typedef {object} TextObject
+ * @property {any} [id] the document's identity for it; the renderer never reads this, but the
+ *   type has to admit it or a text taken straight from a cut is not assignable to it
+ * @property {boolean} [visible] likewise - hiding happens before anything gets here
  * @property {string} [text] the content, newline-separated for multiple lines
  * @property {number} [x] anchor, not the left edge - see measureTextBox
  * @property {number} [y] top of the first line

--- a/src/engine/evaluateFrame.js
+++ b/src/engine/evaluateFrame.js
@@ -1,0 +1,97 @@
+// What the frame looks like at time t, before anything is drawn.
+//
+// Second piece of the scene engine. Selection said which cuts are in the frame; this says what
+// state they are in - the cut's own animation, each layer group's, each text's, and where the
+// camera is looking.
+//
+// The renderer currently answers those questions inline, in the middle of drawing, which has two
+// costs. computeCutAnim is called twice per cut per frame, once in the layer pass and once in the
+// text pass, because the two passes cannot see each other's work. And nothing that needs a frame
+// without a canvas - export at a fixed frame rate, a thumbnail, a test - can ask for one.
+//
+// Everything here is pure and canvas-free. What stays in the renderer is the part that genuinely
+// needs a context: compositing clip groups, slicing for sway, the selection mask, and leaving out
+// a layer that the drag overlay is drawing instead.
+
+import { computeCutAnim, computeLayerAnim, computeTextAnim, flattenLayersInUiOrder, safeArray, cutProgress } from '../canvas/canvasUtils.js';
+import { computeCamera } from '../core/camera.js';
+import { clipGroups } from '../core/clipping.js';
+import { visibleCutsAt } from './selectCuts.js';
+
+/**
+ * @typedef {object} EvaluatedGroup
+ * @property {Layer} base the layer the group composites onto
+ * @property {Layer[]} clipped layers showing only where the base has paint, UI order
+ * @property {any} anim the base layer's transform for this instant, or null
+ */
+
+/**
+ * @typedef {object} EvaluatedCut
+ * @property {Cut} cut
+ * @property {any} anim cut-level animation for this instant, or null when paused
+ * @property {EvaluatedGroup[]} groups visible layers, grouped by clipping, UI order
+ * @property {{text: CutText, anim: any}[]} texts visible texts with their animation
+ */
+
+/**
+ * @typedef {object} Scene
+ * @property {{cx: number, cy: number, zoom: number, rot: number} | null} camera
+ * @property {EvaluatedCut[]} cuts bottom track first, which is drawing order
+ */
+
+/**
+ * Resolve the document to a frame.
+ *
+ * Animation is evaluated only while playing, which is not a shortcut - it is the rule the app is
+ * built on. A cut sitting still at rest is what makes it drawable: if the canvas were showing a
+ * mid-animation transform, the pen would land somewhere other than where the ink appears.
+ *
+ * @param {Cut[]} cuts
+ * @param {number} t
+ * @param {object} opts
+ * @param {boolean} opts.playing
+ * @param {any} opts.currentCutId the cut being edited, drawn even off the playhead while paused
+ * @param {number} opts.cw @param {number} opts.ch canvas size
+ * @returns {Scene}
+ */
+export function evaluateFrame(cuts, t, { playing, currentCutId, cw, ch }) {
+    const active = visibleCutsAt(cuts, t, currentCutId, playing);
+
+    // A shot belongs to the cut on the lowest active track: that is the base scene, and the tracks
+    // above it are parts of the same shot rather than shots of their own.
+    const camCut = playing ? active.find(c => c.camera) : null;
+    const camera = camCut ? computeCamera(camCut.camera, cutProgress(camCut, t), cw, ch) : null;
+
+    return {
+        camera,
+        cuts: active.map(cut => ({
+            cut,
+            anim: playing ? computeCutAnim(cut, t, cw, ch) : null,
+            groups: evaluateGroups(cut, t, playing, cw, ch),
+            texts: evaluateTexts(cut, t, playing),
+        })),
+    };
+}
+
+/** @returns {EvaluatedGroup[]} */
+function evaluateGroups(cut, t, playing, cw, ch) {
+    const visible = flattenLayersInUiOrder(cut.layers || [])
+        .filter(l => l.type === 'layer' && l.visible !== false);
+    return clipGroups(visible).map(g => ({
+        base: g.base,
+        clipped: g.clipped,
+        // The group's transform comes from its base. A clipped layer is paint on the base and
+        // moves with it, which is the same reason the compositing happens before the transform.
+        anim: playing ? computeLayerAnim(g.base, cut, t, cw, ch) : null,
+    }));
+}
+
+/** @returns {{text: CutText, anim: any}[]} */
+function evaluateTexts(cut, t, playing) {
+    return safeArray(cut.texts)
+        .filter(x => x && x.visible !== false)
+        .map(text => ({ text, anim: playing ? computeTextAnim(text, cut, t) : null }))
+        // A text faded to nothing is dropped here rather than drawn transparent, so the renderer
+        // does not measure and lay out something invisible.
+        .filter(x => !(x.anim && x.anim.alpha <= 0.001));
+}

--- a/test/evaluateFrame.test.js
+++ b/test/evaluateFrame.test.js
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateFrame } from '../src/engine/evaluateFrame.js';
+
+const W = 1920, H = 1080;
+const layer = (id, extra = {}) => ({ id, type: 'layer', parentId: null, visible: true, strokes: [], ...extra });
+const cut = (id, start, end, extra = {}) => ({
+    id, name: `Cut ${id}`, startTime: start, endTime: end, track: 0,
+    layers: [layer('L1')], activeLayerId: 'L1', texts: [], ...extra,
+});
+const at = (cuts, t, playing = true, currentCutId = null) =>
+    evaluateFrame(cuts, t, { playing, currentCutId, cw: W, ch: H });
+
+test('an empty document evaluates to an empty frame', () => {
+    const s = at([], 0);
+    assert.deepEqual(s.cuts, []);
+    assert.equal(s.camera, null);
+});
+
+test('only the cuts at t are in the frame, bottom track first', () => {
+    const cuts = [cut('a', 0, 2), cut('b', 2, 4), { ...cut('over', 1, 3), track: 1 }];
+    assert.deepEqual(at(cuts, 1.5).cuts.map(c => c.cut.id), ['a', 'over']);
+});
+
+test('paused, nothing is animated', () => {
+    // The rule the whole app rests on: a cut sitting still is what makes it drawable. A canvas
+    // showing a mid-animation transform would put the pen somewhere other than where ink appears.
+    const c = cut('a', 0, 2, { anim: { inType: 'fade', inDur: 0.5 } });
+    const s = at([c], 0.2, false, 'a');
+    assert.equal(s.cuts[0].anim, null);
+    assert.equal(s.camera, null);
+});
+
+test('playing, cut animation is evaluated once per cut', () => {
+    const c = cut('a', 0, 2, { anim: { inType: 'fade', inDur: 0.5 } });
+    const s = at([c], 0.25);
+    assert.ok(s.cuts[0].anim, 'no cut animation while playing');
+    assert.ok(s.cuts[0].anim.alpha > 0 && s.cuts[0].anim.alpha < 1, 'mid-fade alpha expected');
+});
+
+test('hidden layers are left out, folders are flattened away', () => {
+    const c = cut('a', 0, 2, {
+        layers: [
+            { id: 'F', type: 'folder', parentId: null, visible: true },
+            layer('inFolder', { parentId: 'F' }),
+            layer('hidden', { visible: false }),
+            layer('shown'),
+        ],
+    });
+    const ids = at([c], 1).cuts[0].groups.map(g => g.base.id);
+    assert.ok(ids.includes('shown'));
+    assert.ok(ids.includes('inFolder'), 'a layer inside a folder should still be drawn');
+    assert.ok(!ids.includes('hidden'));
+    assert.ok(!ids.includes('F'), 'the folder itself is not a drawable layer');
+});
+
+test('a hidden folder hides what is inside it', () => {
+    const c = cut('a', 0, 2, {
+        layers: [
+            { id: 'F', type: 'folder', parentId: null, visible: false },
+            layer('inside', { parentId: 'F' }),
+        ],
+    });
+    assert.deepEqual(at([c], 1).cuts[0].groups.map(g => g.base.id), []);
+});
+
+test('clipped layers arrive attached to their base, not as groups of their own', () => {
+    const c = cut('a', 0, 2, {
+        layers: [layer('shade', { clipped: true }), layer('flats')],
+    });
+    const groups = at([c], 1).cuts[0].groups;
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].base.id, 'flats');
+    assert.deepEqual(groups[0].clipped.map(l => l.id), ['shade']);
+});
+
+test('invisible texts are dropped', () => {
+    const c = cut('a', 0, 2, {
+        texts: [{ id: 't1', text: 'x', visible: true }, { id: 't2', text: 'y', visible: false }],
+    });
+    assert.deepEqual(at([c], 1).cuts[0].texts.map(x => x.text.id), ['t1']);
+});
+
+test('a text faded to nothing is dropped rather than drawn transparent', () => {
+    // So the renderer does not measure and lay out something invisible.
+    const c = cut('a', 0, 10, {
+        texts: [{ id: 't', text: 'x', visible: true, anim: { inType: 'fade', inDur: 2 } }],
+    });
+    assert.equal(at([c], 0).cuts[0].texts.length, 0, 'a fully faded-out text should not be in the frame');
+    assert.equal(at([c], 5).cuts[0].texts.length, 1);
+});
+
+test('the camera comes from the lowest active track that has one', () => {
+    // A shot belongs to the base scene; the tracks above are parts of the same shot.
+    const base = cut('base', 0, 4, { camera: { preset: 'zoomIn' } });
+    const over = { ...cut('over', 0, 4, { camera: { preset: 'panLeft' } }), track: 1 };
+    const s = at([over, base], 2);
+    assert.ok(s.camera, 'no camera resolved');
+    assert.equal(s.camera.cx, W / 2, 'took the upper track camera instead of the base');
+});
+
+test('no camera anywhere means no transform for the renderer to apply', () => {
+    assert.equal(at([cut('a', 0, 2)], 1).camera, null);
+});
+
+test('while paused there is no camera, whatever the cut says', () => {
+    const c = cut('a', 0, 2, { camera: { preset: 'zoomIn' } });
+    assert.equal(at([c], 1, false, 'a').camera, null);
+});
+
+test('while paused the cut being edited is in the frame even off the playhead', () => {
+    const cuts = [cut('a', 0, 2), cut('b', 4, 6)];
+    assert.deepEqual(at(cuts, 5, false, 'a').cuts.map(c => c.cut.id), ['b', 'a']);
+});
+
+test('a cut with no layers and no texts still evaluates', () => {
+    const c = cut('a', 0, 2, { layers: [], texts: undefined });
+    const e = at([c], 1).cuts[0];
+    assert.deepEqual(e.groups, []);
+    assert.deepEqual(e.texts, []);
+});


### PR DESCRIPTION
Phase C, second piece.

## The duplicate work

`paintFrame` worked out *what* the frame was in the middle of drawing it, in two passes that could not see each other's work. So:

```js
// layer pass
const anim = playing ? computeCutAnim(ac, t, CANVAS_W, CANVAS_H) : null;
// text pass, ~90 lines later
const anim = playing ? computeCutAnim(ac, t, CANVAS_W, CANVAS_H) : null;
```

**Twice per cut per frame**, with the same transform written out either side.

## What it is now

`evaluateFrame` resolves the document to a scene first — which cuts, their animation, their layer groups, their texts, the camera — and the two passes read the same answer:

```js
const scene = evaluateFrame(cuts, t, { playing, currentCutId, cw: CANVAS_W, ch: CANVAS_H });
```

Pure and canvas-free, so it is testable without a browser: **14 tests**, covering hidden layers, hidden folders, clipped layers arriving attached to their base, the camera coming from the lowest active track, and nothing being animated while paused.

**What stays in the renderer** is what genuinely needs a context: compositing clip groups, slicing for sway, the selection mask, leaving out a layer the drag overlay is drawing instead. *Deciding* moved out; drawing did not.

Dropping invisible and fully-faded texts during evaluation rather than mid-loop is a small thing that reads better — the renderer no longer measures and lays out something it will not draw.

## The type checker found a real inconsistency

A cut's text and the renderer's text are **the same object described in two places**, and the two descriptions had no field in common, so handing one straight to the other was an error:

```
error TS2559: Type 'CutText' has no properties in common with type 'TextObject'.
```

`TextObject` now admits the `id` and `visible` it has always had, with a note that the renderer does not read them.

## Verified

- [x] `npm run check` — 442 tests, typecheck, hook baseline, helper index, build clean
- [x] `npm run smoke` — built bundle loads, canvas 1920×1080, 75 buttons, console clean

## Worth trying — this is the render path

1. Play a cut with an **in/out animation** — fade and slide should look as before
2. A cut with **part animation** on a layer, and one with **sway**
3. **Text animation** during playback, including a text that fades in
4. A **camera** preset, and a **clipped** layer
5. Onion skin on, paused
6. Drag a layer while paused — no ghost
