### PR TITLE
docs: HELPERS.md was 70% wrong, and the check could not tell

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -20,8 +20,8 @@ Which stored bitmaps are still reachable, for garbage collection.
 
 | | |
 |---|---|
-| `collectUsedBitmapIds` | Ids referenced by the strokes of a list of cuts. */ |
-| `unusedBitmapIds` | Ids referenced by the strokes of a list of cuts. */ |
+| `collectUsedBitmapIds` | Every bitmap id still referenced by anything that can bring it back: the cuts, the undo history, the cut clipboard, the lasso clipboard and the live selection. Freeing something an undo still needs is not a leak, it is an undo that comes back blank. |
+| `unusedBitmapIds` | Ids present in the store that nothing references any more. |
 
 ## `src/core/camera.js`
 
@@ -29,11 +29,11 @@ Camera moves: presets, drawn paths, and the transform they resolve to.
 
 | | |
 |---|---|
-| `applyCamera` | No camera at all: the default, and what every existing project has. */ |
+| `applyCamera` | Put the camera onto a 2D context. The caller owns the save/restore. Reads as: move the origin to the middle of the frame, scale and tilt about it, then shift so the camera's centre is the thing sitting there. |
 | `CAMERA_DEFAULT` | No camera at all: the default, and what every existing project has. |
-| `CAMERA_PRESETS` | No camera at all: the default, and what every existing project has. */ |
-| `computeCamera` | No camera at all: the default, and what every existing project has. */ |
-| `resolveCamera` | No camera at all: the default, and what every existing project has. */ |
+| `CAMERA_PRESETS` | The fixed moves. Each returns the same shape a hand-drawn camera produces, so nothing downstream has to know which one it came from. Keyed by id; the label is a translation key resolved by the UI. |
+| `computeCamera` | Where the camera is at a normalised time through the cut. |
+| `resolveCamera` | Resolve a camera setting into the path and zoom range actually used. A drawn path wins over the preset's own, so somebody can pick "ken burns" for its zoom and then replace the movement without losing the zoom. |
 | `zoomForDrift` | The smallest zoom at which a camera may sit that far off centre without the frame running off the artwork. |
 
 ## `src/core/clipping.js`
@@ -67,8 +67,8 @@ Dragging and resizing cuts on the timeline, with snapping.
 
 | | |
 |---|---|
-| `dragCut` | Edges a cut can snap to on a given track: zero, plus every other cut's start and end. */ |
-| `resizeCut` | Edges a cut can snap to on a given track: zero, plus every other cut's start and end. */ |
+| `dragCut` | Drag a whole cut to a new start time and track. `dt` is the time delta from where the drag began; `trackOff` the track delta. |
+| `resizeCut` | Drag one edge of a cut. `edge` is 'left' or 'right'. `initialStart`/`initialEnd` are the cut's bounds when the resize began. |
 
 ## `src/core/cutsReducer.js`
 
@@ -76,32 +76,32 @@ Every change the document can undergo, as named actions. Build them with these c
 
 | | |
 |---|---|
-| `addCuts` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `assignPartTo` | — |
-| `clearCut` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `addCuts` | Append cuts: a new cut, a tween, an imported video's frames. |
+| `assignPartTo` | Action: put these cuts in a part, creating it with this name if it is new. |
+| `clearCut` | Empty a cut's drawing and text, keeping its layers. |
 | `cutsReducer` | ── the reducer ──────────────────────────────────────────────────────────── |
-| `deleteText` | — |
-| `deleteTrack` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `insertCutsShifting` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `mergeLayerDown` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `moveCutGroup` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `moveLayers` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `moveText` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `patchCut` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `patchCuts` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `removeBatch` | — |
-| `renamePart` | — |
-| `replaceBatchCuts` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `deleteText` | Action: remove one text object from a cut. |
+| `deleteTrack` | Delete a track, closing the gap by pulling every track below it up one. |
+| `insertCutsShifting` | Insert cuts at a point on a track, pushing everything later on that track along to make room. Duplicating a cut and filling a gap with tweened frames are the same operation. |
+| `mergeLayerDown` | Flatten a layer into the one below it. |
+| `moveCutGroup` | Move several cuts together, keeping their relative layout and staying in bounds. |
+| `moveLayers` | Shift whole layers (and optionally the cut's texts) by a pixel offset. Bumps rev. |
+| `moveText` | Move a text to an absolute position. |
+| `patchCut` | Escape hatch: run a function over one cut. Prefer a named action. |
+| `patchCuts` | Escape hatch: run a function over the whole list. Prefer a named action. |
+| `removeBatch` | Action: delete every cut that came from one video import. |
+| `renamePart` | Action: rename a part. |
+| `replaceBatchCuts` | Replace the cuts imported from one video source with a fresh set. |
 | `replaceCuts` | Replace the whole document: opening a file, undo/redo, starting over. |
-| `setCutAnim` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `setCutCamera` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `setLayerAnim` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `setCutAnim` | Merge into a cut's animation, over the defaults. |
+| `setCutCamera` | Merge into a cut's camera move. Passing null clears it, which is not the same as setting every field back to its default: the renderer skips the transform entirely when there is no camera object at all, and that is the state every existing… |
+| `setLayerAnim` | Merge into a layer's animation, over the defaults. |
 | `setLayerClipped` | Clip a layer to the one below, or stop. No rev bump - it changes how the layer is composited, not what is drawn on it. |
-| `toggleTextVisible` | — |
-| `ungroupPart` | — |
-| `updateCut` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `updateLayer` | Replace the whole document: opening a file, undo/redo, starting over. */ |
-| `upsertText` | Replace the whole document: opening a file, undo/redo, starting over. */ |
+| `toggleTextVisible` | Action: show or hide one text object without deleting it. |
+| `ungroupPart` | Action: dissolve a part, leaving its cuts where they are. |
+| `updateCut` | Change fields on one cut (name, start/end time, track, activeLayerId). |
+| `updateLayer` | Change fields on one layer. |
+| `upsertText` | Add a text if it is new, otherwise update it in place. |
 
 ## `src/core/historyOps.js`
 
@@ -109,12 +109,12 @@ Undo and redo, and the memory budget that bounds them.
 
 | | |
 |---|---|
-| `canRedo` | — |
-| `canUndo` | Steps affordable at this snapshot size. Exported for the tests and for anyone tuning it. */ |
-| `HISTORY_LIMIT` | Steps affordable at this snapshot size. Exported for the tests and for anyone tuning it. */ |
+| `canRedo` | True when there is a step ahead of the current index to move to. |
+| `canUndo` | Whether there is anything to step to. Index 0 is the original state, so undo needs 1 or more. |
+| `HISTORY_LIMIT` | The old fixed cap, kept as the default when no size is known. |
 | `limitFor` | The undo memory budget. Raising it is a deliberate decision, not a tuning knob. |
-| `pushSnapshot` | Steps affordable at this snapshot size. Exported for the tests and for anyone tuning it. */ |
-| `step` | Steps affordable at this snapshot size. Exported for the tests and for anyone tuning it. */ |
+| `pushSnapshot` | Record a snapshot, returning the new list and position. The input is never modified, so the caller can keep the old pair if it wants to. |
+| `step` | Step one snapshot back or forward. |
 
 ## `src/core/lassoOps.js`
 
@@ -122,10 +122,10 @@ Lasso selection: closing the path, bounding it, lifting the pixels.
 
 | | |
 |---|---|
-| `applyResize` | Close a freehand path into a polygon. |
-| `closeLassoPath` | Close a freehand path into a polygon. |
-| `lassoBounds` | Close a freehand path into a polygon. |
-| `MIN_SELECTION_SIZE` | Close a freehand path into a polygon. |
+| `applyResize` | Resize a selection by dragging one of its handles. The handle names read as compass points, so which edges move falls out of the letters: 'nw' moves the top and left, 'e' moves the right edge alone. |
+| `closeLassoPath` | Close a freehand path into a polygon. If the ends are far apart the path is left as drawn and joined back to the start, adding an edge. |
+| `lassoBounds` | The pixel rectangle a lasso covers, clamped to the canvas. Returned as integers because it indexes into image data: the left and top round down and the right and bottom round up, so a region is never clipped by a fraction of a pixel. |
+| `MIN_SELECTION_SIZE` | Smallest a selection may be dragged to, in pixels. Below this it is impossible to grab again. |
 
 ## `src/core/layerOps.js`
 
@@ -133,13 +133,13 @@ Layers: moving, merging, resolving which one a stroke lands on.
 
 | | |
 |---|---|
-| `commitStroke` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
-| `insertFill` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
+| `commitStroke` | Add a stroke to a layer and make sure it will be seen: the layer itself and every folder above it are forced visible. Returns { activeLayerId, layers }, or null if the layer is gone. The reveal is the point. |
+| `insertFill` | Where a bucket fill belongs in a layer's stroke list. Paint goes *under* the ink. |
 | `isDescendantOf` | True when `folderId` is `maybeChildId` itself or an ancestor of it. |
-| `mergeDown` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
-| `moveLayer` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
-| `offsetLayers` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
-| `resolveDrawLayer` | True when `folderId` is `maybeChildId` itself or an ancestor of it. */ |
+| `mergeDown` | Flatten a layer into the one below it. "Below" means the next drawable layer in UI order — folders are containers, not surfaces, so they are skipped as a target and refused as a source. |
+| `moveLayer` | Move `layerId` relative to `targetId`. `position` is 'before', 'after', or 'inside' (only meaningful when the target is a folder). Returns a new array, or null when the move is refused and the caller should change nothing. |
+| `offsetLayers` | Shift whole layers, and optionally the cut's texts, by a pixel offset. This is what a move-everything drag commits. |
+| `resolveDrawLayer` | Which layer a stroke should actually go into. The active layer is not always usable: it can be a folder, or point at something that no longer exists. |
 
 ## `src/core/mediaReducer.js`
 
@@ -147,21 +147,21 @@ The audio and video tracks, as named actions.
 
 | | |
 |---|---|
-| `clearAudio` | — |
-| `clearMedia` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
-| `clearVideo` | — |
-| `clearVideoCuts` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `clearAudio` | Action: forget the audio track — the file, the url, the clip range, all of it. |
+| `clearMedia` | Everything gone: a new project. |
+| `clearVideo` | Action: forget the video overlay track. |
+| `clearVideoCuts` | Throw away the detected scene markers without touching the video itself. |
 | `EMPTY_MEDIA` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. |
-| `loadAudio` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
-| `loadVideo` | — |
-| `mediaReducer` | — |
-| `moveTrack` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
-| `resizeAudio` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
-| `restoreMedia` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
-| `setAudioClip` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
-| `setAudioDuration` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
-| `setVideoCuts` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
-| `setVideoOpacity` | Nothing loaded. The duration is a placeholder so an empty timeline still has a length. */ |
+| `loadAudio` | A piece of audio arrived. Its length is not known yet — the element reports that later. |
+| `loadVideo` | Action: a video overlay arrived, with its position on the timeline already worked out. |
+| `mediaReducer` | The reducer itself. Audio and video were five pieces of state that only ever moved together, and forgetting one left the app in a state it has no name for — a clip range pointing at audio that is gone. |
+| `moveTrack` | Drag a track along the timeline, keeping its length. |
+| `resizeAudio` | Drag one edge of the audio clip. The left edge also moves into the source. |
+| `restoreMedia` | Restore both tracks at once, opening a project. |
+| `setAudioClip` | Where the clip sits on the timeline, and which part of the source it plays. |
+| `setAudioDuration` | The audio element has read the source and knows how long it is. |
+| `setVideoCuts` | Scene-cut markers found by the detector, in video time. |
+| `setVideoOpacity` | How strongly the overlay shows through, 0..1. A reference layer is usually wanted faint. |
 
 ## `src/core/numInput.js`
 
@@ -170,8 +170,8 @@ Typing into a number field without the value fighting the cursor.
 | | |
 |---|---|
 | `clampNum` | Constrain n to the range, ignoring bounds that were not given. |
-| `commitNumber` | Constrain n to the range, ignoring bounds that were not given. |
-| `liveNumber` | Constrain n to the range, ignoring bounds that were not given. |
+| `commitNumber` | The value to settle on when the field is left: unreadable text falls back to the old value. |
+| `liveNumber` | The value to report while typing; null means "not a number yet, hold on". Intermediate states like "", "-", "." and "1e" hold rather than snapping to zero. |
 
 ## `src/core/partOps.js`
 
@@ -179,12 +179,12 @@ Parts: groups of cuts made from an import or a selection.
 
 | | |
 |---|---|
-| `assignPart` | Group cuts into parts, in timeline order. |
+| `assignPart` | Put the given cuts in a part, taking them out of whichever one they were in. |
 | `derivePartsFrom` | Group cuts into parts, in timeline order. |
-| `deriveVideoBatches` | Group cuts into parts, in timeline order. |
-| `removeVideoBatch` | Group cuts into parts, in timeline order. |
-| `renamePartIn` | Group cuts into parts, in timeline order. |
-| `ungroupPartIn` | Group cuts into parts, in timeline order. |
+| `deriveVideoBatches` | The same grouping for imported frame sets, which predate parts and are keyed separately. Kept apart from derivePartsFrom because an old project can have batches and no parts. |
+| `removeVideoBatch` | Remove every cut of an imported frame set. This one really does delete. |
+| `renamePartIn` | Rename a part, which means renaming it on every cut that belongs to it. |
+| `ungroupPartIn` | Ungroup a part. The cuts stay exactly where they are and only lose their membership - this is not a delete, and confusing the two would be expensive. |
 
 ## `src/core/pathMotion.js`
 
@@ -194,9 +194,9 @@ Turning a drawn line into something that can be moved along smoothly.
 |---|---|
 | `pathLength` | Total length along a polyline. @param {{x:number,y:number}[]} pts @returns {number} |
 | `preparePath` | Even out a drawn path before storing it. Pen points bunch up where the hand slowed, so animating along raw capture data replays the drawing speed instead of the drawn shape. |
-| `resampleByLength` | Total length along a polyline. @param {{x:number,y:number}[]} pts @returns {number} */ |
-| `smoothPath` | Total length along a polyline. @param {{x:number,y:number}[]} pts @returns {number} */ |
-| `spacingRatio` | Total length along a polyline. @param {{x:number,y:number}[]} pts @returns {number} */ |
+| `resampleByLength` | Re-space a polyline so consecutive points are an equal distance apart. This is the whole trick. Afterwards, walking the array at a constant rate moves at a constant speed, which is what the animation loop already does. |
+| `smoothPath` | Chaikin corner cutting: replace each point with two points a quarter in from its neighbours. |
+| `spacingRatio` | How evenly spaced a path is: the longest gap between consecutive points divided by the mean. 1 is perfect. A raw hand-drawn path is usually somewhere past 5, which is the same thing as saying it would stutter. |
 
 ## `src/core/playbackStart.js`
 
@@ -204,7 +204,7 @@ Where playback begins when play is pressed.
 
 | | |
 |---|---|
-| `playbackStartFrom` | — |
+| `playbackStartFrom` | Where pressing play should start from: the playhead if it is inside the range, otherwise the start of the range. The anchor lets a part play from its own beginning rather than the timeline's. |
 
 ## `src/core/probeBackoff.js`
 
@@ -213,9 +213,9 @@ How often to re-check whether the API server is up.
 | | |
 |---|---|
 | `nextProbeDelay` | Delay before the next probe, given how many have failed in a row. |
-| `PROBE_BASE_MS` | — |
-| `PROBE_MAX_MS` | — |
-| `PROBE_QUICK_TRIES` | — |
+| `PROBE_BASE_MS` | The delay between the first few probes, before the backoff starts doubling. Exported so the tests and the caller agree on the schedule. |
+| `PROBE_MAX_MS` | The ceiling the doubling stops at, so a long outage does not become a probe an hour. |
+| `PROBE_QUICK_TRIES` | How many probes go out at the base delay before doubling begins — a server restarting should be noticed quickly. |
 
 ## `src/core/projectAssets.js`
 
@@ -223,16 +223,16 @@ How each piece of a project is stored, and how it comes back.
 
 | | |
 |---|---|
-| `audioExt` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
-| `frameLoad` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
+| `audioExt` | The file extension for the audio track, from its dataURL. |
+| `frameLoad` | How a bitmap read back from a saved project has to be loaded. Only drawing layers are decoded to ImageData up front, because those are the ones the user can still edit pixel by pixel. |
 | `frameStorage` | Which of the three ways a frame is saved. A legacy entry with no Blob still embeds rather than being dropped. |
 | `collectBitmaps` | Every bitmap the cuts reference, packed the way this kind of save wants them. The loop around frameStorage, which used to live in App.jsx where it could be read but never run. Encoders are injected because one needs FileReader and the other a canvas. |
-| `imageExt` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
-| `imageExtFromType` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
+| `imageExt` | The file extension for a frame bitmap. |
+| `imageExtFromType` | The file extension for an image, from a Blob MIME type. |
 | `STORE_ASSET` | A frame or media item goes out as a separate binary asset alongside a small JSON. |
-| `STORE_BLOB` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
-| `STORE_DATAURL` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
-| `videoExt` | A frame or media item goes out as a separate binary asset alongside a small JSON. */ |
+| `STORE_BLOB` | Stored as a Blob in the object itself - only IndexedDB can persist that. |
+| `STORE_DATAURL` | Embedded as a base64 dataURL, so the JSON is self-contained. |
+| `videoExt` | The file extension for the video overlay, from its Blob MIME type. |
 
 ## `src/core/projectFormat.js`
 
@@ -241,7 +241,7 @@ Reading a saved project, including ones written by older versions.
 | | |
 |---|---|
 | `makeLoadProgress` | Throttled progress for a load: no bar for a small project, at most a hundred repaints for a large one. |
-| `migrateCuts` | What the app should look like after opening this project, with defaults for anything absent. */ |
+| `migrateCuts` | Bring saved cuts up to the current shape. Written as spread-then-override so a field the file already has always wins, and adding a new default here can never overwrite real data in an existing project. |
 | `projectSettings` | What the app should look like after opening this project, with defaults for anything absent. |
 
 ## `src/core/shortcuts.js`
@@ -250,14 +250,14 @@ Key bindings, and what a key event means.
 
 | | |
 |---|---|
-| `DEFAULT_KEYS` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
-| `findConflicts` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
-| `KEY_LABELS` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
-| `keyOf` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
-| `loadKeymap` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
-| `matchShortcut` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
-| `TOOL_PREFIX` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
-| `toolFromAction` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can |
+| `DEFAULT_KEYS` | Bindings a user has not changed. Single keys, no modifiers: the other hand is on the pen. |
+| `findConflicts` | Actions sharing a key, as { key: [action, ...] } — only the keys with more than one. With a binding per tool this stopped being hypothetical. |
+| `KEY_LABELS` | What each binding is called in the settings panel. |
+| `keyOf` | Render a key event as a string such as "ctrl+shift+k". |
+| `loadKeymap` | The saved bindings, with anything missing filled in from the defaults. |
+| `matchShortcut` | Which binding, if any, a combo triggers. Compared case-insensitively so a binding stored as "Ctrl+[" still matches; they are written lowercase now, but a shortcut saved by an older version is not going to be rewritten. |
+| `TOOL_PREFIX` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can route it without a list of tool ids to keep in step with the toolbar. |
+| `toolFromAction` | The tool a binding selects, or null if it is not a tool binding. |
 
 ## `src/core/timeCode.js`
 
@@ -266,7 +266,7 @@ Formatting and parsing times.
 | | |
 |---|---|
 | `fmt` | Seconds as mm:ss.cc, which is what the timeline shows and what parseClock reads back. |
-| `parseClock` | Seconds as mm:ss.cc, which is what the timeline shows and what parseClock reads back. */ |
+| `parseClock` | Read a typed time back into seconds. Accepts what a person is likely to type: "1:30", "1:02:03", or a plain number of seconds. |
 
 ## `src/core/timelineZoom.js`
 
@@ -274,14 +274,14 @@ Timeline pixels to time, and zooming without the content sliding.
 
 | | |
 |---|---|
-| `clampPps` | Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */ |
-| `pinchZoom` | Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */ |
-| `PPS_MAX` | — |
+| `clampPps` | Pixels per second, clamped to the usable range. Not a number field: an unclamped value from a pinch is a timeline nobody can grab. |
+| `pinchZoom` | The same thing for a pinch, which scales from where the fingers started rather than from the current value - accumulating a factor per move event would drift. |
+| `PPS_MAX` | Above three hundred pixels a second a few seconds fill the screen and scrolling is the only way to see anything. |
 | `PPS_MIN` | fill the screen and scrolling becomes the only way to see anything. |
-| `scrollToHold` | Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */ |
-| `timeAtX` | Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */ |
+| `scrollToHold` | Scroll position that puts a time back under a point on screen. Never negative: scrolling before the start is not a place the timeline can be, and asking for it once left the first track label overlapping the ruler. |
+| `timeAtX` | The time under a point, given where the timeline is scrolled to. |
 | `TRACK_GUTTER` | Width of the sticky track-label column. Time zero is one of these in from the left edge, so every screen-x-to-time conversion needs it. Must match `.tl-track-label` in App.css. |
-| `xAtTime` | Width of the sticky track-label column, in px. Must match `.tl-track-label` in App.css. */ |
+| `xAtTime` | Where a time sits, as a content x - what the playhead's `left` is set to. |
 | `zoomAnchored` | Zoom about a point. Returns null at the scale limits, so the caller leaves the scroll alone rather than recomputing from an unchanged scale. |
 
 ## `src/canvas/canvasUtils.js`
@@ -291,13 +291,13 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | | |
 |---|---|
 | `accentSoft` | That keeps on-canvas furniture such as selection outlines and paths on the theme colour. |
-| `ANIM_DEFAULT` | — |
+| `ANIM_DEFAULT` | A cut animation with nothing turned on. Every field is present, so a stored animation never has to be merged against a shape that might be missing keys. |
 | `applyEase` | The easing curves. Everything animated should go through this rather than its own. |
-| `bucketFillTransparentRegion` | — |
-| `CANVAS_W` | — |
+| `bucketFillTransparentRegion` | Flood fill across the transparent region under a point, with a tolerance and an optional spread so the fill creeps under the anti-aliased edge of a line instead of leaving a halo. |
+| `CANVAS_W` | The document's pixel size, 1920x1080. The canvas element is scaled by CSS; drawing coordinates are always these. |
 | `computeCutAnim` | at rest (no transform), so callers can skip the save/transform fast-path. |
-| `computeLayerAnim` | — |
-| `computeTextAnim` | — |
+| `computeLayerAnim` | A layer (part) animation resolved to one instant: the offset, rotation, scale, alpha and sway to draw it with. |
+| `computeTextAnim` | A text animation resolved to one instant. Returns the entrance, exit and emphasis values, how much of the string is revealed, and — when the characters own the entrance — the progress they divide between them. |
 | `textAnimStep` | What one entrance or exit contributes at eased presence `e`. Shared so a staggered character cannot move differently from the block it belongs to. `dir` is +1 entering, -1 leaving, and only the vertical motions read it. |
 | `charAnimAt` | One character's share of a staggered entrance. The whole of that character's entrance, not something added on top of the block's - `computeTextAnim` leaves the block at rest when a stagger is set. |
 | `charFxAt` | Where one character is coming from, on top of whatever entrance is playing: scatter, drop, zigzag, spin, pop. This is what makes typing read as characters arriving separately rather than a line sliding in as one, and it is an entrance in its own right - no block entrance need be chosen. |
@@ -305,27 +305,27 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `cutDuration` | A cut's length in seconds, never zero - a cut can be dragged to zero length and everything that animates divides by it. |
 | `cutProgress` | How far through a cut a moment is, 0 to 1, clamped. Animations are evaluated for cuts merely near the playhead, so times outside the cut are routine and extrapolating would overshoot. |
 | `curveToWave` | The returned amp (px) is how far that curve actually swung, and is used as the default strength. |
-| `dataURLToImageData` | — |
-| `DEFAULT_CUT_DURATION` | — |
-| `detectSceneCuts` | The presets in the order they should appear, as [group, fonts] pairs. |
-| `dilateMask` | The presets in the order they should appear, as [group, fonts] pairs. |
-| `dist` | — |
-| `drawStrokesOnCtx` | — |
-| `extractVideoFrames` | The presets in the order they should appear, as [group, fonts] pairs. |
+| `dataURLToImageData` | Decode a dataURL back to pixels. The synchronous counterpart of imageDataToDataURL, for the stored bitmaps a project restores. |
+| `DEFAULT_CUT_DURATION` | How long a new cut lasts, in seconds. |
+| `detectSceneCuts` | Find where a video changes scene, by stepping through it and comparing frames. Refines each hit to the exact boundary, reports progress, and can be stopped part way. |
+| `dilateMask` | Grow a bitmask outwards by r pixels (square structuring element, done separably so it stays O(w*h) whatever r is). Used to bleed a bucket fill under the line that bounds it. |
+| `dist` | Distance between two points. |
+| `drawStrokesOnCtx` | Draw a list of strokes onto a context: the one place that knows what each tool looks like. Clears first unless told not to, and takes the boiling options so a roughened layer draws its own phase. |
+| `extractVideoFrames` | Pull frames out of a video file at a given rate, optionally over a range, scaled, encoded as WebP or PNG, with near-duplicate frames merged. Reports progress and can be stopped part way. |
 | `fitRect` | Letterbox rect: fit source into destination preserving aspect ratio. |
-| `flattenForCanvas` | — |
-| `flattenLayersInUiOrder` | — |
+| `flattenForCanvas` | The layers to draw, bottom first, with folders resolved and hidden branches dropped. |
+| `flattenLayersInUiOrder` | The layer tree flattened the way the panel shows it, so an index in the list means the same thing to the UI and to the renderer. |
 | `FONT_PRESETS` | the app with no Japanese on screen downloads no Japanese. |
 | `fontGroups` | The presets in the order they should appear, as [group, fonts] pairs. |
-| `hexToRgb` | — |
+| `hexToRgb` | A #rrggbb string as {r, g, b}. |
 | `imageDataCanvas` | A canvas holding an ImageData, ready to draw. `putImageData` ignores the transform, composite mode and alpha, so anything that scales or blends ImageData needs this. Reused - valid until the next call. |
-| `imageDataToDataURL` | — |
-| `LAYER_ANIM_DEFAULT` | — |
+| `imageDataToDataURL` | Encode pixels as a dataURL, through a reused canvas — allocating one per call is the trap sizeCanvas exists for. |
+| `LAYER_ANIM_DEFAULT` | A part animation with nothing turned on, every field present for the same reason ANIM_DEFAULT has them. |
 | `layerKey` | cross-cut collisions and an infinite cache-rebuild loop. |
 | `morphFrames` | Filled with the A->B average ink colour; soft 1px edge. |
 | `morphPrepare` | so the caller can update progress or yield to the UI between frames. |
 | `morphSequence` | frame would be N times slower. |
-| `pointInPolygon` | — |
+| `pointInPolygon` | Whether a point is inside a polygon, by ray casting. What decides if a lasso caught something. |
 | `safeArray` | Anything-to-array, for fields that older projects may not have at all. |
 | `sampleKeys` | This is tweening in the original animation sense of the word. |
 | `samplePath` | Sample a polyline path at normalized position s in [0,1]. |
@@ -353,13 +353,13 @@ Measuring and drawing text objects.
 
 | | |
 |---|---|
-| `clampFontSize` | A text object as the document stores it. |
-| `drawTextObject` | A text object as the document stores it. |
-| `measureTextBox` | A text object as the document stores it. |
-| `revealLines` | A text object as the document stores it. |
-| `textFontOf` | A text object as the document stores it. |
-| `textLineHeight` | A text object as the document stores it. |
-| `textNeedsBox` | A text object as the document stores it. |
+| `clampFontSize` | Font size, clamped to what the editor allows. Three call sites relied on the same clamp. |
+| `drawTextObject` | Draw one text object. The order matters and is not arbitrary: the animation transform has to be established before the static rotation so the two compose about the same centre; the background box is painted before the glyphs so it sits behi… |
+| `measureTextBox` | The rectangle a text occupies, in canvas coordinates. |
+| `revealLines` | Split text into the lines to draw, revealing only the first `chars` characters. `chars` of null means no typing effect and the whole string is drawn. |
+| `textFontOf` | The CSS font string, in the order the canvas shorthand requires: style, weight, size, family. |
+| `textLineHeight` | Baseline-to-baseline distance for stacked lines. |
+| `textNeedsBox` | Whether this text has to be measured before it can be drawn. Measuring costs a measureText per line, so it is skipped for plain text. |
 
 ## `src/hooks/useHistory.js`
 
@@ -429,7 +429,7 @@ Every way the timeline can be pointed at, in one place.
 
 | | |
 |---|---|
-| `useTimelineGestures` | — |
+| `useTimelineGestures` | Pointer handling for the timeline: dragging cuts, resizing them, panning, and pinch zoom. One place, because seven copies of the gutter maths is where the dead wheel zoom came from. |
 
 ## `server/rateLimit.js`
 

--- a/scripts/helper-index.mjs
+++ b/scripts/helper-index.mjs
@@ -65,7 +65,20 @@ const missing = found.filter(({ name }) => !index.includes(`\`${name}\``));
 const names = new Set(found.map(f => f.name));
 const stale = [...index.matchAll(/^\| `(\w+)`/gm)].map(m => m[1]).filter(n => !names.has(n));
 
-if (missing.length || stale.length) {
+// What a row actually says. Checking only that the name appears left this index 70% wrong
+// without a word of complaint: 32 rows had no description at all, 62 ended mid-comment in `*/`,
+// and 17 groups of rows shared one description - every export of layerOps.js claimed to be
+// isDescendantOf, because the rows had been filled from the first comment in each file rather
+// than from each export's own. An index that answers "does this already exist" wrongly is worse
+// than no index, because it is trusted.
+const described = [...index.matchAll(/^\| `(\w+)` \| (.*?) \|$/gm)].map(m => ({ name: m[1], text: m[2].trim() }));
+const blank = described.filter(r => !r.text);
+const fragment = described.filter(r => r.text.endsWith('*/'));
+const byText = new Map();
+for (const r of described) byText.set(r.text, [...(byText.get(r.text) || []), r.name]);
+const shared = [...byText.entries()].filter(([, names]) => names.length > 1);
+
+if (missing.length || stale.length || blank.length || fragment.length || shared.length) {
     if (missing.length) {
         console.error(`${missing.length} shared export(s) not in ${INDEX}:`);
         for (const { name, path } of missing) console.error(`  ${name}  (${path})`);
@@ -74,7 +87,19 @@ if (missing.length || stale.length) {
         console.error(`${stale.length} entr(y/ies) in ${INDEX} name something that no longer exists:`);
         for (const n of stale) console.error(`  ${n}`);
     }
-    console.error(`\n${INDEX} is what stops the next person reimplementing one of these. Add the row.`);
+    if (blank.length) {
+        console.error(`${blank.length} row(s) with no description:`);
+        for (const r of blank) console.error(`  ${r.name}`);
+    }
+    if (fragment.length) {
+        console.error(`${fragment.length} row(s) ending in \`*/\`, so a comment was copied in by mistake:`);
+        for (const r of fragment) console.error(`  ${r.name}`);
+    }
+    if (shared.length) {
+        console.error(`${shared.length} description(s) used by more than one row - at most one of them is true:`);
+        for (const [text, names] of shared) console.error(`  ${names.join(', ')}\n    ${text.slice(0, 90)}`);
+    }
+    console.error(`\n${INDEX} is what stops the next person reimplementing one of these. It only works if the rows are true.`);
     process.exit(1);
 }
 


### PR DESCRIPTION
## What I found

`HELPERS.md` exists to answer *"does this already exist?"* before someone writes a second copy of something. I have been reading it all session. **140 of its 200 rows were answering wrongly.**

| | rows |
|---|---|
| no description at all | 32 |
| ending mid-comment, in `*/` | 62 |
| sharing a description with other rows | 17 groups |

The shared ones are the worst kind of wrong, because they are confident rather than absent:

- every export of `layerOps.js` — `commitStroke`, `insertFill`, `mergeDown`, `moveLayer`, `offsetLayers`, `resolveDrawLayer` — claimed to be *"True when `folderId` is `maybeChildId` itself or an ancestor of it. \*/"*
- all 17 exports of `cutsReducer.js` claimed to *"Replace the whole document"*
- all 10 media actions claimed to be *"Nothing loaded…"*

The rows had been filled from **the first comment in each file** rather than from each export's own.

## Why it lasted

`helper-index.mjs` only ever checked that a **name** appeared somewhere in the file. The rot was invisible to it — the check passed on every commit while the thing it guards decayed. A guard that cannot see the failure it exists to prevent is worse than none, because it is trusted.

## The fix

**The rows.** All 200 rebuilt: 74 hand-written ones kept, 90 taken from each export's own doc comment, 36 written by reading the code — reducer action creators and constants, which mostly carry no doc of their own.

**The check.** It now reads the rows, not just the names. Blank, ending in `*/`, or sharing a description with another row all fail, with the offending names printed.

## Verified

Each of the three failure kinds was **injected deliberately** and confirmed to fail:

```
1 row(s) with no description:
  collectUsedBitmapIds
1 row(s) ending in `*/`, so a comment was copied in by mistake:
  unusedBitmapIds
1 description(s) used by more than one row - at most one of them is true:
  applyCamera, CAMERA_DEFAULT
```

A guard nobody has watched fail is a guard nobody knows works.

`npm run check` green — 559 tests.
