### PR TITLE
refactor: one way to patch one layer

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -137,6 +137,7 @@ Layers: moving, merging, resolving which one a stroke lands on.
 | `insertFill` | Where a bucket fill belongs in a layer's stroke list. Paint goes *under* the ink. |
 | `isDescendantOf` | True when `folderId` is `maybeChildId` itself or an ancestor of it. |
 | `mergeDown` | Flatten a layer into the one below it. "Below" means the next drawable layer in UI order — folders are containers, not surfaces, so they are skipped as a target and refused as a source. |
+| `patchLayer` | Replace one layer with a patched copy, leaving the rest alone. Eight call sites wrote the map out by hand; the guard inside it is not noise, because layer ids are unique within a cut and not across cuts, so it must only ever be handed one cut layer list. |
 | `moveLayer` | Move `layerId` relative to `targetId`. `position` is 'before', 'after', or 'inside' (only meaningful when the target is a folder). Returns a new array, or null when the move is refused and the caller should change nothing. |
 | `offsetLayers` | Shift whole layers, and optionally the cut's texts, by a pixel offset. This is what a move-everything drag commits. |
 | `resolveDrawLayer` | Which layer a stroke should actually go into. The active layer is not always usable: it can be a folder, or point at something that no longer exists. |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ import { Timeline } from './ui/Timeline';
 import { ProjectPicker, ProgressOverlay, SettingsModal, HelpModal, VideoImportModal, SceneDetectModal, LinkPromptModal, ToolKeysModal } from './ui/Modals';
 import { tr, loadLang, saveLang, setLangValue } from './i18n';
 import { moveLayer } from './core/layerOps.js';
-import { resolveDrawLayer as resolveDrawLayerPure, commitStroke, insertFill } from './core/layerOps.js';
+import { resolveDrawLayer as resolveDrawLayerPure, commitStroke, insertFill, patchLayer } from './core/layerOps.js';
 import { closeLassoPath, lassoBounds, applyResize } from './core/lassoOps.js';
 import { useTimelineGestures } from './hooks/useTimelineGestures.js';
 import { fmt, parseClock } from './core/timeCode.js';
@@ -708,9 +708,8 @@ export default function App() {
         const cut = cuts.find(c => c.id === sel.cutId);
         const newId = cut ? Math.max(...cut.layers.map(l => l.id), 0) + 1 : 1;
         updLayers(sel.cutId, c => {
-            const layers = c.layers.map(l => l.id === sel.sourceLayerId
-                ? { ...l, strokes: [...l.strokes, { id: Date.now(), tool: 'eraseBitmap', bitmapId: sel.maskBitmapId, x: px, y: py }] }
-                : l);
+            const layers = patchLayer(c.layers, sel.sourceLayerId,
+                l => ({ strokes: [...l.strokes, { id: Date.now(), tool: 'eraseBitmap', bitmapId: sel.maskBitmapId, x: px, y: py }] }));
             const partLayer = { id: newId, name: tr('파츠 {0}', newId), type: 'layer', parentId: null, visible: true, redoStrokes: [], strokes: [{ id: Date.now() + 1, tool: 'paste', bitmapId: sel.bitmapId, x: tx, y: ty, w: tw, h: th }] };
             return { layers: [...layers, partLayer], activeLayerId: newId };
         });
@@ -738,7 +737,8 @@ export default function App() {
         const bitmapId = cloneBitmapId(clip.bitmapId, bmpCache); // independent copy per paste
         const x = Math.round(CANVAS_W / 2 - clip.w / 2), y = Math.round(CANVAS_H / 2 - clip.h / 2);
         updLayers(currentCutId, c => ({
-            layers: c.layers.map(l => l.id === layerId ? { ...l, strokes: [...l.strokes, { id: Date.now(), tool: 'paste', bitmapId, x, y, w: clip.w, h: clip.h }] } : l)
+            layers: patchLayer(c.layers, layerId,
+                l => ({ strokes: [...l.strokes, { id: Date.now(), tool: 'paste', bitmapId, x, y, w: clip.w, h: clip.h }] }))
         }));
     };
 
@@ -1736,14 +1736,14 @@ export default function App() {
             return { layers: nl, activeLayerId: na };
         });
     };
-    const handleToggleVisible = (e, cutId, layerId) => { e.stopPropagation(); updLayers(cutId, c => ({ layers: c.layers.map(l => l.id === layerId ? { ...l, visible: !l.visible } : l) })); };
+    const handleToggleVisible = (e, cutId, layerId) => { e.stopPropagation(); updLayers(cutId, c => ({ layers: patchLayer(c.layers, layerId, l => ({ visible: !l.visible })) })); };
     const handleSetActive = (e, cutId, layerId) => {
         e.stopPropagation();
         const cut = cuts.find(c => c.id === cutId); if (!cut) return;
         const layer = cut.layers.find(l => l.id === layerId); if (!layer || layer.type === 'folder') return;
         dispatchCuts(updateCut(cutId, { activeLayerId: layerId }));
     };
-    const handleToggleFolder = (e, cutId, fid) => { e.stopPropagation(); updLayers(cutId, c => ({ layers: c.layers.map(l => l.id === fid ? { ...l, collapsed: !l.collapsed } : l) })); };
+    const handleToggleFolder = (e, cutId, fid) => { e.stopPropagation(); updLayers(cutId, c => ({ layers: patchLayer(c.layers, fid, l => ({ collapsed: !l.collapsed })) })); };
     // Boiling: wobbles the strokes already on the layer. Each click cycles off, light, strong,
     // and it never alters the stored strokes.
     // Opens and closes the boiling settings, where strength, wavelength, speed and the minimum
@@ -1993,7 +1993,7 @@ export default function App() {
         }
         const bitmapId = storeBitmap(src);
         const stroke = { id: Date.now(), tool: 'paste', bitmapId, x: bx, y: by, w: bw, h: bh };
-        updLayers(currentCutId, c => ({ layers: c.layers.map(l => l.id === c.activeLayerId ? { ...l, strokes: [...l.strokes, stroke] } : l) }));
+        updLayers(currentCutId, c => ({ layers: patchLayer(c.layers, c.activeLayerId, l => ({ strokes: [...l.strokes, stroke] })) }));
     };
 
     // Touch navigation on the canvas (fingers never draw — palm rejection):
@@ -2307,7 +2307,7 @@ export default function App() {
         const stroke = { id: Date.now(), tool: 'paste', bitmapId, x: region.x, y: region.y };
         noteColorUsed(color);
         updLayers(currentCutId, c => ({
-            layers: c.layers.map(l => l.id === activeLayer.id ? { ...l, strokes: insertFill(l.strokes, stroke, region.overPaint) } : l)
+            layers: patchLayer(c.layers, activeLayer.id, l => ({ strokes: insertFill(l.strokes, stroke, region.overPaint) }))
         }));
     };
 
@@ -2437,7 +2437,7 @@ export default function App() {
                 // Eraser must composite against the layer, so it stays on the layer-write path.
                 const newStroke = { id: Date.now(), tool, color, opacity, size: eraserSize, points: [pos] };
                 updLayers(currentCutId, c => ({
-                    layers: c.layers.map(l => l.id === drawTargetLayerRef.current ? { ...l, strokes: [...l.strokes, newStroke] } : l)
+                    layers: patchLayer(c.layers, drawTargetLayerRef.current, l => ({ strokes: [...l.strokes, newStroke] }))
                 }));
                 break;
             }
@@ -2540,14 +2540,13 @@ export default function App() {
                 }
                 // Eraser: layer-write path (needs to composite against the layer).
                 updLayers(currentCutId, c => ({
-                    layers: c.layers.map(l => {
-                        if (l.id !== drawTargetLayerRef.current) return l;
+                    layers: patchLayer(c.layers, drawTargetLayerRef.current, l => {
                         const newStrokes = [...l.strokes];
                         const currentStroke = newStrokes[newStrokes.length - 1];
                         if (currentStroke && currentStroke.tool !== 'paste' && currentStroke.tool !== 'fill') {
                             for (const p of positions) currentStroke.points.push(p);
                         }
-                        return { ...l, strokes: newStrokes };
+                        return { strokes: newStrokes };
                     })
                 }));
                 break;

--- a/src/core/layerOps.js
+++ b/src/core/layerOps.js
@@ -76,6 +76,27 @@ export function resolveDrawLayer(cut, flattenVisibleLeaves) {
 }
 
 /**
+ * Replace one layer with a patched copy, leaving the rest of the list alone.
+ *
+ * Eight call sites wrote this map out by hand. On its own that is only noise, but the guard
+ * inside it is not noise: layer ids are unique within a cut and *not* across cuts, so this must
+ * only ever be handed one cut's layers. Written out eight times, that is eight places to hand it
+ * the wrong list.
+ *
+ * The patch is a function of the layer because most callers need what was there - appending to
+ * `strokes`, flipping `visible`. It returns the fields to change, not the whole layer.
+ *
+ * @param {any[]} layers one cut's layers
+ * @param {any} layerId
+ * @param {(layer: any) => object} patch fields to merge into the matching layer
+ * @returns {any[]} a new list; the same one back if nothing matched
+ */
+export function patchLayer(layers, layerId, patch) {
+    if (!Array.isArray(layers)) return [];
+    return layers.map(l => (l.id === layerId ? { ...l, ...patch(l) } : l));
+}
+
+/**
  * Add a stroke to a layer and make sure it will be seen: the layer itself and every folder above
  * it are forced visible. Returns { activeLayerId, layers }, or null if the layer is gone.
  *

--- a/test/layerOps.test.js
+++ b/test/layerOps.test.js
@@ -4,7 +4,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { moveLayer, isDescendantOf, resolveDrawLayer, commitStroke, insertFill, offsetLayers, mergeDown } from '../src/core/layerOps.js';
+import { moveLayer, isDescendantOf, resolveDrawLayer, commitStroke, insertFill, offsetLayers, mergeDown , patchLayer} from '../src/core/layerOps.js';
 import { flattenLayersInUiOrder } from '../src/canvas/canvasUtils.js';
 
 // f1 > a, b   then c at the root
@@ -367,4 +367,44 @@ test('mergeDown: does not mutate the layers it was given', () => {
     const snapshot = JSON.stringify(before);
     mergeDown(before, 'top', flat);
     assert.equal(JSON.stringify(before), snapshot);
+});
+
+// --- patchLayer --------------------------------------------------------------------------------
+
+test('patchLayer changes the matching layer and leaves the others identical', () => {
+    const a = { id: 1, visible: true }, b = { id: 2, visible: true };
+    const out = patchLayer([a, b], 2, () => ({ visible: false }));
+    assert.equal(out[0], a, 'untouched layers are the same object, so React can skip them');
+    assert.deepEqual(out[1], { id: 2, visible: false });
+    assert.notEqual(out[1], b, 'the patched one is a copy');
+});
+
+test('patchLayer sees the layer, so a caller can build on what was there', () => {
+    const out = patchLayer([{ id: 1, strokes: ['a'] }], 1, l => ({ strokes: [...l.strokes, 'b'] }));
+    assert.deepEqual(out[0].strokes, ['a', 'b']);
+});
+
+test('patchLayer leaves the original list alone', () => {
+    const layers = [{ id: 1, visible: true }];
+    patchLayer(layers, 1, () => ({ visible: false }));
+    assert.equal(layers[0].visible, true);
+});
+
+test('an id that matches nothing changes nothing', () => {
+    const layers = [{ id: 1 }, { id: 2 }];
+    const out = patchLayer(layers, 99, () => ({ visible: false }));
+    assert.deepEqual(out, layers);
+});
+
+test('the patch never runs for a layer that does not match', () => {
+    // Ids are unique within a cut and not across cuts, so a patch handed the wrong cut's layers
+    // must do nothing rather than something surprising to a same-numbered layer elsewhere.
+    let calls = 0;
+    patchLayer([{ id: 1 }, { id: 2 }, { id: 3 }], 2, () => { calls++; return {}; });
+    assert.equal(calls, 1);
+});
+
+test('patchLayer survives being handed nothing', () => {
+    assert.deepEqual(patchLayer(null, 1, () => ({})), []);
+    assert.deepEqual(patchLayer(undefined, 1, () => ({})), []);
 });


### PR DESCRIPTION
## What

Eight call sites wrote this out by hand:

```js
c.layers.map(l => l.id === X ? { ...l, ...fields } : l)
```

On its own that is only noise. The **guard** inside it is not: layer ids are unique within a cut and *not* across cuts, so this must only ever be handed one cut's layers. Written out eight times, that is eight places to hand it the wrong list.

`patchLayer(layers, layerId, patch)` takes the patch as a function of the layer, because most callers need what was there — appending to `strokes`, flipping `visible` — and returns the fields to change rather than the whole layer.

## Verified

`npm run check` green — 565 tests, 6 of them new, including that untouched layers come back as the *same object* (so React can skip them) and that the patch never runs for a non-matching layer.

The rewritten sites are in the drawing path, where a mistake is not a crash but a stroke that goes nowhere, so they were driven in a browser:

| | ink |
|---|---|
| empty canvas | 0 |
| pen stroke | 476 |
| bucket fill | 121,977 |
| eraser across it | 120,842 |
| hide the layer | 0 |
| show it again | **120,842** |

Those cover every shape that was rewritten, including the awkward one that extends the stroke in progress point by point. The exact return to 120,842 is the `visible` toggle round-tripping.
