### PR TITLE
feat: the text editor is a tab in the cut panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -473,26 +473,30 @@ body {
     backdrop-filter: blur(8px);
 }
 
-.text-editor {
-    position: absolute;
-    min-width: 300px;
-    max-width: 560px;
-    /* There are enough controls to run tall, so it scrolls within the panel rather than off-screen. */
-    max-height: 80vh;
-    overflow-y: auto;
-    z-index: 40;
-    transform: translate(10px, 10px);
-    padding: 12px;
-    border-radius: 12px;
-    /* Theme-driven, like every other panel. This used to be a hardcoded navy that ignored the
-       theme colour entirely, so it looked pasted in from another application. */
-    background: hsl(var(--ui-h) var(--ui-s) 14%);
-    border: 1px solid hsl(var(--ui-h) var(--ui-s) 28%);
-    backdrop-filter: blur(10px);
-    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.5);
+/* The text editor is a docked panel now, not a window over the canvas: it had grown enough
+   controls to cover the drawing it was meant to be editing. It keeps the .right-panel chrome
+   and only needs its own scrolling body, so the header stays put while the controls scroll. */
+/* The CUT / LAYER tab's contents. It is a flex column so the cut list scrolls and the buttons
+   under it stay put, which is what the panel did before the tabs existed. */
+.cut-tab-body {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
 }
 
-.text-editor textarea {
+.cut-tab-body[hidden] {
+    display: none;
+}
+
+.text-panel-body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 2px;
+}
+
+.text-panel-body textarea {
     width: 100%;
     height: 110px;
     resize: vertical;
@@ -506,11 +510,39 @@ body {
     outline: none;
 }
 
-.text-editor textarea:focus {
+.text-panel-body textarea:focus {
     border-color: var(--accent-hi);
 }
 
-.text-editor textarea::placeholder {
+.text-panel-body textarea::placeholder {
+    color: rgba(255, 255, 255, 0.55);
+}
+
+/* Pulled out of the dock, the panel is inside .float-panel, which sizes itself to its content -
+   so the height has to come from somewhere or the body would grow without limit. */
+.float-panel .text-panel {
+    max-height: 80vh;
+}
+
+.text-panel-body textarea {
+    width: 100%;
+    height: 110px;
+    resize: vertical;
+    background: hsl(var(--ui-h) var(--ui-s) 10%);
+    color: #e6e6ee;
+    caret-color: var(--accent-soft);
+    border: 1px solid hsl(var(--ui-h) var(--ui-s) 26%);
+    border-radius: 8px;
+    padding: 10px;
+    font: 14px/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    outline: none;
+}
+
+.text-panel-body textarea:focus {
+    border-color: var(--accent-hi);
+}
+
+.text-panel-body textarea::placeholder {
     color: rgba(255, 255, 255, 0.55);
 }
 
@@ -1766,7 +1798,7 @@ html {
 }
 
 /* Colour swatches read as part of the control they belong to, not as gaps. */
-.text-editor .text-editor-color {
+.text-panel-body .text-editor-color {
     width: 26px;
     height: 26px;
     padding: 0;
@@ -1776,7 +1808,7 @@ html {
     cursor: pointer;
 }
 
-.text-editor .text-editor-label {
+.text-panel-body .text-editor-label {
     font-size: 11px;
     color: #9a9aa8;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useLayoutEffect, useMemo } from 'react';
-import { Plus, Trash2, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, ClipboardPaste, GitBranch, Move, Type, Cloud, Film, Repeat, Minus, Waves, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw, ArrowDownToLine, CornerDownRight } from 'lucide-react';
+import { X, Plus, Trash2, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, ClipboardPaste, GitBranch, Move, Type, Cloud, Film, Repeat, Minus, Waves, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw, ArrowDownToLine, CornerDownRight } from 'lucide-react';
 import './App.css';
 import { saveAutosave, loadAutosave, saveProject, loadProject, listProjects, deleteProject, autosaveKey } from './db';
 import { CutAnimPanel, LayerAnimPanel, JitterPanel } from './ui/AnimPanels';
@@ -220,6 +220,9 @@ export default function App() {
     const [loopPlay, setLoopPlay] = useState(false);
     const [playbackRate, setPlaybackRate] = useState(1);
     const [rightW, setRightW] = useState(270);
+    // Which tab the cut panel is showing. It follows the editor rather than being chosen: a text
+    // you have just opened is the thing you want to see.
+    const [rightTab, setRightTab] = useState('cut');
     const [leftW, setLeftW] = useState(96);
     const [colorW, setColorW] = useState(200);
     const [timelineH, setTimelineH] = useState(240);
@@ -231,22 +234,6 @@ export default function App() {
     const [scrubbing, setScrubbing] = useState(false);
 
     // The editor opens at the text's position, so clicking near an edge used to put half of it
-    // off-screen with the Done button unreachable. Measure once it is laid out and nudge it back
-    // in; its size changes as options appear, so this reruns whenever the editor does.
-    const textEditorRef = useRef(null);
-    useLayoutEffect(() => {
-        const el = textEditorRef.current;
-        if (!el) return;
-        el.style.transform = 'translate(10px, 10px)';
-        const r = el.getBoundingClientRect();
-        const pad = 8;
-        let dx = 0, dy = 0;
-        if (r.right > window.innerWidth - pad) dx = window.innerWidth - pad - r.right;
-        if (r.bottom > window.innerHeight - pad) dy = window.innerHeight - pad - r.bottom;
-        if (r.left + dx < pad) dx = pad - r.left;
-        if (r.top + dy < pad) dy = pad - r.top;
-        el.style.transform = `translate(${10 + dx}px, ${10 + dy}px)`;
-    });
 
     // Where each panel lives: 'left', 'right' or 'float'. Panels are drawn from these rather than
     // from fixed positions in the layout, so dragging one only has to change this value.
@@ -3837,6 +3824,12 @@ export default function App() {
 
     // Tool panel: the buttons keep a comfortable size and the column count follows the width.
     const toolW = Math.max(56, leftW || 96);
+    // Named rather than inlined as [!!textEdit]: a dependency the linter cannot read is a
+    // dependency nobody can check. This way it runs when the editor opens or closes and not
+    // on every keystroke, which would drag the user back from the cut list mid-edit.
+    const editingText = !!textEdit;
+    useEffect(() => { setRightTab(editingText ? 'text' : 'cut'); }, [editingText]);
+
     const isSelectionTool = tool === 'lasso' || !!selection;
     liveRef.current = { cuts, copiedCut, selection, audioData, numTracks }; // current GC + history sources
 
@@ -3907,6 +3900,189 @@ export default function App() {
                     width={colorW}
                     onClose={() => setLeftDock(null)} />
     );
+    // The editor is a tab in the cut panel, not a window over the canvas and not a fourth
+    // panel beside it. It had grown enough controls to cover the drawing it was meant to be
+    // editing; docked next to CUT / LAYER it left the canvas a sliver. Sharing that panel's
+    // space, the way the project tabs share one bar, costs the canvas nothing.
+    const textEditorBody = textEdit ? (
+        <div className="text-panel-body">
+                        <textarea
+                            ref={textAreaRef}
+                            value={textEdit.text}
+                            onChange={e => setTextEdit(te => te ? ({ ...te, text: e.target.value }) : te)}
+                            onKeyDown={e => {
+                                if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); cancelText(); }
+                                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); e.stopPropagation(); commitText(); }
+                            }}
+                            placeholder={tr('텍스트 입력 (Ctrl+Enter 완료, Esc 취소)')}
+                        />
+                        <div className="text-editor-row">
+                            <div className="te-section">{tr('글꼴')}</div>
+                            <label className="text-editor-label">Size</label>
+                            {/* No range at all while editing - not per keystroke, and not
+                                on blur either. Any clamp during editing makes 100
+                                unreachable: "1" becomes 6 before the zeros arrive, and
+                                clamping when the field is left does the same thing a
+                                keystroke later if focus moves between digits. The size is
+                                held to 6..400 where it is used instead - textRender clamps
+                                for drawing, and commitText clamps what gets saved. */}
+                            <NumField
+                                value={textEdit.fontSize}
+                                onChange={v => setTextEdit(te => te ? ({ ...te, fontSize: v }) : te)}
+                                className="text-editor-num"
+                            />
+                            {(() => {
+                                const isPreset = FONT_PRESETS.some(f => f.value === textEdit.fontFamily);
+                                return (
+                                    <>
+                                        <select
+                                            className="text-editor-font"
+                                            value={isPreset ? textEdit.fontFamily : '__custom__'}
+                                            onChange={e => {
+                                                const v = e.target.value;
+                                                setTextEdit(te => te ? ({ ...te, fontFamily: v === '__custom__' ? (te.fontFamily || 'sans-serif') : v }) : te);
+                                            }}
+                                            title={tr('폰트')}
+                                        >
+                                            <option value="__custom__">Custom</option>
+                                            {/* Grouped by script: a flat list of twenty
+                                                is harder to use than a short one. Each
+                                                option previews its own face. */}
+                                            {fontGroups().map(([group, fonts]) => (
+                                                <optgroup key={group} label={group}>
+                                                    {fonts.map(f => (
+                                                        <option key={f.value} value={f.value} style={{ fontFamily: f.value }}>{f.label}</option>
+                                                    ))}
+                                                </optgroup>
+                                            ))}
+                                        </select>
+                                        {!isPreset && (
+                                            <input
+                                                className="text-editor-font"
+                                                value={textEdit.fontFamily}
+                                                onChange={e => setTextEdit(te => te ? ({ ...te, fontFamily: e.target.value }) : te)}
+                                                placeholder="Custom font-family"
+                                                title={tr('커스텀 폰트')}
+                                            />
+                                        )}
+                                    </>
+                                );
+                            })()}
+                            <input
+                                type="color"
+                                value={textEdit.color}
+                                onChange={e => setTextEdit(te => te ? ({ ...te, color: e.target.value }) : te)}
+                                className="text-editor-color"
+                                title={tr('색상')}
+                            />
+                            <button className="button" title={tr('굵게')} onClick={() => setTextEdit(te => te ? ({ ...te, bold: !te.bold }) : te)}
+                                style={{ height: 26, width: 28, padding: 0, fontWeight: 800, background: textEdit.bold ? 'hsl(var(--ui-h) var(--ui-s) 29%)' : undefined }}>B</button>
+                            <button className="button" title={tr('기울임')} onClick={() => setTextEdit(te => te ? ({ ...te, italic: !te.italic }) : te)}
+                                style={{ height: 26, width: 28, padding: 0, fontStyle: 'italic', background: textEdit.italic ? 'hsl(var(--ui-h) var(--ui-s) 29%)' : undefined }}>I</button>
+                            <select className="time-input" style={{ width: 52 }} title={tr('정렬')} value={textEdit.align || 'left'}
+                                onChange={e => setTextEdit(te => te ? ({ ...te, align: e.target.value }) : te)}>
+                                <option value="left">◧</option><option value="center">▣</option><option value="right">◨</option>
+                            </select>
+                            <select className="time-input" style={{ width: 54 }} title={tr('줄간격')} value={textEdit.lineHeight ?? 1.25}
+                                onChange={e => setTextEdit(te => te ? ({ ...te, lineHeight: +e.target.value }) : te)}>
+                                {[1, 1.15, 1.25, 1.5, 1.8, 2].map(v => <option key={v} value={v}>{v}x</option>)}
+                            </select>
+                            <select className="time-input" style={{ width: 58 }} title={tr('자간(글자 간격)')} value={textEdit.letterSpacing ?? 0}
+                                onChange={e => setTextEdit(te => te ? ({ ...te, letterSpacing: +e.target.value }) : te)}>
+                                {[-2, 0, 1, 2, 4, 8, 12].map(v => <option key={v} value={v}>{tr('자간')}{v}</option>)}
+                            </select>
+                            <div className="te-section">{tr('효과')}</div>
+                            <label className="te-check" title={tr('가독성용 외곽선')}>
+                                <input type="checkbox" checked={!!textEdit.outline} onChange={e => setTextEdit(te => te ? ({ ...te, outline: e.target.checked }) : te)} />{tr('테두리')}
+                            </label>
+                            {textEdit.outline && <input type="color" value={textEdit.outlineColor || '#ffffff'} onChange={e => setTextEdit(te => te ? ({ ...te, outlineColor: e.target.value }) : te)} className="text-editor-color" title={tr('테두리 색')} />}
+                            <label className="te-check" title={tr('그림자')}>
+                                <input type="checkbox" checked={!!textEdit.shadow} onChange={e => setTextEdit(te => te ? ({ ...te, shadow: e.target.checked }) : te)} />{tr('그림자')}
+                            </label>
+                            {textEdit.shadow && <input type="color" value={(textEdit.shadowColor || '#000000').startsWith('#') ? textEdit.shadowColor : '#000000'} onChange={e => setTextEdit(te => te ? ({ ...te, shadowColor: e.target.value }) : te)} className="text-editor-color" title={tr('그림자 색')} />}
+                            <label className="te-check" title={tr('위→아래 2색 그라데이션')}>
+                                <input type="checkbox" checked={!!textEdit.gradient} onChange={e => setTextEdit(te => te ? ({ ...te, gradient: e.target.checked }) : te)} />{tr('그라데이션')}
+                            </label>
+                            {textEdit.gradient && <input type="color" value={textEdit.color2 || '#ffffff'} onChange={e => setTextEdit(te => te ? ({ ...te, color2: e.target.value }) : te)} className="text-editor-color" title={tr('그라데이션 끝 색')} />}
+                            <label className="te-check" title={tr('글자 뒤 배경 박스')}>
+                                <input type="checkbox" checked={!!textEdit.bgColor} onChange={e => setTextEdit(te => te ? ({ ...te, bgColor: e.target.checked ? (te.bgColor || '#ffffff') : '' }) : te)} />{tr('배경')}
+                            </label>
+                            {textEdit.bgColor && <input type="color" value={textEdit.bgColor.startsWith('#') ? textEdit.bgColor : '#ffffff'} onChange={e => setTextEdit(te => te ? ({ ...te, bgColor: e.target.value }) : te)} className="text-editor-color" title={tr('배경 색')} />}
+                            <NumField className="time-input" width={54} title={tr('회전(도)')} value={textEdit.rotation ?? 0} step={5}
+                                onChange={v => setTextEdit(te => te ? ({ ...te, rotation: v }) : te)} />
+                            <NumField className="time-input" width={54} title={tr('곡률(도) — 양수는 위로 휩니다')} value={textEdit.curve ?? 0} step={10}
+                                onChange={v => setTextEdit(te => te ? ({ ...te, curve: Math.max(-180, Math.min(180, v)) }) : te)} />
+                            <label className="te-check" title={tr('좌우 반전')}>
+                                <input type="checkbox" checked={!!textEdit.flipX} onChange={e => setTextEdit(te => te ? ({ ...te, flipX: e.target.checked }) : te)} />{tr('좌우뒤집기')}
+                            </label>
+                            <label className="te-check" title={tr('상하 반전')}>
+                                <input type="checkbox" checked={!!textEdit.flipY} onChange={e => setTextEdit(te => te ? ({ ...te, flipY: e.target.checked }) : te)} />{tr('상하뒤집기')}
+                            </label>
+                            {/* Text animation, visible only during playback. */}
+                            {(() => {
+                                const an = { ...TEXT_ANIM_DEFAULT, ...(textEdit.anim || {}) };
+                                const on = !!textEdit.anim;
+                                const set = (o) => setTextEdit(te => te ? ({ ...te, anim: { ...an, ...o } }) : te);
+                                return (<>
+                                    <div className="te-section">{tr('애니메이션')}</div>
+                                    <label className="te-check" title={tr('재생할 때만 적용됩니다')}>
+                                        <input type="checkbox" checked={on}
+                                            onChange={e => setTextEdit(te => te ? ({ ...te, anim: e.target.checked ? { ...TEXT_ANIM_DEFAULT } : null }) : te)} />{tr('애니메이션')}
+                                    </label>
+                                    {on && <>
+                                        <select className="time-input" style={{ width: 74 }} title={tr('등장')} value={an.inType} onChange={e => set({ inType: e.target.value })}>
+                                            <option value="none">{tr('등장없음')}</option><option value="fade">{tr('페이드')}</option><option value="up">{tr('아래→위')}</option>
+                                            <option value="down">{tr('위→아래')}</option><option value="scale">{tr('확대')}</option><option value="blur">{tr('흐림')}</option>
+                                        </select>
+                                        <select className="time-input" style={{ width: 74 }} title={tr('퇴장')} value={an.outType} onChange={e => set({ outType: e.target.value })}>
+                                            <option value="none">{tr('퇴장없음')}</option><option value="fade">{tr('페이드')}</option><option value="up">{tr('위로')}</option>
+                                            <option value="down">{tr('아래로')}</option><option value="scale">{tr('축소')}</option><option value="blur">{tr('흐림')}</option>
+                                        </select>
+                                        {/* A stagger is a modifier: it needs an entrance or a letter effect to
+                                            spread, and typing overrides it entirely. Offering it when it can do
+                                            nothing is what made the whole feature look broken. */}
+                                        {!an.typing && (an.inType !== 'none' || an.outType !== 'none' || (an.charFx ?? 'none') !== 'none') &&
+                                        <select className="time-input" style={{ width: 92 }} title={tr('글자 하나씩 — 등장/퇴장이 글자마다 차례로 일어납니다')} value={an.charStagger ?? 0}
+                                            onChange={e => set({ charStagger: +e.target.value })}>
+                                            <option value="0">{tr('통째로')}</option><option value="0.4">{tr('글자별 약하게')}</option>
+                                            <option value="0.7">{tr('글자별')}</option><option value="0.9">{tr('글자별 크게')}</option>
+                                        </select>}
+                                        <select className="time-input" style={{ width: 74 }} title={tr('계속 반복되는 강조')} value={an.emphasis} onChange={e => set({ emphasis: e.target.value })}>
+                                            <option value="none">{tr('강조없음')}</option><option value="pulse">{tr('두근두근')}</option><option value="shake">{tr('흔들기')}</option><option value="swing">{tr('갸우뚱')}</option>
+                                        </select>
+                                        {an.emphasis !== 'none' && <>
+                                            <input type="number" className="time-input" style={{ width: 50 }} title={tr('강조 세기')} value={an.emAmount} step={5} min={0}
+                                                onChange={e => set({ emAmount: Math.max(0, +e.target.value || 0) })} />
+                                            <input type="number" className="time-input" style={{ width: 50 }} title={tr('강조 속도')} value={an.emSpeed} step={0.5} min={0}
+                                                onChange={e => set({ emSpeed: Math.max(0, +e.target.value || 0) })} />
+                                        </>}
+                                        <label className="te-check" title={tr('한 글자씩 나타남 — 등장 효과를 고르면 글자마다 그 효과로 들어옵니다')}>
+                                            <input type="checkbox" checked={!!an.typing} onChange={e => set({ typing: e.target.checked })} />{tr('타이핑')}
+                                        </label>
+                                        {an.typing && <input type="number" className="time-input" style={{ width: 56 }} title={tr('초당 글자수')} value={an.typeSpeed} step={2} min={1}
+                                            onChange={e => set({ typeSpeed: Math.max(1, +e.target.value || 1) })} />}
+                                        {/* Its own control rather than a modifier on the entrance: this is an
+                                            entrance in itself, and needing to pick a second one as well was
+                                            why ticking only 'typing' looked like it did nothing. */}
+                                        <select className="time-input" style={{ width: 96 }} title={tr('글자마다 따로 — 각 글자가 저마다 다른 곳에서 들어옵니다')} value={an.charFx ?? 'none'}
+                                            onChange={e => set({ charFx: e.target.value })}>
+                                            <option value="none">{tr('글자효과없음')}</option><option value="scatter">{tr('흩어져 모임')}</option>
+                                            <option value="drop">{tr('하나씩 떨어짐')}</option><option value="zigzag">{tr('위아래 번갈아')}</option>
+                                            <option value="spin">{tr('돌면서')}</option><option value="pop">{tr('톡톡 튀어나옴')}</option>
+                                        </select>
+                                        {(an.charFx ?? 'none') !== 'none' && <input type="number" className="time-input" style={{ width: 56 }} title={tr('글자 효과 세기 (px, 회전은 도)')} value={an.charFxAmount ?? 40} step={10} min={0}
+                                            onChange={e => set({ charFxAmount: Math.max(0, +e.target.value || 0) })} />}
+                                    </>}
+                                </>);
+                            })()}
+                            <div className="te-footer">
+                                <button className="button button-primary" onClick={commitText} style={{ height: 28, padding: '0 12px' }}>{tr('완료')}</button>
+                                <button className="button" onClick={cancelText} style={{ height: 28, padding: '0 12px' }}>{tr('취소')}</button>
+                            </div>
+                        </div>
+        </div>
+    ) : null;
+
     const cutPanelEl = (
                 <CutLayerPanel
                     collapsedCutIds={collapsedCutIds} copiedCut={copiedCut} currentCutId={currentCutId} cuts={cuts}
@@ -3924,8 +4100,11 @@ export default function App() {
                     updCutAnim={updCutAnim} updCutTime={updCutTime} updLayers={updLayers}
                     updCutCamera={updCutCamera} cameraCapture={cameraCapture} setCameraCapture={setCameraCapture}
                     canvasW={CANVAS_W} canvasH={CANVAS_H}
+                    rightTab={rightTab} setRightTab={setRightTab} textEditorBody={textEditorBody} cancelText={cancelText}
                     videoBatches={videoBatches} />
     );
+
+
     const panelEls = { color: colorPanelEl, tools: toolsPanelEl, cut: cutPanelEl };
 
     // Panels docked to one side, each with its splitter facing the canvas.
@@ -4140,184 +4319,6 @@ export default function App() {
                                 <button className="button" onClick={copyLassoSelection} style={{ height: 30, padding: '0 10px' }} title={tr('선택 영역 복사 (다른 컷/레이어에 붙여넣기)')}>{tr('복사')}</button>
                                 <button className="button" onClick={commitSelection} style={{ height: 30, padding: '0 10px' }} title={tr('제자리에 적용(이동/크기)')}>{tr('완료')}</button>
                                 <button className="button" onClick={cancelSelection} style={{ height: 30, padding: '0 10px' }}>{tr('취소')}</button>
-                            </div>
-                        )}
-                        {textEdit && (
-                            <div className="text-editor" ref={textEditorRef} style={{ left: Math.round(textEdit.cssX), top: Math.round(textEdit.cssY) }}>
-                                <textarea
-                                    ref={textAreaRef}
-                                    value={textEdit.text}
-                                    onChange={e => setTextEdit(te => te ? ({ ...te, text: e.target.value }) : te)}
-                                    onKeyDown={e => {
-                                        if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); cancelText(); }
-                                        if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); e.stopPropagation(); commitText(); }
-                                    }}
-                                    placeholder={tr('텍스트 입력 (Ctrl+Enter 완료, Esc 취소)')}
-                                />
-                                <div className="text-editor-row">
-                                    <div className="te-section">{tr('글꼴')}</div>
-                                    <label className="text-editor-label">Size</label>
-                                    {/* No range at all while editing - not per keystroke, and not
-                                        on blur either. Any clamp during editing makes 100
-                                        unreachable: "1" becomes 6 before the zeros arrive, and
-                                        clamping when the field is left does the same thing a
-                                        keystroke later if focus moves between digits. The size is
-                                        held to 6..400 where it is used instead - textRender clamps
-                                        for drawing, and commitText clamps what gets saved. */}
-                                    <NumField
-                                        value={textEdit.fontSize}
-                                        onChange={v => setTextEdit(te => te ? ({ ...te, fontSize: v }) : te)}
-                                        className="text-editor-num"
-                                    />
-                                    {(() => {
-                                        const isPreset = FONT_PRESETS.some(f => f.value === textEdit.fontFamily);
-                                        return (
-                                            <>
-                                                <select
-                                                    className="text-editor-font"
-                                                    value={isPreset ? textEdit.fontFamily : '__custom__'}
-                                                    onChange={e => {
-                                                        const v = e.target.value;
-                                                        setTextEdit(te => te ? ({ ...te, fontFamily: v === '__custom__' ? (te.fontFamily || 'sans-serif') : v }) : te);
-                                                    }}
-                                                    title={tr('폰트')}
-                                                >
-                                                    <option value="__custom__">Custom</option>
-                                                    {/* Grouped by script: a flat list of twenty
-                                                        is harder to use than a short one. Each
-                                                        option previews its own face. */}
-                                                    {fontGroups().map(([group, fonts]) => (
-                                                        <optgroup key={group} label={group}>
-                                                            {fonts.map(f => (
-                                                                <option key={f.value} value={f.value} style={{ fontFamily: f.value }}>{f.label}</option>
-                                                            ))}
-                                                        </optgroup>
-                                                    ))}
-                                                </select>
-                                                {!isPreset && (
-                                                    <input
-                                                        className="text-editor-font"
-                                                        value={textEdit.fontFamily}
-                                                        onChange={e => setTextEdit(te => te ? ({ ...te, fontFamily: e.target.value }) : te)}
-                                                        placeholder="Custom font-family"
-                                                        title={tr('커스텀 폰트')}
-                                                    />
-                                                )}
-                                            </>
-                                        );
-                                    })()}
-                                    <input
-                                        type="color"
-                                        value={textEdit.color}
-                                        onChange={e => setTextEdit(te => te ? ({ ...te, color: e.target.value }) : te)}
-                                        className="text-editor-color"
-                                        title={tr('색상')}
-                                    />
-                                    <button className="button" title={tr('굵게')} onClick={() => setTextEdit(te => te ? ({ ...te, bold: !te.bold }) : te)}
-                                        style={{ height: 26, width: 28, padding: 0, fontWeight: 800, background: textEdit.bold ? 'hsl(var(--ui-h) var(--ui-s) 29%)' : undefined }}>B</button>
-                                    <button className="button" title={tr('기울임')} onClick={() => setTextEdit(te => te ? ({ ...te, italic: !te.italic }) : te)}
-                                        style={{ height: 26, width: 28, padding: 0, fontStyle: 'italic', background: textEdit.italic ? 'hsl(var(--ui-h) var(--ui-s) 29%)' : undefined }}>I</button>
-                                    <select className="time-input" style={{ width: 52 }} title={tr('정렬')} value={textEdit.align || 'left'}
-                                        onChange={e => setTextEdit(te => te ? ({ ...te, align: e.target.value }) : te)}>
-                                        <option value="left">◧</option><option value="center">▣</option><option value="right">◨</option>
-                                    </select>
-                                    <select className="time-input" style={{ width: 54 }} title={tr('줄간격')} value={textEdit.lineHeight ?? 1.25}
-                                        onChange={e => setTextEdit(te => te ? ({ ...te, lineHeight: +e.target.value }) : te)}>
-                                        {[1, 1.15, 1.25, 1.5, 1.8, 2].map(v => <option key={v} value={v}>{v}x</option>)}
-                                    </select>
-                                    <select className="time-input" style={{ width: 58 }} title={tr('자간(글자 간격)')} value={textEdit.letterSpacing ?? 0}
-                                        onChange={e => setTextEdit(te => te ? ({ ...te, letterSpacing: +e.target.value }) : te)}>
-                                        {[-2, 0, 1, 2, 4, 8, 12].map(v => <option key={v} value={v}>{tr('자간')}{v}</option>)}
-                                    </select>
-                                    <div className="te-section">{tr('효과')}</div>
-                                    <label className="te-check" title={tr('가독성용 외곽선')}>
-                                        <input type="checkbox" checked={!!textEdit.outline} onChange={e => setTextEdit(te => te ? ({ ...te, outline: e.target.checked }) : te)} />{tr('테두리')}
-                                    </label>
-                                    {textEdit.outline && <input type="color" value={textEdit.outlineColor || '#ffffff'} onChange={e => setTextEdit(te => te ? ({ ...te, outlineColor: e.target.value }) : te)} className="text-editor-color" title={tr('테두리 색')} />}
-                                    <label className="te-check" title={tr('그림자')}>
-                                        <input type="checkbox" checked={!!textEdit.shadow} onChange={e => setTextEdit(te => te ? ({ ...te, shadow: e.target.checked }) : te)} />{tr('그림자')}
-                                    </label>
-                                    {textEdit.shadow && <input type="color" value={(textEdit.shadowColor || '#000000').startsWith('#') ? textEdit.shadowColor : '#000000'} onChange={e => setTextEdit(te => te ? ({ ...te, shadowColor: e.target.value }) : te)} className="text-editor-color" title={tr('그림자 색')} />}
-                                    <label className="te-check" title={tr('위→아래 2색 그라데이션')}>
-                                        <input type="checkbox" checked={!!textEdit.gradient} onChange={e => setTextEdit(te => te ? ({ ...te, gradient: e.target.checked }) : te)} />{tr('그라데이션')}
-                                    </label>
-                                    {textEdit.gradient && <input type="color" value={textEdit.color2 || '#ffffff'} onChange={e => setTextEdit(te => te ? ({ ...te, color2: e.target.value }) : te)} className="text-editor-color" title={tr('그라데이션 끝 색')} />}
-                                    <label className="te-check" title={tr('글자 뒤 배경 박스')}>
-                                        <input type="checkbox" checked={!!textEdit.bgColor} onChange={e => setTextEdit(te => te ? ({ ...te, bgColor: e.target.checked ? (te.bgColor || '#ffffff') : '' }) : te)} />{tr('배경')}
-                                    </label>
-                                    {textEdit.bgColor && <input type="color" value={textEdit.bgColor.startsWith('#') ? textEdit.bgColor : '#ffffff'} onChange={e => setTextEdit(te => te ? ({ ...te, bgColor: e.target.value }) : te)} className="text-editor-color" title={tr('배경 색')} />}
-                                    <NumField className="time-input" width={54} title={tr('회전(도)')} value={textEdit.rotation ?? 0} step={5}
-                                        onChange={v => setTextEdit(te => te ? ({ ...te, rotation: v }) : te)} />
-                                    <NumField className="time-input" width={54} title={tr('곡률(도) — 양수는 위로 휩니다')} value={textEdit.curve ?? 0} step={10}
-                                        onChange={v => setTextEdit(te => te ? ({ ...te, curve: Math.max(-180, Math.min(180, v)) }) : te)} />
-                                    <label className="te-check" title={tr('좌우 반전')}>
-                                        <input type="checkbox" checked={!!textEdit.flipX} onChange={e => setTextEdit(te => te ? ({ ...te, flipX: e.target.checked }) : te)} />{tr('좌우뒤집기')}
-                                    </label>
-                                    <label className="te-check" title={tr('상하 반전')}>
-                                        <input type="checkbox" checked={!!textEdit.flipY} onChange={e => setTextEdit(te => te ? ({ ...te, flipY: e.target.checked }) : te)} />{tr('상하뒤집기')}
-                                    </label>
-                                    {/* Text animation, visible only during playback. */}
-                                    {(() => {
-                                        const an = { ...TEXT_ANIM_DEFAULT, ...(textEdit.anim || {}) };
-                                        const on = !!textEdit.anim;
-                                        const set = (o) => setTextEdit(te => te ? ({ ...te, anim: { ...an, ...o } }) : te);
-                                        return (<>
-                                            <div className="te-section">{tr('애니메이션')}</div>
-                                            <label className="te-check" title={tr('재생할 때만 적용됩니다')}>
-                                                <input type="checkbox" checked={on}
-                                                    onChange={e => setTextEdit(te => te ? ({ ...te, anim: e.target.checked ? { ...TEXT_ANIM_DEFAULT } : null }) : te)} />{tr('애니메이션')}
-                                            </label>
-                                            {on && <>
-                                                <select className="time-input" style={{ width: 74 }} title={tr('등장')} value={an.inType} onChange={e => set({ inType: e.target.value })}>
-                                                    <option value="none">{tr('등장없음')}</option><option value="fade">{tr('페이드')}</option><option value="up">{tr('아래→위')}</option>
-                                                    <option value="down">{tr('위→아래')}</option><option value="scale">{tr('확대')}</option><option value="blur">{tr('흐림')}</option>
-                                                </select>
-                                                <select className="time-input" style={{ width: 74 }} title={tr('퇴장')} value={an.outType} onChange={e => set({ outType: e.target.value })}>
-                                                    <option value="none">{tr('퇴장없음')}</option><option value="fade">{tr('페이드')}</option><option value="up">{tr('위로')}</option>
-                                                    <option value="down">{tr('아래로')}</option><option value="scale">{tr('축소')}</option><option value="blur">{tr('흐림')}</option>
-                                                </select>
-                                                {/* A stagger is a modifier: it needs an entrance or a letter effect to
-                                                    spread, and typing overrides it entirely. Offering it when it can do
-                                                    nothing is what made the whole feature look broken. */}
-                                                {!an.typing && (an.inType !== 'none' || an.outType !== 'none' || (an.charFx ?? 'none') !== 'none') &&
-                                                <select className="time-input" style={{ width: 92 }} title={tr('글자 하나씩 — 등장/퇴장이 글자마다 차례로 일어납니다')} value={an.charStagger ?? 0}
-                                                    onChange={e => set({ charStagger: +e.target.value })}>
-                                                    <option value="0">{tr('통째로')}</option><option value="0.4">{tr('글자별 약하게')}</option>
-                                                    <option value="0.7">{tr('글자별')}</option><option value="0.9">{tr('글자별 크게')}</option>
-                                                </select>}
-                                                <select className="time-input" style={{ width: 74 }} title={tr('계속 반복되는 강조')} value={an.emphasis} onChange={e => set({ emphasis: e.target.value })}>
-                                                    <option value="none">{tr('강조없음')}</option><option value="pulse">{tr('두근두근')}</option><option value="shake">{tr('흔들기')}</option><option value="swing">{tr('갸우뚱')}</option>
-                                                </select>
-                                                {an.emphasis !== 'none' && <>
-                                                    <input type="number" className="time-input" style={{ width: 50 }} title={tr('강조 세기')} value={an.emAmount} step={5} min={0}
-                                                        onChange={e => set({ emAmount: Math.max(0, +e.target.value || 0) })} />
-                                                    <input type="number" className="time-input" style={{ width: 50 }} title={tr('강조 속도')} value={an.emSpeed} step={0.5} min={0}
-                                                        onChange={e => set({ emSpeed: Math.max(0, +e.target.value || 0) })} />
-                                                </>}
-                                                <label className="te-check" title={tr('한 글자씩 나타남 — 등장 효과를 고르면 글자마다 그 효과로 들어옵니다')}>
-                                                    <input type="checkbox" checked={!!an.typing} onChange={e => set({ typing: e.target.checked })} />{tr('타이핑')}
-                                                </label>
-                                                {an.typing && <input type="number" className="time-input" style={{ width: 56 }} title={tr('초당 글자수')} value={an.typeSpeed} step={2} min={1}
-                                                    onChange={e => set({ typeSpeed: Math.max(1, +e.target.value || 1) })} />}
-                                                {/* Its own control rather than a modifier on the entrance: this is an
-                                                    entrance in itself, and needing to pick a second one as well was
-                                                    why ticking only 'typing' looked like it did nothing. */}
-                                                <select className="time-input" style={{ width: 96 }} title={tr('글자마다 따로 — 각 글자가 저마다 다른 곳에서 들어옵니다')} value={an.charFx ?? 'none'}
-                                                    onChange={e => set({ charFx: e.target.value })}>
-                                                    <option value="none">{tr('글자효과없음')}</option><option value="scatter">{tr('흩어져 모임')}</option>
-                                                    <option value="drop">{tr('하나씩 떨어짐')}</option><option value="zigzag">{tr('위아래 번갈아')}</option>
-                                                    <option value="spin">{tr('돌면서')}</option><option value="pop">{tr('톡톡 튀어나옴')}</option>
-                                                </select>
-                                                {(an.charFx ?? 'none') !== 'none' && <input type="number" className="time-input" style={{ width: 56 }} title={tr('글자 효과 세기 (px, 회전은 도)')} value={an.charFxAmount ?? 40} step={10} min={0}
-                                                    onChange={e => set({ charFxAmount: Math.max(0, +e.target.value || 0) })} />}
-                                            </>}
-                                        </>);
-                                    })()}
-                                    <div className="te-footer">
-                                        <button className="button button-primary" onClick={commitText} style={{ height: 28, padding: '0 12px' }}>{tr('완료')}</button>
-                                        <button className="button" onClick={cancelText} style={{ height: 28, padding: '0 12px' }}>{tr('취소')}</button>
-                                    </div>
-                                </div>
                             </div>
                         )}
                     </div>

--- a/src/ui/CutLayerPanel.jsx
+++ b/src/ui/CutLayerPanel.jsx
@@ -16,16 +16,46 @@ export function CutLayerPanel({
     renderLayers, rightW, selectedCutIds, selectedText, setDragLayerInfo,
     setDropInfo, setRenamingCutId, setSelectedText, setShowRight, showRight,
     toggleCutCollapse, toggleCutSettings, toggleTextVisible, updCutAnim, updCutTime,
-    updLayers, videoBatches,
+    updLayers, videoBatches, rightTab, setRightTab, textEditorBody, cancelText,
 }) {
+    // The text editor arrives as a tab rather than a panel of its own. Two panels side by side
+    // in the right dock left the canvas a sliver, and a window over the canvas covered the very
+    // drawing it was editing.
+    const showingText = rightTab === 'text' && !!textEditorBody;
+    const tab = (id, label, active, onClose) => (
+        <div key={id} onClick={() => setRightTab(id)}
+            style={{
+                display: 'flex', alignItems: 'center', gap: 6, padding: '4px 9px', cursor: 'pointer',
+                borderRadius: '6px 6px 0 0', fontSize: 11, letterSpacing: '0.04em', whiteSpace: 'nowrap',
+                background: active ? 'hsl(var(--ui-h) var(--ui-s) 17%)' : 'transparent',
+                color: active ? '#fff' : '#9a9ab0',
+                borderBottom: active ? '2px solid var(--accent-soft)' : '2px solid transparent',
+            }}>
+            <span>{label}</span>
+            {onClose && <span onClick={e => { e.stopPropagation(); onClose(); }} title={tr('취소')}
+                style={{ opacity: 0.6, fontSize: 12, lineHeight: 1 }}>✕</span>}
+        </div>
+    );
     return (
             <div className="right-panel" style={{ width: rightW, flexShrink: 0 }}>
                 {/* panel-head is what the docking drag looks for, so this header has to carry the
                     class the other panels use or CUT / LAYER cannot be dragged between docks. */}
-                <div className="panel-head" style={{ marginBottom: 10 }}>
-                    <span className="panel-title">CUT / LAYER</span>
+                {/* panel-head is what the docking drag looks for, and the drag handler ignores
+                    anything inside a button - the tabs are plain divs, so they get a stopPropagation
+                    of their own rather than starting a panel drag. */}
+                <div className="panel-head" style={{ marginBottom: 8, gap: 2 }}
+                    onPointerDown={e => { if (e.target.closest('[data-tab]')) e.stopPropagation(); }}>
+                    <div style={{ display: 'flex', alignItems: 'stretch', gap: 2, flex: 1, minWidth: 0, overflowX: 'auto' }} data-tab>
+                        {tab('cut', 'CUT / LAYER', !showingText)}
+                        {textEditorBody && tab('text', 'TEXT', showingText, cancelText)}
+                    </div>
                     <button className="icon-btn" onClick={() => setShowRight(false)}><ChevronRight size={14} /></button>
                 </div>
+                {showingText && textEditorBody}
+                {/* Everything below belongs to the CUT / LAYER tab. `hidden` rather than an
+                    unmount: the cut list keeps its scroll position and its expanded rows while
+                    a text is being edited, so switching back is where you left off. */}
+                <div className="cut-tab-body" hidden={showingText}>
                 <div className="cut-list">
                     {[...cuts].sort((a, b) => (a.track || 0) - (b.track || 0) || a.startTime - b.startTime).map((cut, _i, _arr) => { const isCur = currentCutId === cut.id; const collapsed = collapsedCutIds.has(cut.id); const layerCount = cut.layers.filter(l => l.type === 'layer').length; const showTrackHeader = _i === 0 || (_arr[_i - 1].track || 0) !== (cut.track || 0); return (
                         <React.Fragment key={cut.id}>
@@ -119,6 +149,7 @@ export function CutLayerPanel({
                         ))}
                     </div>
                 )}
+                </div>
             </div>
     );
 }


### PR DESCRIPTION
## What

The text editor was a floating window anchored where you clicked. With curve, flip, per-character effects and the rest, it had grown tall enough to cover the drawing it was meant to be editing — and being anchored, it sat somewhere different every time.

It is now a **tab in the cut panel**, the way the project tabs share one bar: `CUT / LAYER` and `TEXT`. Opening a text selects the tab, closing it goes back to the cuts, and you can switch to the cut list mid-edit and back without losing anything.

## The approach that did not survive contact

The first commit here made it a fourth dockable panel beside CUT / LAYER, which was the obvious reading of "컷/레이어 자리에". It works, but two panels in the right dock left the canvas **415px of a 1035px window** — the opposite of the problem being solved. Sharing one panel's space costs the canvas nothing.

## Details

- The cut list is **hidden, not unmounted**, so its scroll position and expanded rows survive a trip to the text tab.
- The tabs are plain divs inside `.panel-head`, which is what the panel-docking drag looks for — so they stop propagation of their own rather than starting a drag.
- The effect that follows the editor names its condition instead of writing `[!!textEdit]`. A dependency the linter cannot read is a dependency nobody can check, and inlining it would have meant re-running on every keystroke — which would drag you back from the cut list mid-edit.
- The old `useLayoutEffect` that nudged the floating window back on screen is gone with the window.

## Verified

`npm run check` green — 548 tests, hook baseline unchanged at 12 warnings.

In a browser, driving the real UI:

| | |
|---|---|
| right panels | 1 (not two side by side) |
| tabs | `CUT / LAYER`, `TEXT` |
| canvas width, before → after opening | 415 → **415** |
| opening a text | TEXT tab selected, cut list hidden |
| clicking CUT / LAYER mid-edit | cut list back, TEXT tab still there |
| clicking TEXT again | editor back with its values |
