### PR TITLE
refactor: preferences remember themselves, and one of them stops crashing

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -187,6 +187,26 @@ Parts: groups of cuts made from an import or a selection.
 | `renamePartIn` | Rename a part, which means renaming it on every cut that belongs to it. |
 | `ungroupPartIn` | Ungroup a part. The cuts stay exactly where they are and only lose their membership - this is not a delete, and confusing the two would be expensive. |
 
+## `src/core/persist.js`
+
+The small preferences that live in localStorage: which panels are open, the theme, recent colours.
+
+| | |
+|---|---|
+| `readStored` | A stored preference, or the fallback. Returns the fallback for a key never written, for one that will not parse, and for a decoder that rejects what it found - so bad stored data cannot take the app down. |
+| `writeStored` | Write a preference, or quietly do nothing. Failing to save which panel was open is not worth interrupting anybody over, and localStorage throws for reasons the user chose. |
+| `jsonCodec` | JSON, for preferences that are objects or arrays. |
+| `arrayCodec` | JSON that must decode to an array. A stored value of the wrong shape is treated as absent rather than handed to code that will index into it. |
+| `onOffCodec` | A flag that defaults to on: only the literal `off` turns it off. |
+| `oneZeroCodec` | A flag that defaults to off: only the literal `1` turns it on. Kept separate from onOffCodec because migrating either spelling would silently reset the preference for everyone who had set it. |
+| `numberCodec` | A number, treating anything unparseable as absent. |
+
+## `src/hooks/useStored.js`
+
+| | |
+|---|---|
+| `useStored` | State that remembers itself in localStorage: reads once on first render, writes when it changes. Replaces nine hand-written read/write pairs, one of which had no try/catch at all. |
+
 ## `src/core/pathMotion.js`
 
 Turning a drawn line into something that can be moved along smoothly.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,8 @@ import { NumField, clampNum } from './ui/NumField';
 import ColorPanel, { RECENT_SLOTS } from './ui/ColorPanel';
 import { TopBar } from './ui/TopBar';
 import { CutLayerPanel } from './ui/CutLayerPanel';
+import { useStored } from './hooks/useStored.js';
+import { arrayCodec, onOffCodec, oneZeroCodec, numberCodec } from './core/persist.js';
 import { TextEditor } from './ui/TextEditor';
 import { ToolsPanel } from './ui/ToolsPanel';
 import { Timeline } from './ui/Timeline';
@@ -238,22 +240,17 @@ export default function App() {
 
     // Where each panel lives: 'left', 'right' or 'float'. Panels are drawn from these rather than
     // from fixed positions in the layout, so dragging one only has to change this value.
-    const [docks, setDocks] = useState(() => {
-        try {
-            const v = JSON.parse(localStorage.getItem('mv_docks'));
-            if (v && ['left', 'right', 'float'].includes(v.tools)) return v;
-        } catch { }
-        return { tools: 'left', color: 'left', cut: 'right' };
+    const [docks, setDocks] = useStored('mv_docks', { tools: 'left', color: 'left', cut: 'right' }, {
+        // A layout stored by a version that docked differently is treated as absent rather than
+        // restored into a shape this one cannot lay out.
+        decode: (raw) => { const v = JSON.parse(raw); return v && ['left', 'right', 'float'].includes(v.tools) ? v : undefined; },
+        encode: JSON.stringify,
     });
-    const [floatPos, setFloatPos] = useState(() => {
-        try {
-            const v = JSON.parse(localStorage.getItem('mv_floats'));
-            if (v && typeof v === 'object') return v;
-        } catch { }
-        return { tools: { x: 120, y: 120 }, color: { x: 160, y: 160 }, cut: { x: 200, y: 200 } };
+    const [floatPos, setFloatPos] = useStored('mv_floats',
+        { tools: { x: 120, y: 120 }, color: { x: 160, y: 160 }, cut: { x: 200, y: 200 } }, {
+        decode: (raw) => { const v = JSON.parse(raw); return v && typeof v === 'object' ? v : undefined; },
+        encode: JSON.stringify,
     });
-    useEffect(() => { try { localStorage.setItem('mv_docks', JSON.stringify(docks)); } catch { } }, [docks]);
-    useEffect(() => { try { localStorage.setItem('mv_floats', JSON.stringify(floatPos)); } catch { } }, [floatPos]);
     // The panel being dragged by its header, plus where it would land if dropped now.
     const [panelDrag, setPanelDrag] = useState(null);
 
@@ -271,19 +268,16 @@ export default function App() {
     const [sceneDetect, setSceneDetect] = useState(null);   // { done, total } while auto-detecting scene cuts
     // Which media rows are folded away in the timeline. Purely a view setting - the audio still
     // plays and the video still draws; this is only about giving the cut tracks the height back.
-    const [hiddenTracks, setHiddenTracks] = useState(() => {
-        try { return { audio: false, video: false, ...JSON.parse(localStorage.getItem('mv_hidden_tracks') || '{}') }; }
-        catch { return { audio: false, video: false }; }
+    const [hiddenTracks, setHiddenTracks] = useStored('mv_hidden_tracks', { audio: false, video: false }, {
+        // Spread over the defaults, so a stored value from before a track existed still names it.
+        decode: (raw) => ({ audio: false, video: false, ...JSON.parse(raw) }),
+        encode: JSON.stringify,
     });
     const toggleTrackHidden = (which) => setHiddenTracks(h => ({ ...h, [which]: !h[which] }));
-    useEffect(() => { try { localStorage.setItem('mv_hidden_tracks', JSON.stringify(hiddenTracks)); } catch { } }, [hiddenTracks]);
     const [showToolKeys, setShowToolKeys] = useState(false);
     const sceneStopRef = useRef(false);   // set to ask a running scene detection to stop
     const [sceneCfg, setSceneCfg] = useState(null);         // scene-detect settings modal { threshold, rangeOn, startText, endText }
-    const [autoSceneDetect, setAutoSceneDetect] = useState(() => {
-        try { return localStorage.getItem('mv_auto_scene') !== 'off'; } catch { return true; }
-    });
-    useEffect(() => { try { localStorage.setItem('mv_auto_scene', autoSceneDetect ? 'on' : 'off'); } catch { } }, [autoSceneDetect]);
+    const [autoSceneDetect, setAutoSceneDetect] = useStored('mv_auto_scene', true, onOffCodec);
     const videoElRef = useRef(null);      // hidden <video> element that decodes/plays the overlay
     const videoBlobRef = useRef(null);    // the video Blob, for saving
     const videoSeekTokRef = useRef(0);    // paused-seek token so a stale 'seeked' doesn't repaint
@@ -315,20 +309,16 @@ export default function App() {
     const [color, setColor] = useState('#000000');
     // Recent colours only collect colours actually used, not ones merely selected.
     // See noteColorUsed below.
-    const [recentColors, setRecentColors] = useState(() => {
-        try { const v = JSON.parse(localStorage.getItem('mv_recent_colors')); if (Array.isArray(v)) return v; } catch { }
-        return [];
-    });
-    useEffect(() => { try { localStorage.setItem('mv_recent_colors', JSON.stringify(recentColors)); } catch { } }, [recentColors]);
+    const [recentColors, setRecentColors] = useStored('mv_recent_colors', [], arrayCodec);
     const [pickingColor, setPickingColor] = useState(false); // eyedropper: next canvas click samples a pixel
     // Palettes start empty - no built-in presets. The user fills them.
-    const [palettes, setPalettes] = useState(() => {
-        try { const s = JSON.parse(localStorage.getItem('mv_palettes')); if (Array.isArray(s) && s.length) return s; } catch { }
-        return [{ name: tr('내 팔레트'), colors: [] }];
+    const [palettes, setPalettes] = useStored('mv_palettes', [{ name: tr('내 팔레트'), colors: [] }], {
+        // An empty stored list means the starting palette, not no palettes at all.
+        decode: (raw) => { const v = JSON.parse(raw); return Array.isArray(v) && v.length ? v : undefined; },
+        encode: JSON.stringify,
     });
     const [activePalette, setActivePalette] = useState(0);
     const [paletteEdit, setPaletteEdit] = useState(false); // when on, tapping a swatch deletes it (for tablets)
-    useEffect(() => { try { localStorage.setItem('mv_palettes', JSON.stringify(palettes)); } catch { } }, [palettes]);
     const addToPalette = (c) => setPalettes(ps => ps.map((p, i) => i === activePalette && !p.colors.some(x => x.toLowerCase() === c.toLowerCase()) ? { ...p, colors: [...p.colors, c] } : p));
     const removeFromPalette = (ci) => setPalettes(ps => ps.map((p, i) => i === activePalette ? { ...p, colors: p.colors.filter((_, j) => j !== ci) } : p));
     const addPalette = () => { setPalettes(ps => [...ps, { name: tr('팔레트 {0}', ps.length + 1), colors: [] }]); setActivePalette(palettes.length); };
@@ -350,10 +340,7 @@ export default function App() {
     const [brushSize, setBrushSize] = useState(5);
     // Pen pressure. Off means an even line however hard the pen is pressed - wanted for lineart,
     // and for pens that report pressure unevenly.
-    const [pressureOn, setPressureOn] = useState(() => {
-        try { return localStorage.getItem('mv_pressure') !== 'off'; } catch { return true; }
-    });
-    useEffect(() => { try { localStorage.setItem('mv_pressure', pressureOn ? 'on' : 'off'); } catch { } }, [pressureOn]);
+    const [pressureOn, setPressureOn] = useStored('mv_pressure', true, onOffCodec);
     const [eraserSize, setEraserSize] = useState(20);
     const [opacity, setOpacity] = useState(1.0);
     const [expandedCuts, setExpandedCuts] = useState(new Set());
@@ -466,10 +453,7 @@ export default function App() {
     // A transparent canvas is a different document, not a different view: the frame really has
     // no background, and the checkerboard behind it is CSS on the element rather than pixels.
     // Painting the checkerboard in would put it in every export.
-    const [transparentBg, setTransparentBg] = useState(() => {
-        try { return localStorage.getItem('mv_transparent_bg') === '1'; } catch { return false; }
-    });
-    useEffect(() => { try { localStorage.setItem('mv_transparent_bg', transparentBg ? '1' : '0'); } catch { } }, [transparentBg]);
+    const [transparentBg, setTransparentBg] = useStored('mv_transparent_bg', false, oneZeroCodec);
     // Whether the project API is reachable. Re-checked with a backoff rather than once, because
     // an app that decided at load time is an app that never notices the server starting.
     const serverAvailable = useServerProbe();
@@ -483,24 +467,20 @@ export default function App() {
     // Nothing here is memoised, so changing it re-renders the whole tree in the new language.
     const [lang, setLang] = useState(loadLang);
     const changeLang = (l) => { setLangValue(l); saveLang(l); setLang(l); };
-    const [themeColor, setThemeColor] = useState(() => { try { return localStorage.getItem('mv_theme') || DEFAULT_THEME; } catch { return DEFAULT_THEME; } });
-    const [themeRecent, setThemeRecent] = useState(() => {
-        try { const v = JSON.parse(localStorage.getItem('mv_theme_recent')); return Array.isArray(v) ? v : []; } catch { return []; }
-    });
-    const [uiSat, setUiSat] = useState(() => { const v = parseFloat(localStorage.getItem('mv_ui_sat')); return isNaN(v) ? 3 : v; });
-    useEffect(() => {
-        applyTheme(themeColor, uiSat);
-        try { localStorage.setItem('mv_theme', themeColor); localStorage.setItem('mv_ui_sat', String(uiSat)); } catch { }
-    }, [themeColor, uiSat]);
+    const [themeColor, setThemeColor] = useStored('mv_theme', DEFAULT_THEME);
+    const [themeRecent, setThemeRecent] = useStored('mv_theme_recent', [], arrayCodec);
+    // This one had no try/catch at all, so a browser that refuses localStorage took the app
+    // down on first render instead of falling back to 3.
+    const [uiSat, setUiSat] = useStored('mv_ui_sat', 3, numberCodec);
+    // Only the applying is left here; useStored does the remembering.
+    useEffect(() => { applyTheme(themeColor, uiSat); }, [themeColor, uiSat]);
     // The value changes continuously while picking, so it is only recorded once picking stops.
     useEffect(() => {
         if (!/^#[0-9a-fA-F]{6}$/.test(themeColor)) return;
         const t = setTimeout(() => {
-            setThemeRecent(p => {
-                const next = [themeColor, ...p.filter(x => x.toLowerCase() !== themeColor.toLowerCase())].slice(0, 10);
-                try { localStorage.setItem('mv_theme_recent', JSON.stringify(next)); } catch { }
-                return next;
-            });
+            // No write here: the list only changes after the debounce, and useStored records
+            // it when it does.
+            setThemeRecent(p => [themeColor, ...p.filter(x => x.toLowerCase() !== themeColor.toLowerCase())].slice(0, 10));
         }, 800);
         return () => clearTimeout(t);
     }, [themeColor]);

--- a/src/core/persist.js
+++ b/src/core/persist.js
@@ -1,0 +1,97 @@
+// Reading and writing the small preferences that live in localStorage.
+//
+// Nine pieces of state were persisted, and each wrote out its own try/catch twice - once to read
+// on first render, once to write when it changed. Eighteen copies of the same two lines, which
+// would be merely noisy if they all agreed. They did not: the UI saturation was read with a bare
+//
+//     parseFloat(localStorage.getItem('mv_ui_sat'))
+//
+// with no guard at all, so in a browser where localStorage throws - a private window, or site
+// data blocked - the app failed to mount rather than falling back to its default. Every other
+// read had the guard. That is what a copied idiom costs: the one place it was left off is
+// invisible until someone opens the app in the wrong window.
+//
+// Anything that must survive reliably belongs in the project file or IndexedDB. This is for
+// preferences: which panels are open, the theme, the recent colours.
+
+/**
+ * A stored preference, or the fallback.
+ *
+ * The fallback is returned for a key that was never written, for one that cannot be parsed, and
+ * for a decode that rejects what it found - so a decoder can validate by returning undefined and
+ * a hand-edited or half-written value cannot take the app down with it.
+ *
+ * @template T
+ * @param {string} key
+ * @param {T} fallback
+ * @param {(raw: string) => T | undefined} [decode] defaults to the raw string
+ * @returns {T}
+ */
+export function readStored(key, fallback, decode) {
+    try {
+        const raw = localStorage.getItem(key);
+        if (raw === null) return fallback;
+        const value = decode ? decode(raw) : /** @type {any} */ (raw);
+        return value === undefined ? fallback : value;
+    } catch {
+        return fallback;
+    }
+}
+
+/**
+ * Write a preference, or quietly do nothing.
+ *
+ * Failing to save which panel was open is not worth interrupting anybody over, and localStorage
+ * throws for reasons the user chose: a private window, blocked site data, a full quota.
+ *
+ * @template T
+ * @param {string} key
+ * @param {T} value
+ * @param {(value: T) => string} [encode] defaults to String
+ */
+export function writeStored(key, value, encode) {
+    try {
+        localStorage.setItem(key, encode ? encode(value) : String(value));
+    } catch {
+        // Deliberately silent - see above.
+    }
+}
+
+/** JSON, for the preferences that are objects or arrays. */
+export const jsonCodec = {
+    decode: (raw) => JSON.parse(raw),
+    encode: (value) => JSON.stringify(value),
+};
+
+/**
+ * JSON that must decode to an array, for the lists. A stored value of the wrong shape is treated
+ * as absent rather than handed on to code that will index into it.
+ */
+export const arrayCodec = {
+    decode: (raw) => { const v = JSON.parse(raw); return Array.isArray(v) ? v : undefined; },
+    encode: (value) => JSON.stringify(value),
+};
+
+/**
+ * An on/off preference that defaults to on: only the literal 'off' turns it off.
+ *
+ * The two flags in the app disagreed about this - one stored 'on'/'off' and defaulted to on, the
+ * other stored '1'/'0' and defaulted to off - so both spellings are kept rather than migrated,
+ * because changing the spelling would silently reset the preference for everyone who had set it.
+ */
+export const onOffCodec = {
+    decode: (raw) => raw !== 'off',
+    encode: (value) => (value ? 'on' : 'off'),
+};
+
+/** An on/off preference that defaults to off: only the literal '1' turns it on. */
+export const oneZeroCodec = {
+    decode: (raw) => raw === '1',
+    encode: (value) => (value ? '1' : '0'),
+};
+
+/** A number, treating anything unparseable as absent. */
+export const numberCodec = {
+    decode: (raw) => { const v = parseFloat(raw); return Number.isNaN(v) ? undefined : v; },
+    encode: (value) => String(value),
+};

--- a/src/hooks/useStored.js
+++ b/src/hooks/useStored.js
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from 'react';
+import { readStored, writeStored } from '../core/persist.js';
+
+/**
+ * State that remembers itself in localStorage.
+ *
+ * Reads once, on first render, and writes whenever the value changes - which is what the nine
+ * hand-written pairs it replaces did, so a preference set in this tab is there in the next one.
+ *
+ * The codec is held in a ref rather than listed as a dependency: every call site passes an object
+ * literal, so depending on it would write on every render. What it encodes cannot change for a
+ * given key anyway.
+ *
+ * @template T
+ * @param {string} key
+ * @param {T} fallback used when nothing is stored, or when what is stored will not decode
+ * @param {{ decode?: (raw: string) => T | undefined, encode?: (value: T) => string }} [codec]
+ * @returns {[T, (next: T | ((prev: T) => T)) => void]}
+ */
+export function useStored(key, fallback, codec = {}) {
+    const [value, setValue] = useState(() => readStored(key, fallback, codec.decode));
+    const encode = useRef(codec.encode);
+    encode.current = codec.encode;
+    useEffect(() => { writeStored(key, value, encode.current); }, [key, value]);
+    return [value, setValue];
+}

--- a/test/persist.test.js
+++ b/test/persist.test.js
@@ -1,0 +1,118 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readStored, writeStored, jsonCodec, arrayCodec, onOffCodec, oneZeroCodec, numberCodec }
+    from '../src/core/persist.js';
+
+/** A localStorage stand-in. `throws` makes it behave like a browser with site data blocked. */
+function fakeStorage({ throws = false, data = {} } = {}) {
+    return {
+        data,
+        getItem(k) { if (throws) throw new DOMException('denied'); return k in data ? data[k] : null; },
+        setItem(k, v) { if (throws) throw new DOMException('denied'); data[k] = String(v); },
+    };
+}
+
+function withStorage(storage, fn) {
+    const real = globalThis.localStorage;
+    Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true, writable: true });
+    try { return fn(); } finally {
+        Object.defineProperty(globalThis, 'localStorage', { value: real, configurable: true, writable: true });
+    }
+}
+
+test('a key that was never written gives the fallback', () => {
+    withStorage(fakeStorage(), () => {
+        assert.equal(readStored('nope', 'default'), 'default');
+    });
+});
+
+test('a stored value comes back', () => {
+    withStorage(fakeStorage({ data: { k: 'hello' } }), () => {
+        assert.equal(readStored('k', 'default'), 'hello');
+    });
+});
+
+test('a storage that throws gives the fallback instead of taking the app down', () => {
+    // This is the bug the helper exists for: one of the nine reads had no guard, so a private
+    // window or blocked site data stopped the app mounting.
+    withStorage(fakeStorage({ throws: true }), () => {
+        assert.equal(readStored('k', 3, numberCodec.decode), 3);
+    });
+});
+
+test('writing to a storage that throws is silent', () => {
+    withStorage(fakeStorage({ throws: true }), () => {
+        assert.doesNotThrow(() => writeStored('k', 'v'));
+    });
+});
+
+test('a decoder that throws gives the fallback', () => {
+    withStorage(fakeStorage({ data: { k: 'not json' } }), () => {
+        assert.deepEqual(readStored('k', [], arrayCodec.decode), []);
+    });
+});
+
+test('a decoder can reject a value it does not like by returning undefined', () => {
+    withStorage(fakeStorage({ data: { k: '{"a":1}' } }), () => {
+        assert.deepEqual(readStored('k', ['fallback'], arrayCodec.decode), ['fallback'],
+            'an object is not an array, so it is treated as absent');
+    });
+});
+
+test('an empty string is a stored value, not an absent one', () => {
+    withStorage(fakeStorage({ data: { k: '' } }), () => {
+        assert.equal(readStored('k', 'default'), '');
+    });
+});
+
+test('a value written comes back through the same codec', () => {
+    const s = fakeStorage();
+    withStorage(s, () => {
+        writeStored('k', { a: [1, 2] }, jsonCodec.encode);
+        assert.deepEqual(readStored('k', null, jsonCodec.decode), { a: [1, 2] });
+    });
+});
+
+// --- the codecs -------------------------------------------------------------------------------
+
+test('onOff defaults to on: only the literal off turns it off', () => {
+    assert.equal(onOffCodec.decode('off'), false);
+    assert.equal(onOffCodec.decode('on'), true);
+    assert.equal(onOffCodec.decode('anything'), true);
+    assert.equal(onOffCodec.encode(true), 'on');
+    assert.equal(onOffCodec.encode(false), 'off');
+});
+
+test('oneZero defaults to off: only the literal 1 turns it on', () => {
+    assert.equal(oneZeroCodec.decode('1'), true);
+    assert.equal(oneZeroCodec.decode('0'), false);
+    assert.equal(oneZeroCodec.decode('on'), false);
+    assert.equal(oneZeroCodec.encode(true), '1');
+});
+
+test('the two flag spellings are kept apart, because changing one would reset it for everyone', () => {
+    // 'mv_pressure' stores on/off and defaults to on; 'mv_transparent_bg' stores 1/0 and defaults
+    // to off. Migrating either spelling would silently discard what a user had set.
+    assert.notEqual(onOffCodec.encode(true), oneZeroCodec.encode(true));
+    assert.equal(onOffCodec.decode('0'), true, 'an on/off flag does not read 0 as off');
+    assert.equal(oneZeroCodec.decode('on'), false, 'a 1/0 flag does not read on as true');
+});
+
+test('number treats anything unparseable as absent', () => {
+    assert.equal(numberCodec.decode('2.5'), 2.5);
+    assert.equal(numberCodec.decode('abc'), undefined);
+    assert.equal(numberCodec.decode(''), undefined);
+    assert.equal(numberCodec.encode(3), '3');
+});
+
+test('zero is a number, not an absent value', () => {
+    withStorage(fakeStorage({ data: { k: '0' } }), () => {
+        assert.equal(readStored('k', 3, numberCodec.decode), 0);
+    });
+});
+
+test('an empty array is a stored value, not an absent one', () => {
+    withStorage(fakeStorage({ data: { k: '[]' } }), () => {
+        assert.deepEqual(readStored('k', ['x'], arrayCodec.decode), []);
+    });
+});


### PR DESCRIPTION
## The bug this turned up

Ten pieces of state were persisted to localStorage, each writing out its own try/catch twice — once to read on first render, once to write when it changed. Twenty copies of the same two lines, which would be merely noisy if they all agreed.

They did not. The UI saturation was read like this, during `useState` init:

```js
const [uiSat, setUiSat] = useState(() => {
    const v = parseFloat(localStorage.getItem('mv_ui_sat'));   // no guard
    return isNaN(v) ? 3 : v;
});
```

In a browser where localStorage throws — a private window, or site data blocked — that throws during the first render and **the app does not mount**. Every other read had the guard. That is what a copied idiom costs: the one place it was left off is invisible until someone opens the app in the wrong kind of window.

## The shape

`useStored(key, fallback, codec)` does both halves.

The codecs are **named rather than inlined**, because two of them disagree on purpose:

| key | stored as | default when absent |
|---|---|---|
| `mv_pressure` | `on` / `off` | on |
| `mv_transparent_bg` | `1` / `0` | off |

Migrating either spelling would silently reset the preference for everyone who had set it, so both are kept and the difference is written down instead of smoothed over.

A decoder can also **reject** what it finds by returning `undefined` — which is how a stored layout from a version that docked differently is treated as absent rather than restored into a shape this one cannot lay out.

App.jsx keeps four localStorage calls, all of which are something other than "persist this state": a key created on demand, and writes inside setters.

## Verified

`npm run check` green — 579 tests, 14 of them new. The ones worth naming:

- a storage that throws gives the fallback instead of taking the app down
- a decoder that rejects a value falls back rather than handing an object to code expecting an array
- `0` is a number and `''` is a string — neither is treated as absent
- the two flag spellings do not read each other's values

In the browser: all nine preferences are written on load, and toggling the canvas background and pressure flips `0`→`1` and `on`→`off`, with the spellings intact.

The crash itself is shown by the unit test rather than end to end — making a live page's localStorage throw before React mounts is not something the harness can set up.
