### PR TITLE
refactor: one answer to "is this bitmap drawable yet"

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -391,6 +391,8 @@ Which pasted bitmaps a frame needs but does not have decoded yet.
 
 | | |
 |---|---|
+| `bitmapPending` | Whether a bitmap is known but not yet drawable. The four-term predicate four places wrote out separately; the cost of them disagreeing is a blank layer cached under a signature that says it is complete. |
+| `scanLayerBitmaps` | One layer split into what it can and cannot draw yet. The decoded half is only the ImageBitmaps, because that is the form the LRU evicts and so the only one worth touching. |
 | `pendingBitmapIds` | Playback asks so it can hold the last frame instead of flashing a half-drawn one; the frame exporter asks so it can wait for the decode. Both used to be the same nested loop written twice. |
 
 ## `src/engine/selectCuts.js`

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,7 +51,7 @@ import { clipGroups, canClip } from './core/clipping.js';
 import { setLayerClipped } from './core/cutsReducer.js';
 import { onionNeighbours, topCutAt } from './engine/selectCuts.js';
 import { evaluateFrame } from './engine/evaluateFrame.js';
-import { pendingBitmapIds } from './engine/pendingBitmaps.js';
+import { pendingBitmapIds, scanLayerBitmaps } from './engine/pendingBitmaps.js';
 import { makeZip, frameName } from './export/zip.js';
 import { unusedBitmapIds } from './core/bitmapRefs.js';
 import { dragCut, resizeCut } from './core/cutOps.js';
@@ -2849,9 +2849,7 @@ export default function App() {
                 if (!canvas || canvas.dataset.strokes !== layerStrokes) {
                     // Skip (don't cache a blank) if a frame isn't decoded yet — the prefetch effect
                     // decodes it and repaints. Do NOT request a decode here (would loop with tick).
-                    let notReady = false;
-                    for (const st of safeArray(layer.strokes)) { if (st.tool === 'paste' && st.bitmapId) { const e = bitmapStoreRef.current.get(st.bitmapId); if (e && e.blob && !e.imageBitmap && !e.imageData) { notReady = true; break; } } }
-                    if (notReady) continue;
+                    if (scanLayerBitmaps(layer, bitmapStoreRef.current).pending.length) continue;
                     const newCanvas = canvas || document.createElement('canvas');
                     sizeCanvas(newCanvas, CANVAS_W, CANVAS_H);
                     drawStrokesOnCtx(newCanvas.getContext('2d'), layer.strokes, true, bitmapStoreRef.current, { roughen: layer.roughen || 0 });
@@ -2992,8 +2990,10 @@ export default function App() {
             while (map.size > LAYER_CANVAS_LRU) map.delete(map.keys().next().value);
             return cnv;
         };
-        const missing = [];
-        for (const st of safeArray(layer.strokes)) { if (st.tool === 'paste' && st.bitmapId) { const e = store.get(st.bitmapId); if (e && e.blob) { if (!e.imageBitmap && !e.imageData) missing.push(st.bitmapId); else if (e.imageBitmap) touchDecoded(st.bitmapId); } } }
+        const scan = scanLayerBitmaps(layer, store);
+        const missing = scan.pending;
+        // Anything this layer did draw from is now the most recently used, so the LRU keeps it.
+        for (const id of scan.decoded) touchDecoded(id);
         if (missing.length) {
             if (isPlayingRef.current) requestFrameDecode(missing);
             if (cached || hit) return cached || hit;

--- a/src/engine/pendingBitmaps.js
+++ b/src/engine/pendingBitmaps.js
@@ -1,14 +1,56 @@
-// Which pasted bitmaps a set of cuts needs but does not have decoded yet.
+// Which pasted bitmaps a layer or a frame needs but does not have decoded yet.
 //
-// Two callers ask the same question for opposite reasons. Playback asks so it can hold the last
-// frame instead of flashing a half-drawn one; the frame exporter asks so it can wait for the
-// decode and write a frame that is actually complete. Both used to be the same nested loop,
-// which is the kind of duplication where the two copies quietly drift apart.
+// Four callers ask this, for four reasons. Playback asks so it can hold the last frame instead
+// of flashing a half-drawn one. The frame exporter asks so it can wait for the decode and write
+// a frame that is actually complete. The layer cache asks twice: once to avoid baking a blank
+// canvas, and once to note which bitmaps it did use so the LRU keeps them.
+//
+// All four were the same nested loop around the same four-term predicate, written out separately.
+// A predicate copied four times is four chances to disagree about what "decoded" means, and the
+// cost of disagreeing here is a blank layer cached under a signature that says it is complete.
 
 /**
  * @typedef {{ blob?: unknown, imageBitmap?: unknown, imageData?: unknown }} BitmapEntry
  * @typedef {{ get(id: string): BitmapEntry | undefined }} BitmapStore
  */
+
+/**
+ * Whether this bitmap is known but not yet drawable.
+ *
+ * A blob with nothing decoded from it is the pending case. No blob at all means there is nothing
+ * to wait for - it was never going to arrive - and either decoded form is enough to draw with.
+ *
+ * @param {BitmapEntry | undefined | null} entry
+ * @returns {boolean}
+ */
+export function bitmapPending(entry) {
+    return !!(entry && entry.blob && !entry.imageBitmap && !entry.imageData);
+}
+
+/**
+ * The pasted bitmaps one layer refers to, split by whether they can be drawn yet.
+ *
+ * `decoded` is only the ones held as an ImageBitmap, because that is the form the LRU evicts and
+ * so the only one worth touching. Ids appear once each.
+ *
+ * @param {any} layer
+ * @param {BitmapStore} store
+ * @returns {{ pending: string[], decoded: string[] }}
+ */
+export function scanLayerBitmaps(layer, store) {
+    const pending = [];
+    const decoded = [];
+    if (!layer || !store) return { pending, decoded };
+    const seen = new Set();
+    for (const stroke of (Array.isArray(layer.strokes) ? layer.strokes : [])) {
+        if (stroke.tool !== 'paste' || !stroke.bitmapId || seen.has(stroke.bitmapId)) continue;
+        seen.add(stroke.bitmapId);
+        const entry = store.get(stroke.bitmapId);
+        if (bitmapPending(entry)) pending.push(stroke.bitmapId);
+        else if (entry && entry.imageBitmap) decoded.push(stroke.bitmapId);
+    }
+    return { pending, decoded };
+}
 
 /**
  * @param {any[]} cuts the cuts drawn in this frame, not the whole document
@@ -23,15 +65,10 @@ export function pendingBitmapIds(cuts, store) {
         for (const layer of (cut && Array.isArray(cut.layers) ? cut.layers : [])) {
             // Folders hold no pixels, and a hidden layer is not drawn, so neither can stall a frame.
             if (layer.type !== 'layer' || layer.visible === false) continue;
-            for (const stroke of (Array.isArray(layer.strokes) ? layer.strokes : [])) {
-                if (stroke.tool !== 'paste' || !stroke.bitmapId || seen.has(stroke.bitmapId)) continue;
-                const entry = store.get(stroke.bitmapId);
-                // A blob with nothing decoded from it is the pending case. No blob at all means
-                // there is nothing to wait for, and either decoded form is enough to draw with.
-                if (entry && entry.blob && !entry.imageBitmap && !entry.imageData) {
-                    seen.add(stroke.bitmapId);
-                    out.push(stroke.bitmapId);
-                }
+            for (const id of scanLayerBitmaps(layer, store).pending) {
+                if (seen.has(id)) continue;
+                seen.add(id);
+                out.push(id);
             }
         }
     }

--- a/test/pendingBitmaps.test.js
+++ b/test/pendingBitmaps.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { pendingBitmapIds } from '../src/engine/pendingBitmaps.js';
+import { pendingBitmapIds, scanLayerBitmaps, bitmapPending } from '../src/engine/pendingBitmaps.js';
 
 const store = (obj) => ({ get: (id) => obj[id] });
 const cut = (...layers) => ({ layers });
@@ -57,4 +57,48 @@ test('missing or malformed input is empty rather than a crash', () => {
     assert.deepEqual(pendingBitmapIds([cut(layer(paste('a')))], null), []);
     assert.deepEqual(pendingBitmapIds([{}, { layers: null }], store({})), []);
     assert.deepEqual(pendingBitmapIds([cut({ type: 'layer' })], store({})), []);
+});
+
+// --- the shared predicate ----------------------------------------------------------------------
+
+test('bitmapPending is only true for a blob with nothing decoded from it', () => {
+    assert.equal(bitmapPending({ blob: {} }), true);
+    assert.equal(bitmapPending({ blob: {}, imageBitmap: {} }), false);
+    assert.equal(bitmapPending({ blob: {}, imageData: {} }), false);
+    assert.equal(bitmapPending({}), false, 'no blob means nothing to wait for');
+    assert.equal(bitmapPending(undefined), false);
+    assert.equal(bitmapPending(null), false);
+});
+
+test('scanLayerBitmaps splits a layer into what it can and cannot draw', () => {
+    const s = store({ a: { blob: {} }, b: { blob: {}, imageBitmap: {} }, c: { blob: {}, imageData: {} } });
+    const out = scanLayerBitmaps(layer(paste('a'), paste('b'), paste('c')), s);
+    assert.deepEqual(out.pending, ['a']);
+    assert.deepEqual(out.decoded, ['b'], 'only ImageBitmaps are worth touching: they are what the LRU evicts');
+});
+
+test('scanLayerBitmaps reports each id once however often it is used', () => {
+    const s = store({ a: { blob: {} }, b: { blob: {}, imageBitmap: {} } });
+    const out = scanLayerBitmaps(layer(paste('a'), paste('a'), paste('b'), paste('b')), s);
+    assert.deepEqual(out.pending, ['a']);
+    assert.deepEqual(out.decoded, ['b']);
+});
+
+test('scanLayerBitmaps ignores strokes that are not pasted bitmaps', () => {
+    const l = layer({ tool: 'pen', bitmapId: 'a' }, { tool: 'paste' }, paste('b'));
+    const out = scanLayerBitmaps(l, store({ a: { blob: {} }, b: { blob: {} } }));
+    assert.deepEqual(out.pending, ['b']);
+});
+
+test('scanLayerBitmaps survives a layer with nothing in it', () => {
+    assert.deepEqual(scanLayerBitmaps({}, store({})), { pending: [], decoded: [] });
+    assert.deepEqual(scanLayerBitmaps(null, store({})), { pending: [], decoded: [] });
+    assert.deepEqual(scanLayerBitmaps(layer(paste('a')), null), { pending: [], decoded: [] });
+});
+
+test('pendingBitmapIds and scanLayerBitmaps agree, because one is built on the other', () => {
+    // The point of the refactor: four copies of this predicate cannot drift if there is one.
+    const s = store({ a: { blob: {} }, b: { blob: {}, imageBitmap: {} }, c: { blob: {} } });
+    const l = layer(paste('a'), paste('b'), paste('c'));
+    assert.deepEqual(pendingBitmapIds([cut(l)], s), scanLayerBitmaps(l, s).pending);
 });


### PR DESCRIPTION
## What

Four places asked the same question and four wrote out the same four-term predicate:

```js
e && e.blob && !e.imageBitmap && !e.imageData
```

- **playback** asks so it can hold the last frame rather than flash a half-drawn one
- **the exporter** asks so it can wait for the decode
- **the layer cache** asks twice — once to avoid baking a blank canvas, once to note which bitmaps it did use so the LRU keeps them

Two were already behind `pendingBitmapIds`; the other two were still loops in `App.jsx`.

Four copies of a predicate are four chances to disagree about what "decoded" means, and the cost of disagreeing here is **a blank layer cached under a signature that says it is complete** — not a crash, just a drawing that never comes back.

`bitmapPending` is the predicate. `scanLayerBitmaps` splits one layer into what it can and cannot draw yet, and `pendingBitmapIds` is now built on it, so the module cannot disagree with itself either.

Behaviour is unchanged except that ids are reported once each rather than once per stroke: `requestFrameDecode` already filtered duplicates, and touching the same id twice was the same LRU move twice.

## Verified

`npm run check` green — 559 tests, 6 of them new, including that `pendingBitmapIds` and `scanLayerBitmaps` agree, which is the property the refactor exists to guarantee.

Past the unit tests, the interesting path is a restore, where bitmaps arrive as blobs and have to decode before the cache may bake them.

The pixels could not tell me whether a paste stroke existed at all — the lasso paste landed on identical ink, so the count did not move. So I read the autosaved document back out of IndexedDB instead: **3 paste strokes, 4 stored bitmaps**. Reloading and restoring that document renders at the same ink with no console errors, which is the decode-then-bake path running through the unified scan.
