### PR TITLE
refactor: one expression for the layer cache key

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -354,6 +354,7 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `sizeCanvas` | Resizes only when the size differs. Assigning `canvas.width` reallocates the backing store even when the value is unchanged - 8MB at 1920x1080, and the measured 79MB/s that ran the tab out of memory. |
 | `scratchCanvas` | A full-size scratch canvas kept in a ref: allocated once, then sized and cleared for reuse. Three places in the composite path did this by hand and disagreed about the clear - two cleared after a resize, which the resize had already done. Reuse is not a micro-optimisation here: a fresh canvas is 8MB per masked layer per frame. |
 | `strokeSig` | used to invalidate the layer canvas cache without stringifying the whole array. |
+| `layerSig` | The cache key for one baked layer canvas. Two caches use it and compare their keys against each other, so for a layer that is not boiling both forms must come out byte-identical - otherwise every such layer misses the cache and is redrawn every frame, with no visible symptom. |
 | `swayWeightAt` | bend one direction while the next bends back. |
 | `targetCanvasFor` | two shapes people actually publish. |
 | `TEXT_ANIM_DEFAULT` | - emphasis: a looping accent (pulse/shake/wave) |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,7 +61,7 @@ import {
     DEFAULT_CUT_DURATION, CANVAS_W as CANVAS_W_DEFAULT, CANVAS_H as CANVAS_H_DEFAULT, FONT_PRESETS, fontGroups,
     pointInPolygon, dist, safeArray, hexToRgb, bucketFillTransparentRegion,
     layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas,
-    flattenForCanvas, flattenLayersInUiOrder, strokeSig, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, swayWeightAt, morphPrepare,
+    flattenForCanvas, flattenLayersInUiOrder, layerSig, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, swayWeightAt, morphPrepare,
     accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
     targetCanvasFor, imageDataCanvas, cutProgress,
 } from './canvas/canvasUtils';
@@ -2821,10 +2821,7 @@ export default function App() {
                 // A boiling layer changes phase constantly, so nothing is baked here;
                 // ensureLayerCanvas redraws it per phase. Only a single still frame (phase 0) is
                 // kept, for the thumbnail.
-                // rev exists because edits that move coordinates without changing the stroke count
-                // or the last stroke - a whole-layer move, say - are invisible to strokeSig.
-                // Bumping rev invalidates the cache for those.
-                const layerStrokes = strokeSig(layer.strokes) + '|r' + (layer.roughen || 0) + '|v' + (layer.rev || 0);
+                const layerStrokes = layerSig(layer);
                 if (!canvas || canvas.dataset.strokes !== layerStrokes) {
                     // Skip (don't cache a blank) if a frame isn't decoded yet — the prefetch effect
                     // decodes it and repaints. Do NOT request a decode here (would loop with tick).
@@ -2935,7 +2932,7 @@ export default function App() {
         const phase = Math.floor(boilPhaseRef.current * (layer.roughSpeed ?? 1));
         const boil = layer.roughen ? ((phase % BOIL_PHASES) + BOIL_PHASES) % BOIL_PHASES : 0;
         const rOpts = { roughen: layer.roughen || 0, roughPhase: boil, roughWave: layer.roughWave ?? 1, roughMinSize: layer.roughMinSize ?? 0 };
-        const sig = strokeSig(layer.strokes) + '|r' + (layer.roughen || 0) + '|v' + (layer.rev || 0) + (layer.roughen ? `|b${boil}|w${rOpts.roughWave}|m${rOpts.roughMinSize}` : '');
+        const sig = layerSig(layer, rOpts);
         // Each phase needs its own canvas, or they would evict one another every tick and the
         // cycling would buy nothing.
         const slotKey = layer.roughen ? `${key}#${boil}` : key;

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -1061,6 +1061,30 @@ export function strokeSig(strokes) {
     return strokes.length + '|' + (last.id ?? '') + '|' + (last.points ? last.points.length : 0) + '|' + (last.bitmapId ?? '') + '|' + (last.tool ?? '');
 }
 
+/**
+ * The cache key for one layer's baked canvas.
+ *
+ * Two caches use this and they are compared against each other: the still-frame cache writes the
+ * key without a phase, and the boiling path checks its own key against what the still frame
+ * stored. For a layer that is not boiling the two must come out byte-identical or every such
+ * layer misses the cache and is redrawn every frame - a performance cliff with no visible
+ * symptom, which is exactly the kind of agreement that should not depend on two expressions
+ * being edited together.
+ *
+ * `rev` is in it because edits that move coordinates without changing the stroke count or the
+ * last stroke - a whole-layer move, say - are invisible to strokeSig.
+ *
+ * @param {{strokes?: any[], roughen?: number, rev?: number}} layer
+ * @param {{roughPhase?: number, roughWave?: number, roughMinSize?: number} | null} [rough]
+ *   the boiling options, when asking for a particular phase; omitted for the still frame
+ * @returns {string}
+ */
+export function layerSig(layer, rough = null) {
+    const base = strokeSig(layer?.strokes) + '|r' + (layer?.roughen || 0) + '|v' + (layer?.rev || 0);
+    if (!rough || !layer?.roughen) return base;
+    return base + `|b${rough.roughPhase}|w${rough.roughWave}|m${rough.roughMinSize}`;
+}
+
 export const ANIM_DEFAULT = { inType: 'none', inDur: 0.4, inDir: 'left', outType: 'none', outDur: 0.4, outDir: 'right', deformAxis: 'x', deformAmount: 0, deformReturn: false, deformSpeed: 1, deformCount: 0, moveX: 0, moveY: 0, moveReturn: false, moveSpeed: 1, moveCount: 0, ease: 'linear', easePower: 2 };
 
 // Per-cut animation state at a given absolute time. Returns null when the cut is

--- a/test/canvasUtils.test.js
+++ b/test/canvasUtils.test.js
@@ -14,7 +14,7 @@ import {
     pointInPolygon, dist, safeArray, hexToRgb, fitRect, layerKey, strokeSig,
     applyEase, triwave, swayWeightAt, sampleWave, sampleKeys, targetCanvasFor,
     computeCutAnim, flattenLayersInUiOrder, sizeCanvas, dilateMask, FONT_PRESETS, fontGroups,
-cutDuration, cutProgress, scratchCanvas } from '../src/canvas/canvasUtils.js';
+cutDuration, cutProgress, scratchCanvas , layerSig} from '../src/canvas/canvasUtils.js';
 
 const near = (a, b, eps = 1e-9) => assert.ok(Math.abs(a - b) < eps, `${a} ≈ ${b}`);
 
@@ -345,4 +345,89 @@ test('the second call at the same size clears, the first does not', () => {
     assert.equal(ctx.cleared.length, 0, 'first call resized');
     scratchCanvas(ref, 320, 180);
     assert.equal(ctx.cleared.length, 1, 'second call had nothing to resize');
+});
+
+// --- layerSig ----------------------------------------------------------------------------------
+
+const stroked = (over = {}) => ({ strokes: [{ id: 7, tool: 'pen', points: [1, 2, 3] }], ...over });
+
+test('a layer that is not boiling gets the same key with or without boiling options', () => {
+    // The two caches compare their keys against each other. If these ever differ, every
+    // non-boiling layer misses the cache and is redrawn every frame - fast to write, invisible
+    // to notice.
+    const layer = stroked();
+    const rough = { roughPhase: 3, roughWave: 2, roughMinSize: 1 };
+    assert.equal(layerSig(layer), layerSig(layer, rough));
+});
+
+test('a boiling layer gets a different key per phase', () => {
+    const layer = stroked({ roughen: 4 });
+    const at = (phase) => layerSig(layer, { roughPhase: phase, roughWave: 1, roughMinSize: 0 });
+    assert.notEqual(at(0), at(1));
+    assert.equal(at(2), at(2));
+});
+
+test('the still-frame key of a boiling layer is the phase key without the phase', () => {
+    const layer = stroked({ roughen: 4 });
+    const withPhase = layerSig(layer, { roughPhase: 0, roughWave: 1, roughMinSize: 0 });
+    assert.ok(withPhase.startsWith(layerSig(layer)));
+    assert.notEqual(withPhase, layerSig(layer), 'so a boiling layer never hits the still-frame cache');
+});
+
+test('the boiling settings are part of the key, not just the phase', () => {
+    const layer = stroked({ roughen: 4 });
+    const at = (wave, minSize) => layerSig(layer, { roughPhase: 0, roughWave: wave, roughMinSize: minSize });
+    assert.notEqual(at(1, 0), at(2, 0), 'a different wavelength is a different picture');
+    assert.notEqual(at(1, 0), at(1, 3), 'so is a different minimum width');
+});
+
+test('roughen and rev change the key', () => {
+    assert.notEqual(layerSig(stroked()), layerSig(stroked({ roughen: 2 })));
+    assert.notEqual(layerSig(stroked()), layerSig(stroked({ rev: 1 })),
+        'rev is what catches an edit that moves coordinates without changing the stroke list');
+});
+
+test('adding a stroke changes the key', () => {
+    const one = { strokes: [{ id: 1, tool: 'pen', points: [] }] };
+    const two = { strokes: [...one.strokes, { id: 2, tool: 'pen', points: [] }] };
+    assert.notEqual(layerSig(one), layerSig(two));
+});
+
+test('layerSig survives a layer with nothing in it', () => {
+    assert.equal(typeof layerSig({}), 'string');
+    assert.equal(typeof layerSig(null), 'string');
+});
+
+test('layerSig reproduces both expressions it replaced, byte for byte', () => {
+    // The two call sites each built this string by hand. An extraction is only safe if the new
+    // one is identical for every shape, so both old expressions are kept here and compared.
+    const oldStillFrame = (layer) =>
+        strokeSig(layer.strokes) + '|r' + (layer.roughen || 0) + '|v' + (layer.rev || 0);
+    const oldBoiling = (layer, boil, rOpts) =>
+        strokeSig(layer.strokes) + '|r' + (layer.roughen || 0) + '|v' + (layer.rev || 0)
+        + (layer.roughen ? `|b${boil}|w${rOpts.roughWave}|m${rOpts.roughMinSize}` : '');
+
+    const strokeSets = [
+        [],
+        [{ id: 1, tool: 'pen', points: [1, 2] }],
+        [{ id: 1, tool: 'pen', points: [] }, { id: 2, tool: 'paste', bitmapId: 'b7' }],
+    ];
+    for (const strokes of strokeSets) {
+        for (const roughen of [0, 1, 6]) {
+            for (const rev of [0, 3]) {
+                for (const boil of [0, 2]) {
+                    for (const roughWave of [1, 2.5]) {
+                        for (const roughMinSize of [0, 4]) {
+                            const layer = { strokes, roughen, rev };
+                            const rOpts = { roughen, roughPhase: boil, roughWave, roughMinSize };
+                            assert.equal(layerSig(layer), oldStillFrame(layer),
+                                `still frame differs for ${JSON.stringify(layer)}`);
+                            assert.equal(layerSig(layer, rOpts), oldBoiling(layer, boil, rOpts),
+                                `boiling differs for ${JSON.stringify({ layer, rOpts })}`);
+                        }
+                    }
+                }
+            }
+        }
+    }
 });


### PR DESCRIPTION
## What

Two places built the layer cache key by hand, and **they are compared against each other**: the still-frame cache writes its key into `dataset.strokes`, and the boiling path checks its own key against what the still frame stored.

```js
// still frame
strokeSig(layer.strokes) + '|r' + (layer.roughen || 0) + '|v' + (layer.rev || 0)

// boiling
strokeSig(layer.strokes) + '|r' + (layer.roughen || 0) + '|v' + (layer.rev || 0)
    + (layer.roughen ? `|b${boil}|w${rOpts.roughWave}|m${rOpts.roughMinSize}` : '')
```

For a layer that is **not** boiling the two have to come out byte-identical, or the still-frame cache never hits. Edit one prefix and not the other and every non-boiling layer is redrawn every frame — a performance cliff with **no visible symptom**, which is the worst kind of agreement to leave depending on two expressions being kept in step by hand.

`layerSig(layer)` is the still frame; `layerSig(layer, rOpts)` adds the phase. Written that way the relationship is the code rather than a comment about the code.

## The test that matters

An extraction is only safe if it is identical for *every* shape, so rather than a few examples the test keeps **both old expressions** and compares them against the new one across every combination of strokes, `roughen`, `rev`, phase, wavelength and minimum width.

Plus the property the two hand-written copies had to satisfy, now stated outright:

```js
assert.equal(layerSig(layer), layerSig(layer, rough));   // when the layer is not boiling
```

and that a boiling layer's phase keys are distinct, and that each one starts with the still-frame key — which is why a boiling layer deliberately never hits the still-frame cache.

`npm run check` green — 587 tests, 8 of them new.

## Scope of the browser check

The key behaviour was re-confirmed against the real module in a running page, and the app renders and is error-free. I did not manage to drive the boiling animation itself in the harness — the control I reached was not the strength field, and boiling only advances during playback — so that part rests on the tests rather than on having watched it.
