### PR TITLE
refactor: one scratch canvas helper, one cache tail

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -331,6 +331,7 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `samplePath` | Sample a polyline path at normalized position s in [0,1]. |
 | `sampleWave` | Samples the waveform cyclically over 0..1 with linear interpolation. |
 | `sizeCanvas` | Resizes only when the size differs. Assigning `canvas.width` reallocates the backing store even when the value is unchanged - 8MB at 1920x1080, and the measured 79MB/s that ran the tab out of memory. |
+| `scratchCanvas` | A full-size scratch canvas kept in a ref: allocated once, then sized and cleared for reuse. Three places in the composite path did this by hand and disagreed about the clear - two cleared after a resize, which the resize had already done. Reuse is not a micro-optimisation here: a fresh canvas is 8MB per masked layer per frame. |
 | `strokeSig` | used to invalidate the layer canvas cache without stringifying the whole array. |
 | `swayWeightAt` | bend one direction while the next bends back. |
 | `targetCanvasFor` | two shapes people actually publish. |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,7 +58,7 @@ import { dragCut, resizeCut } from './core/cutOps.js';
 import {
     DEFAULT_CUT_DURATION, CANVAS_W as CANVAS_W_DEFAULT, CANVAS_H as CANVAS_H_DEFAULT, FONT_PRESETS, fontGroups,
     pointInPolygon, dist, safeArray, hexToRgb, bucketFillTransparentRegion,
-    layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas,
+    layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas,
     flattenForCanvas, flattenLayersInUiOrder, strokeSig, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, swayWeightAt, morphPrepare,
     accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
     targetCanvasFor, imageDataCanvas, cutProgress,
@@ -2974,6 +2974,24 @@ export default function App() {
         // loop) — it's a safety net if the prefetch fell behind. When paused, decoding is driven only
         // by the prefetch effect (a paused decode fires setState, which would loop from here).
         const store = bitmapStoreRef.current;
+        // Draw the layer into the cache under a signature. The complete and the incomplete paths
+        // below were the same six lines twice, differing only in that signature - and two copies
+        // of a caching rule are two chances for them to drift into disagreeing about what is
+        // cached under what.
+        //
+        // Resize only when the size actually changed: this canvas is reused every boiling phase,
+        // ten times a second, and re-assigning the same width reallocated 8MB each time - the
+        // measured 79MB/s that ran the tab out of memory. drawStrokesOnCtx clears it either way,
+        // which is why this does not go through scratchCanvas.
+        const bake = (signature) => {
+            const cnv = hit || document.createElement('canvas');
+            sizeCanvas(cnv, CANVAS_W, CANVAS_H);
+            drawStrokesOnCtx(cnv.getContext('2d'), layer.strokes, true, store, rOpts);
+            cnv.dataset.strokes = signature;
+            map.delete(slotKey); map.set(slotKey, cnv);   // re-insert = most recently used
+            while (map.size > LAYER_CANVAS_LRU) map.delete(map.keys().next().value);
+            return cnv;
+        };
         const missing = [];
         for (const st of safeArray(layer.strokes)) { if (st.tool === 'paste' && st.bitmapId) { const e = store.get(st.bitmapId); if (e && e.blob) { if (!e.imageBitmap && !e.imageData) missing.push(st.bitmapId); else if (e.imageBitmap) touchDecoded(st.bitmapId); } } }
         if (missing.length) {
@@ -2984,24 +3002,9 @@ export default function App() {
             // layer with it and leave the screen blank, which is what happened when a server
             // asset was unavailable. Instead the strokes that can be drawn are drawn, and the
             // signature is marked incomplete so it redraws once the decode finishes.
-            const part = document.createElement('canvas');
-            sizeCanvas(part, CANVAS_W, CANVAS_H);
-            drawStrokesOnCtx(part.getContext('2d'), layer.strokes, true, store, rOpts);
-            part.dataset.strokes = sig + '|miss' + missing.length;
-            map.delete(slotKey); map.set(slotKey, part);
-            while (map.size > LAYER_CANVAS_LRU) map.delete(map.keys().next().value);
-            return part;
+            return bake(sig + '|miss' + missing.length);
         }
-        // Resize only when the size actually changed. This canvas is reused every boiling phase,
-        // ten times a second, and re-assigning the same width reallocated 8MB each time - the
-        // measured 79MB/s that ran the tab out of memory. drawStrokesOnCtx clears it either way.
-        const cnv = hit || document.createElement('canvas');
-        sizeCanvas(cnv, CANVAS_W, CANVAS_H);
-        drawStrokesOnCtx(cnv.getContext('2d'), layer.strokes, true, bitmapStoreRef.current, rOpts);
-        cnv.dataset.strokes = sig;
-        map.delete(slotKey); map.set(slotKey, cnv); // re-insert = most recently used
-        while (map.size > LAYER_CANVAS_LRU) map.delete(map.keys().next().value);
-        return cnv;
+        return bake(sig);
     };
 
 
@@ -3041,10 +3044,7 @@ export default function App() {
         }
         if (parts.length === 0) return baseCanvas;
 
-        const paint = clipPaintRef.current || (clipPaintRef.current = document.createElement('canvas'));
-        sizeCanvas(paint, CANVAS_W, CANVAS_H);
-        const pctx = paint.getContext('2d');
-        pctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+        const { canvas: paint, ctx: pctx } = scratchCanvas(clipPaintRef, CANVAS_W, CANVAS_H);
         pctx.globalCompositeOperation = 'source-over';
         for (const c of parts) pctx.drawImage(c, 0, 0);
 
@@ -3053,10 +3053,7 @@ export default function App() {
         pctx.drawImage(baseCanvas, 0, 0);
         pctx.globalCompositeOperation = 'source-over';
 
-        const out = clipScratchRef.current || (clipScratchRef.current = document.createElement('canvas'));
-        sizeCanvas(out, CANVAS_W, CANVAS_H);
-        const octx = out.getContext('2d');
-        octx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+        const { canvas: out, ctx: octx } = scratchCanvas(clipScratchRef, CANVAS_W, CANVAS_H);
         octx.drawImage(baseCanvas, 0, 0);
         octx.drawImage(paint, 0, 0);
         return out;
@@ -3208,9 +3205,7 @@ export default function App() {
                     // Reused rather than allocated. This runs inside the composite loop, so a
                     // fresh canvas here is 8MB per masked layer per frame - sixty times a second
                     // while playing, which is the shape of allocation that took a tab out once.
-                    const tmp = maskScratchRef.current || (maskScratchRef.current = document.createElement('canvas'));
-                    const tctx = tmp.getContext('2d');
-                    if (!sizeCanvas(tmp, CANVAS_W, CANVAS_H)) tctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+                    const { canvas: tmp, ctx: tctx } = scratchCanvas(maskScratchRef, CANVAS_W, CANVAS_H);
                     tctx.setTransform(1, 0, 0, 1, 0, 0);
                     tctx.globalAlpha = 1.0;
                     tctx.globalCompositeOperation = 'source-over';

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -587,6 +587,28 @@ export function sizeCanvas(cnv, w, h) {
     cnv.height = h;
     return true;
 }
+/**
+ * A scratch canvas kept in a ref: allocated once, then sized and cleared for reuse.
+ *
+ * Three places in the composite path did this by hand, and the hand-written versions disagreed
+ * about the clear. Two called clearRect unconditionally after sizing, which is wasted work
+ * whenever the size did change - resizing a canvas clears it. Only one checked. They agree now,
+ * and the check is here rather than at three call sites.
+ *
+ * The reuse is not a micro-optimisation. These run inside the per-frame composite loop, so a
+ * fresh canvas is 8MB per masked layer per frame - the shape of allocation that took a tab out.
+ *
+ * @param {{current: HTMLCanvasElement|null}} ref
+ * @param {number} w
+ * @param {number} h
+ * @returns {{ canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D }}
+ */
+export function scratchCanvas(ref, w, h) {
+    const canvas = ref.current || (ref.current = document.createElement('canvas'));
+    const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+    if (!sizeCanvas(canvas, w, h)) ctx.clearRect(0, 0, w, h);
+    return { canvas, ctx };
+}
 
 // Drawing an ImageData somewhere other than where it starts.
 //

--- a/test/canvasUtils.test.js
+++ b/test/canvasUtils.test.js
@@ -14,8 +14,7 @@ import {
     pointInPolygon, dist, safeArray, hexToRgb, fitRect, layerKey, strokeSig,
     applyEase, triwave, swayWeightAt, sampleWave, sampleKeys, targetCanvasFor,
     computeCutAnim, flattenLayersInUiOrder, sizeCanvas, dilateMask, FONT_PRESETS, fontGroups,
-cutDuration, cutProgress,
-} from '../src/canvas/canvasUtils.js';
+cutDuration, cutProgress, scratchCanvas } from '../src/canvas/canvasUtils.js';
 
 const near = (a, b, eps = 1e-9) => assert.ok(Math.abs(a - b) < eps, `${a} ≈ ${b}`);
 
@@ -294,4 +293,56 @@ test('cutProgress on a zero-length cut is a number, not NaN', () => {
     const p = cutProgress({ startTime: 3, endTime: 3 }, 3);
     assert.ok(Number.isFinite(p), `got ${p}`);
     assert.ok(p >= 0 && p <= 1);
+});
+
+// --- scratchCanvas -----------------------------------------------------------------------------
+
+/** A canvas-shaped stub: enough of the surface for sizing and clearing. */
+function fakeCanvas() {
+    const ctx = { cleared: [] , clearRect: (...a) => ctx.cleared.push(a) };
+    return { width: 0, height: 0, getContext: () => ctx, _ctx: ctx };
+}
+
+test('scratchCanvas allocates once and reuses the same canvas', () => {
+    const made = [];
+    const realDoc = globalThis.document;
+    globalThis.document = { createElement: () => { const c = fakeCanvas(); made.push(c); return c; } };
+    try {
+        const ref = { current: null };
+        const a = scratchCanvas(ref, 100, 50);
+        const b = scratchCanvas(ref, 100, 50);
+        assert.equal(made.length, 1, 'a second call must not allocate 8MB again');
+        assert.equal(a.canvas, b.canvas);
+        assert.equal(ref.current, a.canvas);
+    } finally { globalThis.document = realDoc; }
+});
+
+test('scratchCanvas sizes the canvas it is given', () => {
+    const ref = { current: fakeCanvas() };
+    const { canvas } = scratchCanvas(ref, 640, 360);
+    assert.equal(canvas.width, 640);
+    assert.equal(canvas.height, 360);
+});
+
+test('a resize does the clearing, so scratchCanvas does not clear as well', () => {
+    // Assigning width to a canvas clears it. Clearing again is wasted work on a full-size canvas
+    // inside the composite loop, which is exactly where this runs.
+    const ref = { current: fakeCanvas() };
+    const { ctx } = scratchCanvas(ref, 640, 360);
+    assert.deepEqual(ctx.cleared, []);
+});
+
+test('a canvas already the right size is cleared, because nothing else did it', () => {
+    const c = fakeCanvas();
+    c.width = 640; c.height = 360;
+    const { ctx } = scratchCanvas({ current: c }, 640, 360);
+    assert.deepEqual(ctx.cleared, [[0, 0, 640, 360]]);
+});
+
+test('the second call at the same size clears, the first does not', () => {
+    const ref = { current: fakeCanvas() };
+    const { ctx } = scratchCanvas(ref, 320, 180);
+    assert.equal(ctx.cleared.length, 0, 'first call resized');
+    scratchCanvas(ref, 320, 180);
+    assert.equal(ctx.cleared.length, 1, 'second call had nothing to resize');
 });


### PR DESCRIPTION
Two duplications in the composite path, both the kind that drift.

## `scratchCanvas(ref, w, h)`

Three places wrote out "a canvas kept in a ref, sized and cleared" by hand, and **the three copies disagreed**:

```js
// two of them
sizeCanvas(paint, W, H);
paint.getContext('2d').clearRect(0, 0, W, H);

// the third
if (!sizeCanvas(tmp, W, H)) tctx.clearRect(0, 0, W, H);
```

Resizing a canvas clears it, so the first form does the clearing twice whenever the size actually changed — on a full-size canvas, inside the per-frame composite loop. Only one of the three knew that. They agree now and the check lives in one place.

The helper keeps the ref rather than hiding it: the reuse is not a micro-optimisation. A fresh canvas is 8MB per masked layer per frame — the allocation shape that took a tab out once already.

## One cache tail instead of two

In the layer-canvas builder, the complete path and the incomplete-bitmap path were the same six lines twice, differing only in the signature they cached under. Two copies of a caching rule are two chances to disagree about what is cached under what.

```js
return bake(sig + '|miss' + missing.length);   // …some strokes could not be drawn yet
return bake(sig);                              // …all of them could
```

The incomplete path allocated a fresh canvas where the other reused `hit`. That branch is only reached when `hit` is absent (it returns early otherwise), so sharing the line changes nothing.

## Verified

`npm run check` green — 553 tests, 5 of them new for the helper, including that a resize is left to do its own clearing.

A markup-free change in the render hot path is exactly where "the build passed" means least, so the composite was driven in a browser:

| | ink |
|---|---|
| a band on the base layer | 476 |
| a stroke across it on a second layer | 788 |
| clipping on | 314 |
| clipping off again | **788** |

The exact return to 788 is the point: a reused scratch canvas that stopped being cleared correctly would leave residue and would not round-trip to the same number.
