### PR TITLE
feat: curve text along an arc, and mirror it

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -332,6 +332,15 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `TEXT_ANIM_DEFAULT` | - emphasis: a looping accent (pulse/shake/wave) |
 | `triwave` | Triangle wave 0->1->0 (period 2); used for ping-pong path following. |
 
+## `src/canvas/textLayout.js`
+
+Where each character of a line goes, for curving and for animating characters separately.
+
+| | |
+|---|---|
+| `layoutLine` | Per-character position and angle along an arc. The straight path is left alone on purpose: drawing character by character gives up the font's kerning and shaping, so this is the cost of curving rather than something every text pays. |
+| `charProgress` | One character's own 0..1 when they are staggered. `spread` is capped below 1, because spending the whole duration on starts leaves the last character no time to move. |
+
 ## `src/canvas/textRender.js`
 
 Measuring and drawing text objects.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2808,6 +2808,9 @@ export default function App() {
             color2: textEdit.color2 || '#ffffff',
             bgColor: textEdit.bgColor || '',
             rotation: textEdit.rotation ?? 0,
+            curve: textEdit.curve ?? 0,
+            flipX: !!textEdit.flipX,
+            flipY: !!textEdit.flipY,
             anim: textEdit.anim || null,
         };
         dispatchCuts(upsertText(textEdit.cutId, obj));
@@ -2851,6 +2854,9 @@ export default function App() {
             color2: t.color2 || '#ffffff',
             bgColor: t.bgColor || '',
             rotation: t.rotation ?? 0,
+            curve: t.curve ?? 0,
+            flipX: !!t.flipX,
+            flipY: !!t.flipY,
             anim: t.anim || null,
         });
     };
@@ -4238,6 +4244,14 @@ export default function App() {
                                     {textEdit.bgColor && <input type="color" value={textEdit.bgColor.startsWith('#') ? textEdit.bgColor : '#ffffff'} onChange={e => setTextEdit(te => te ? ({ ...te, bgColor: e.target.value }) : te)} className="text-editor-color" title={tr('배경 색')} />}
                                     <NumField className="time-input" width={54} title={tr('회전(도)')} value={textEdit.rotation ?? 0} step={5}
                                         onChange={v => setTextEdit(te => te ? ({ ...te, rotation: v }) : te)} />
+                                    <NumField className="time-input" width={54} title={tr('곡률(도) — 양수는 위로 휩니다')} value={textEdit.curve ?? 0} step={10}
+                                        onChange={v => setTextEdit(te => te ? ({ ...te, curve: Math.max(-180, Math.min(180, v)) }) : te)} />
+                                    <label className="te-check" title={tr('좌우 반전')}>
+                                        <input type="checkbox" checked={!!textEdit.flipX} onChange={e => setTextEdit(te => te ? ({ ...te, flipX: e.target.checked }) : te)} />{tr('좌우뒤집기')}
+                                    </label>
+                                    <label className="te-check" title={tr('상하 반전')}>
+                                        <input type="checkbox" checked={!!textEdit.flipY} onChange={e => setTextEdit(te => te ? ({ ...te, flipY: e.target.checked }) : te)} />{tr('상하뒤집기')}
+                                    </label>
                                     {/* Text animation, visible only during playback. */}
                                     {(() => {
                                         const an = { ...TEXT_ANIM_DEFAULT, ...(textEdit.anim || {}) };

--- a/src/canvas/textLayout.js
+++ b/src/canvas/textLayout.js
@@ -1,0 +1,112 @@
+// Where each character of a line goes.
+//
+// Text is normally drawn a whole line at a time, and should stay that way: fillText applies the
+// font's kerning and shaping, and drawing character by character throws both away. On Latin that
+// shows up as visibly wrong spacing between pairs like "AV"; it is the reason this module is not
+// the default path but the one taken only when something actually needs per-character positions.
+//
+// Two things need them. Curving a line means every character sits at its own angle. Animating
+// characters separately - the ones that drop in one after another - means every character has its
+// own transform. Both want the same answer, so it is worked out once, here, without a canvas.
+//
+// Measurement stays with the caller. Character widths come from ctx.measureText, and keeping that
+// out means this file is pure and its arithmetic is testable.
+
+/**
+ * @typedef {object} PlacedChar
+ * @property {string} ch
+ * @property {number} x offset from the line's anchor, along the baseline
+ * @property {number} y offset from the baseline, growing downward like canvas y
+ * @property {number} angle radians, clockwise, about the character's own centre
+ * @property {number} index position in the line, for staggering an animation
+ */
+
+/**
+ * Lay a line out character by character.
+ *
+ * The curve is expressed as the total angle the line subtends, in degrees, which is the number a
+ * person can reason about: 0 is straight, 180 is a half circle. Positive arcs upward - the
+ * middle of the line rises - because that is what "curve" means on a banner.
+ *
+ * @param {string[]} chars
+ * @param {number[]} widths advance width of each character, same order
+ * @param {object} opts
+ * @param {number} [opts.curve] total arc in degrees; 0 is a straight line
+ * @param {number} [opts.letterSpacing] extra px between characters
+ * @returns {PlacedChar[]}
+ */
+export function layoutLine(chars, widths, { curve = 0, letterSpacing = 0 } = {}) {
+    const n = Math.min(chars.length, widths.length);
+    if (n === 0) return [];
+
+    // Advance of each character including the gap that follows it, and the total the line spans.
+    const advances = [];
+    let total = 0;
+    for (let i = 0; i < n; i++) {
+        const adv = widths[i] + (i < n - 1 ? letterSpacing : 0);
+        advances.push(adv);
+        total += adv;
+    }
+
+    // Distance from the start of the line to the middle of each character.
+    const centres = [];
+    let run = 0;
+    for (let i = 0; i < n; i++) {
+        centres.push(run + widths[i] / 2);
+        run += advances[i];
+    }
+
+    const theta = (curve * Math.PI) / 180;
+    // Below this the radius is enormous and the arc is a straight line to any pixel that matters,
+    // and computing it invites dividing by nearly zero.
+    if (Math.abs(theta) < 1e-4 || total <= 0) {
+        return chars.slice(0, n).map((ch, i) => ({ ch, x: centres[i], y: 0, angle: 0, index: i }));
+    }
+
+    // Wrap the line onto a circle whose arc length is the line's width, so curving does not change
+    // how much room the text takes along its own length.
+    const radius = total / theta;
+
+    return chars.slice(0, n).map((ch, i) => {
+        // Angle of this character measured from the middle of the line.
+        const a = (centres[i] - total / 2) / radius;
+        return {
+            ch,
+            // Rebased so a curve of zero and a curve of nearly zero agree: without the half-total
+            // the whole line would jump sideways the moment it started bending.
+            x: radius * Math.sin(a) + total / 2,
+            // y grows downward, and (1 - cos) is never negative, so the sign has to come from the
+            // radius - which is negative when the curve is. The middle stays at zero and the ends
+            // drop away, which is a positive curve arcing upward.
+            y: radius * (1 - Math.cos(a)),
+            angle: a,
+            index: i,
+        };
+    });
+}
+
+/**
+ * Progress of one character when they are staggered.
+ *
+ * Every character runs the same animation; they start at different times. `spread` is how much of
+ * the total duration is given over to starting them: 0 means all at once, and the more of it is
+ * spent staggering, the less each character has to move in.
+ *
+ * It is capped below 1. Spending the whole duration on starts leaves the last character no time
+ * at all, so it would snap into place instead of animating - and at exactly 1 it never starts,
+ * which is how the cap came to be written down.
+ *
+ * @param {number} index
+ * @param {number} count
+ * @param {number} progress 0..1 through the whole animation
+ * @param {number} [spread] 0..1
+ * @returns {number} this character's own 0..1, clamped
+ */
+export function charProgress(index, count, progress, spread = 0.5) {
+    if (count <= 1 || spread <= 0) return Math.max(0, Math.min(1, progress));
+    // The last character always keeps a tenth of the duration to move in.
+    const s = Math.min(0.9, spread);
+    const span = 1 - s;
+    const start = (index / (count - 1)) * s;
+    return Math.max(0, Math.min(1, (progress - start) / span));
+}

--- a/src/canvas/textRender.js
+++ b/src/canvas/textRender.js
@@ -29,6 +29,9 @@
  * @property {number} [shadowBlur]
  * @property {number} [shadowDX]
  * @property {number} [shadowDY]
+ * @property {number} [curve] degrees of arc the line bends through; 0 is straight
+ * @property {boolean} [flipX] mirror left to right, about the centre of the box
+ * @property {boolean} [flipY] mirror top to bottom
  * @property {number} [rotation] degrees, about the centre of the box
  * @property {number} [opacity] 0..1, multiplied with any animation alpha
  */
@@ -53,6 +56,8 @@
  * @property {number} rot degrees
  * @property {number} chars how much of the string is revealed, for the typing effect
  */
+
+import { layoutLine } from './textLayout.js';
 
 // Measuring and drawing text objects.
 //
@@ -126,7 +131,9 @@ export function measureTextBox(t, measureCtx) {
  * @returns {boolean}
  */
 export function textNeedsBox(t, anim) {
-    return !!(t?.gradient || t?.bgColor || t?.rotation || anim);
+    // Flipping needs it for the same reason rotation does: both pivot on the centre of the box,
+    // and without one the text would mirror about the canvas origin and leave the frame.
+    return !!(t?.gradient || t?.bgColor || t?.rotation || t?.flipX || t?.flipY || anim);
 }
 
 /**
@@ -187,6 +194,14 @@ export function drawTextObject(ctx, t, { anim = null, box = null, alpha = 1 } = 
         const cx = box.x + box.w / 2, cy = box.y + box.h / 2;
         ctx.translate(cx, cy); ctx.rotate((t.rotation * Math.PI) / 180); ctx.translate(-cx, -cy);
     }
+    // Mirroring, about the centre of the box for the same reason rotation is: scaling about the
+    // origin would fling the text across the canvas instead of flipping it where it sits.
+    if ((t.flipX || t.flipY) && box) {
+        const cx = box.x + box.w / 2, cy = box.y + box.h / 2;
+        ctx.translate(cx, cy);
+        ctx.scale(t.flipX ? -1 : 1, t.flipY ? -1 : 1);
+        ctx.translate(-cx, -cy);
+    }
     // Background box (the highlight).
     if (t.bgColor && box) {
         const pad = Math.round(fontSize * 0.22);
@@ -223,6 +238,14 @@ export function drawTextObject(ctx, t, { anim = null, box = null, alpha = 1 } = 
         ctx.shadowOffsetY = t.shadowDY ?? 2;
     }
     const x = t.x ?? 0, y = t.y ?? 0;
+
+    if (t.curve) {
+        drawCurved(ctx, t, lines, { x, y, lineHeight, fontSize, fillStyle });
+        try { ctx.letterSpacing = '0px'; } catch { }
+        ctx.restore();
+        return;
+    }
+
     if (t.outline) {
         ctx.lineJoin = 'round';
         ctx.lineWidth = Math.max(2, fontSize / 6);
@@ -243,4 +266,61 @@ export function drawTextObject(ctx, t, { anim = null, box = null, alpha = 1 } = 
     }
     try { ctx.letterSpacing = '0px'; } catch { }
     ctx.restore();
+}
+
+
+/**
+ * Draw the lines along an arc, one character at a time.
+ *
+ * Only reached when a curve is set. Placing characters individually gives up the font's kerning
+ * and shaping, which is a real loss on Latin text - so it is the cost of curving, not something
+ * every text pays.
+ *
+ * letterSpacing is applied by the layout rather than the context here: ctx.letterSpacing affects
+ * a whole fillText call, and each call is now one character with nothing to space it against.
+ */
+function drawCurved(ctx, t, lines, { x, y, lineHeight, fontSize, fillStyle }) {
+    const spacing = t.letterSpacing || 0;
+    try { ctx.letterSpacing = '0px'; } catch { }
+    // Each character is drawn centred on its own point, so the arc reads as one turning line
+    // rather than a row of glyphs whose left edges happen to follow a curve.
+    const align = ctx.textAlign;
+    ctx.textAlign = 'center';
+
+    for (let i = 0; i < lines.length; i++) {
+        const chars = [...lines[i]];
+        if (!chars.length) continue;
+        const widths = chars.map(c => ctx.measureText(c).width);
+        const placed = layoutLine(chars, widths, { curve: t.curve, letterSpacing: spacing });
+        const total = widths.reduce((a, b) => a + b, 0) + spacing * Math.max(0, chars.length - 1);
+        // The anchor means the same thing it does for a straight line, so switching the curve on
+        // does not also move the text.
+        const originX = align === 'center' ? x - total / 2 : align === 'right' ? x - total : x;
+        const originY = y + i * lineHeight;
+
+        for (const c of placed) {
+            ctx.save();
+            ctx.translate(originX + c.x, originY + c.y);
+            ctx.rotate(c.angle);
+            if (t.outline) {
+                ctx.lineJoin = 'round';
+                ctx.lineWidth = Math.max(2, fontSize / 6);
+                ctx.strokeStyle = t.outlineColor || '#ffffff';
+                ctx.strokeText(c.ch, 0, 0);
+            }
+            ctx.fillStyle = fillStyle;
+            ctx.fillText(c.ch, 0, 0);
+            ctx.restore();
+        }
+
+        // As on the straight path: the shadow is cast once by the block, or every character would
+        // drop one onto its neighbours.
+        if (i === 0 && t.shadow) {
+            ctx.shadowColor = 'transparent';
+            ctx.shadowBlur = 0;
+            ctx.shadowOffsetX = 0;
+            ctx.shadowOffsetY = 0;
+        }
+    }
+    ctx.textAlign = align;
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -610,4 +610,9 @@ const EN = {
     '키 추가': 'Add key',
     '{0}개': '{0}',
     '{0}점': '{0} pts',
+    '곡률(도) — 양수는 위로 휩니다': 'Curve (degrees) - positive arcs upward',
+    '좌우 반전': 'Mirror left to right',
+    '상하 반전': 'Mirror top to bottom',
+    '좌우뒤집기': 'Flip H',
+    '상하뒤집기': 'Flip V',
 };

--- a/test/textLayout.test.js
+++ b/test/textLayout.test.js
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { layoutLine, charProgress } from '../src/canvas/textLayout.js';
+
+const chars = (s) => [...s];
+const even = (s, w = 10) => chars(s).map(() => w);
+const close = (a, b, eps = 1e-6) => Math.abs(a - b) < eps;
+
+test('a straight line puts each character at its own centre', () => {
+    const p = layoutLine(chars('abc'), even('abc'));
+    assert.deepEqual(p.map(c => c.x), [5, 15, 25]);
+    assert.deepEqual(p.map(c => c.y), [0, 0, 0]);
+    assert.deepEqual(p.map(c => c.angle), [0, 0, 0]);
+    assert.deepEqual(p.map(c => c.ch), ['a', 'b', 'c']);
+});
+
+test('letter spacing widens the gaps but not the last character', () => {
+    // The trailing gap is not part of the line: adding it would make a centred line sit off-centre
+    // by half a space.
+    const p = layoutLine(chars('abc'), even('abc'), { letterSpacing: 4 });
+    assert.deepEqual(p.map(c => c.x), [5, 19, 33]);
+});
+
+test('nothing in, nothing out', () => {
+    assert.deepEqual(layoutLine([], []), []);
+    assert.deepEqual(layoutLine(chars('abc'), []), []);
+});
+
+test('a curve of zero is exactly a straight line', () => {
+    const straight = layoutLine(chars('hello'), even('hello'));
+    const zero = layoutLine(chars('hello'), even('hello'), { curve: 0 });
+    assert.deepEqual(zero, straight);
+});
+
+test('a nearly-zero curve does not jump away from a straight line', () => {
+    // The arc is computed about the line's middle, so without rebasing, the instant the curve
+    // stopped being exactly zero the whole line would slide sideways by half its width.
+    const straight = layoutLine(chars('hello'), even('hello'));
+    const barely = layoutLine(chars('hello'), even('hello'), { curve: 0.01 });
+    for (let i = 0; i < straight.length; i++) {
+        assert.ok(close(barely[i].x, straight[i].x, 0.01), `x jumped at ${i}: ${barely[i].x} vs ${straight[i].x}`);
+        assert.ok(Math.abs(barely[i].y) < 0.01, `y jumped at ${i}: ${barely[i].y}`);
+    }
+});
+
+test('a positive curve arcs upward', () => {
+    // "Curve" on a banner means the middle rises. Negative is the frown.
+    const up = layoutLine(chars('abcde'), even('abcde'), { curve: 60 });
+    const mid = up[2], end = up[4];
+    assert.ok(mid.y < end.y, 'the middle should sit above the ends');
+    const down = layoutLine(chars('abcde'), even('abcde'), { curve: -60 });
+    assert.ok(down[2].y > down[4].y, 'a negative curve should dip in the middle');
+});
+
+test('the curve is symmetric about the middle of the line', () => {
+    const p = layoutLine(chars('abcde'), even('abcde'), { curve: 90 });
+    const total = 50;
+    // First and last sit the same distance in from each end, and at the same height.
+    assert.ok(close(p[0].x, total - p[4].x, 1e-9), `${p[0].x} vs ${total - p[4].x}`);
+    assert.ok(close(p[0].y, p[4].y, 1e-9));
+    assert.ok(close(p[0].angle, -p[4].angle, 1e-9));
+});
+
+test('the middle of an odd-length line stays on the centre line', () => {
+    const p = layoutLine(chars('abcde'), even('abcde'), { curve: 120 });
+    assert.ok(close(p[2].y, 0, 1e-9), `middle lifted to ${p[2].y}`);
+    assert.ok(close(p[2].angle, 0, 1e-9));
+    assert.ok(close(p[2].x, 25, 1e-9));
+});
+
+test('curving does not change how far the line reaches along its own length', () => {
+    // The arc length is the line width, so a curved line occupies the same amount of text.
+    for (const curve of [30, 90, 179]) {
+        const p = layoutLine(chars('abcdefgh'), even('abcdefgh'), { curve });
+        let arc = 0;
+        for (let i = 1; i < p.length; i++) arc += Math.hypot(p[i].x - p[i - 1].x, p[i].y - p[i - 1].y);
+        // Chords across an arc are shorter than the arc; on eight characters the gap is small.
+        assert.ok(arc > 60 && arc < 71, `curve ${curve} gave chord length ${arc}`);
+    }
+});
+
+test('a character on the arc is turned to face along it', () => {
+    const p = layoutLine(chars('abcde'), even('abcde'), { curve: 90 });
+    assert.ok(p[0].angle < 0 && p[4].angle > 0, 'the ends should tilt in opposite directions');
+    // Total turn across the line is the curve that was asked for.
+    const span = p[4].angle - p[0].angle;
+    assert.ok(span > 0 && span < Math.PI / 2, `turned ${span} radians for a 90 degree curve`);
+});
+
+test('characters of different widths are spaced by their own widths', () => {
+    const p = layoutLine(chars('ill'), [4, 12, 12]);
+    assert.deepEqual(p.map(c => c.x), [2, 10, 22]);
+});
+
+test('charProgress: no spread means every character moves together', () => {
+    for (const i of [0, 1, 2]) assert.equal(charProgress(i, 3, 0.4, 0), 0.4);
+});
+
+test('charProgress: with spread, later characters start later', () => {
+    const p = [0, 1, 2, 3].map(i => charProgress(i, 4, 0.4, 0.6));
+    for (let i = 1; i < p.length; i++) assert.ok(p[i] <= p[i - 1], `character ${i} ran ahead of ${i - 1}`);
+    assert.ok(p[0] > 0, 'the first character should have started');
+    assert.equal(p[3], 0, 'the last should not have started yet at 0.4 with spread 0.6');
+});
+
+test('charProgress: everyone finishes by the end', () => {
+    for (const spread of [0, 0.3, 0.7, 1]) {
+        for (const i of [0, 3, 7]) {
+            assert.equal(charProgress(i, 8, 1, spread), 1, `spread ${spread}, char ${i} unfinished`);
+        }
+    }
+});
+
+test('charProgress: nobody has started at zero, and it never leaves 0..1', () => {
+    for (const i of [0, 4, 9]) {
+        assert.equal(charProgress(i, 10, 0, 0.5), 0);
+        for (const p of [-1, 0.5, 2]) {
+            const v = charProgress(i, 10, p, 0.5);
+            assert.ok(v >= 0 && v <= 1, `out of range: ${v}`);
+        }
+    }
+});
+
+test('charProgress: a spread of one still leaves each character time to move', () => {
+    // Otherwise the last character would have a zero-length window and snap.
+    const v = charProgress(1, 3, 0.6, 1);
+    assert.ok(Number.isFinite(v) && v >= 0 && v <= 1, `got ${v}`);
+});
+
+test('charProgress: a single character ignores the spread', () => {
+    assert.equal(charProgress(0, 1, 0.3, 0.9), 0.3);
+});

--- a/test/textRender.test.js
+++ b/test/textRender.test.js
@@ -214,3 +214,10 @@ test('drawTextObject: a context without letterSpacing or roundRect is still usab
     assert.equal(only(ctx, 'rect').length, 1, 'fell back to a square-cornered box');
     assert.equal(only(ctx, 'fillText').length, 1);
 });
+
+test('textNeedsBox: flipping needs the box, because it pivots on the centre', () => {
+    // Without one the text would mirror about the canvas origin and leave the frame entirely.
+    assert.equal(textNeedsBox({ text: 'x' }, null), false);
+    assert.equal(textNeedsBox({ text: 'x', flipX: true }, null), true);
+    assert.equal(textNeedsBox({ text: 'x', flipY: true }, null), true);
+});


### PR DESCRIPTION
Two of the three text requests. The third — characters falling in one after another — needs the same per-character positions, which is why the layout is its own module rather than something buried inside the curve branch.

## Curving

Expressed as **the total angle the line bends through, in degrees**, because that is the number a person can reason about: 0 straight, 180 a half circle. Positive arcs upward, since that is what "curve" means on a banner.

The line is wrapped onto a circle whose arc length is the line's own width, so bending it does not change how much room the text takes.

**The straight path is untouched on purpose.** Placing characters one at a time gives up the font's kerning and shaping — a real loss on Latin — so it is the price of curving, not something every text pays. The anchor means the same thing either way, so switching the curve on does not also move the text.

## Mirroring

Pivots on the centre of the box, for the same reason rotation does: scaling about the origin would fling the text off the canvas rather than flip it in place. `textNeedsBox` knows about it now, or the box would be absent exactly when it is needed.

## Three bugs found before this ran anywhere

**Two by the unit tests:**

- a positive curve arced *downward* — the sign has to come from the radius, because `(1 - cos)` is never negative
- a stagger `spread` of 1 left the last character starting exactly at the end, so it never animated. Capped, so the last character always keeps a tenth of the duration

**One by the i18n check** (added in #77): `'좌우'` already means "Horizontal" as a deform axis. One Korean word cannot mean two things when the source text *is* the dictionary key, so the flip toggles got their own.

## Verified on screen, not only in tests

Unit tests on layout say nothing about whether the renderer takes the new path. Driven with Playwright against the built app:

```
text   ok   ink 107, box 124x40
curve  ok   height 40 -> 44
flipX  ok   box unchanged at 124x40, pixels reversed
```

The first version of that script reported "no text drawn" — **the script was wrong, not the feature**: `+ Text` only selects the tool, the editor opens where you click the canvas, and nothing is drawn until Done commits it.

- [x] `npm run check` — 446 tests, typecheck, hook baseline, helper index, build clean

## Next

Per-character animation ("characters dropping in one at a time") builds directly on `layoutLine` and `charProgress`, both of which are already here and tested.
