### PR TITLE
refactor: one keymap editor, written once

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -285,7 +285,7 @@ Key bindings, and what a key event means.
 | `findConflicts` | Actions sharing a key, as { key: [action, ...] } — only the keys with more than one. With a binding per tool this stopped being hypothetical. |
 | `KEY_LABELS` | What each binding is called in the settings panel. |
 | `keyOf` | Render a key event as a string such as "ctrl+shift+k". |
-| `loadKeymap` | The saved bindings, with anything missing filled in from the defaults. |
+| `keymapFrom` | A stored keymap with anything missing filled in from the defaults: a binding the user removed stays removed, one that never existed comes from the defaults or it would be unreachable. It no longer reads storage itself - that is readStored's job, and a second reader meant a second try/catch to keep in step. |
 | `matchShortcut` | Which binding, if any, a combo triggers. Compared case-insensitively so a binding stored as "Ctrl+[" still matches; they are written lowercase now, but a shortcut saved by an older version is not going to be rewritten. |
 | `TOOL_PREFIX` | Selecting a tool is a binding like any other, distinguished by this prefix so the handler can route it without a list of tool ids to keep in step with the toolbar. |
 | `toolFromAction` | The tool a binding selects, or null if it is not a tool binding. |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,7 +31,7 @@ import {
     loadVideo, clearVideo, setVideoCuts, setVideoOpacity, clearVideoCuts, moveTrack, resizeAudio,
 } from './core/mediaReducer.js';
 import { cloneCutContents as cloneCutContentsPure } from './core/cutClone.js';
-import { DEFAULT_KEYS, KEY_LABELS, keyOf, matchShortcut, loadKeymap, toolFromAction, findConflicts } from './core/shortcuts.js';
+import { DEFAULT_KEYS, KEY_LABELS, keyOf, matchShortcut, keymapFrom, toolFromAction, findConflicts } from './core/shortcuts.js';
 import { derivePartsFrom, deriveVideoBatches } from './core/partOps.js';
 import {
     cutsReducer, replaceCuts, addCuts, updateCut, setCutAnim, setCutCamera, clearCut,
@@ -491,7 +491,10 @@ export default function App() {
             setThemeRecent(p => [themeColor, ...p.filter(x => x.toLowerCase() !== themeColor.toLowerCase())].slice(0, 10));
         }, 800);
         return () => clearTimeout(t);
-    }, [themeColor]);
+        // The setter is listed because it comes from a custom hook: the linter knows a useState
+        // setter is stable and cannot know that about one handed back from useStored. It is
+        // stable, so saying so costs nothing and keeps the warning count honest.
+    }, [themeColor, setThemeRecent]);
     const [leftDock, setLeftDock] = useState('color'); // which panel is open in the left dock (null = closed); switched from the icon rail
 
     // Tab collapses every panel to leave just the canvas, and remembers what was open so the
@@ -523,7 +526,12 @@ export default function App() {
     // paintFrame already uses.
     const toggleAllPanelsRef = useRef(null);
     toggleAllPanelsRef.current = toggleAllPanels;
-    const [keymap, setKeymap] = useState(loadKeymap);
+    // One place writes the keymap. It used to be written in three: here, and again inside each
+    // of the two modals that edit it.
+    const [keymap, setKeymap] = useStored('mv_keymap', { ...DEFAULT_KEYS }, {
+        decode: (raw) => keymapFrom(JSON.parse(raw)),
+        encode: JSON.stringify,
+    });
     const [showSettings, setShowSettings] = useState(false); // settings dialog (shortcuts and theme)
     const [settingsTab, setSettingsTab] = useState('theme'); // open on the theme tab
     const [rebinding, setRebinding] = useState(null);  // id of the action waiting to be rebound
@@ -2055,14 +2063,13 @@ export default function App() {
                 const next = { ...prev };
                 for (const k of Object.keys(next)) if (next[k] === combo) next[k] = '';
                 next[rebinding] = combo;
-                try { localStorage.setItem('mv_keymap', JSON.stringify(next)); } catch { }
                 return next;
             });
             setRebinding(null);
         };
         window.addEventListener('keydown', h, true);
         return () => window.removeEventListener('keydown', h, true);
-    }, [rebinding]);
+    }, [rebinding, setKeymap]);
 
     // Zoom about the centre of the view, for the buttons and shortcuts.
     const zoomCanvas = (factor) => {

--- a/src/core/shortcuts.js
+++ b/src/core/shortcuts.js
@@ -118,14 +118,20 @@ export function findConflicts(keymap) {
     return out;
 }
 
-/** The saved bindings, with anything missing filled in from the defaults. */
-export function loadKeymap(storage = typeof localStorage === 'undefined' ? null : localStorage) {
-    try {
-        const v = JSON.parse(storage.getItem('mv_keymap'));
-        // A binding the user removed should stay removed, but one that never existed - a shortcut
-        // added since they last saved - has to come from the defaults or it would be unreachable.
-        return v && typeof v === 'object' ? { ...DEFAULT_KEYS, ...v } : { ...DEFAULT_KEYS };
-    } catch {
-        return { ...DEFAULT_KEYS };
-    }
+/**
+ * A stored keymap, with anything missing filled in from the defaults.
+ *
+ * A binding the user removed should stay removed, but one that never existed - a shortcut added
+ * since they last saved - has to come from the defaults or it would be unreachable.
+ *
+ * It used to read localStorage itself. It does not any more: reading and guarding storage is
+ * readStored's job, and having a second reader meant a second try/catch to keep in step.
+ *
+ * @param {unknown} value whatever was stored, already parsed
+ * @returns {Record<string, string>} always a fresh object, so editing it cannot touch the defaults
+ */
+export function keymapFrom(value) {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? { ...DEFAULT_KEYS, ...value }
+        : { ...DEFAULT_KEYS };
 }

--- a/src/ui/Modals.jsx
+++ b/src/ui/Modals.jsx
@@ -59,7 +59,6 @@ export function SettingsModal({
     keymap, setKeymap, defaultKeys, keyLabels, conflicts, rebinding, setRebinding,
     lang, changeLang, videoOpacity, setVideoOpacity, setShowToolKeys,
 }) {
-    const saveKeymap = (next) => { setKeymap(next); try { localStorage.setItem('mv_keymap', JSON.stringify(next)); } catch { } };
     return (
         <Modal title={tr('설정')} onClose={onClose} width={520} maxHeight="80vh" className="settings-modal"
             closeOnEscape={!rebinding} panelStyle={{ borderRadius: 10, padding: 20 }}>
@@ -131,27 +130,14 @@ export function SettingsModal({
                     <div style={{ fontSize: 11, color: '#888', marginBottom: 10 }}>
                         {rebinding ? tr('원하는 키를 누르세요 (Esc = 취소)') : tr('바꿀 항목을 누른 뒤 새 키를 누르세요.')}
                     </div>
-                    {Object.entries(conflicts || {}).map(([key, actions]) => (
-                        <div key={key} style={{ fontSize: 11, color: '#e0a84e', padding: '4px 0' }}>
-                            <AlertTriangle size={11} style={{ verticalAlign: '-1px' }} /> {tr('{0} 키가 겹칩니다: {1} — 하나만 동작합니다.', key, actions.map(a => tr(keyLabels[a] || a)).join(', '))}
-                        </div>
-                    ))}
-                    {Object.keys(defaultKeys).filter(id => !id.startsWith(TOOL_PREFIX)).map(id => (
-                        <div key={id} className="key-row" style={{ display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)' }}>
-                            <span style={{ flex: 1, color: '#ddd' }}>{tr(keyLabels[id])}</span>
-                            <button className="button" style={{ height: 30, minWidth: 110, justifyContent: 'center', background: rebinding === id ? 'var(--accent)' : undefined }}
-                                onClick={() => setRebinding(rebinding === id ? null : id)}>
-                                {rebinding === id ? tr('키 입력 대기…') : (keymap[id] || tr('(없음)'))}
-                            </button>
-                            {keymap[id] !== defaultKeys[id] && (
-                                <button className="small-btn" title={tr('기본값으로')} onClick={() => saveKeymap({ ...keymap, [id]: defaultKeys[id] })}>{tr('되돌리기')}</button>
-                            )}
-                        </div>
-                    ))}
+                    <KeyConflicts conflicts={conflicts} keyLabels={keyLabels} />
+                    <KeyRows ids={Object.keys(defaultKeys).filter(id => !id.startsWith(TOOL_PREFIX))}
+                        keymap={keymap} defaultKeys={defaultKeys} keyLabels={keyLabels}
+                        rebinding={rebinding} setRebinding={setRebinding} setKeymap={setKeymap} />
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 12 }}>
                         <span style={{ fontSize: 10, color: '#777' }}>{tr('Ctrl+S 저장 · Ctrl+Z/Y 등 기본 조합은 항상 동작합니다')}</span>
                         <button className="button" onClick={() => setShowToolKeys(true)}>{tr('도구 단축키…')}</button>
-                        <button className="button" onClick={() => saveKeymap({ ...defaultKeys })}>{tr('전체 기본값')}</button>
+                        <button className="button" onClick={() => setKeymap({ ...defaultKeys })}>{tr('전체 기본값')}</button>
                     </div>
                 </>
             )}
@@ -409,10 +395,6 @@ export function LinkPromptModal({ title, placeholder, onSubmit, onClose }) {
  * tool ones while deciding how to work.
  */
 export function ToolKeysModal({ keymap, setKeymap, defaultKeys, keyLabels, conflicts, rebinding, setRebinding, onClose }) {
-    const saveKeymap = (next) => {
-        setKeymap(next);
-        try { localStorage.setItem('mv_keymap', JSON.stringify(next)); } catch { }
-    };
     const ids = Object.keys(defaultKeys).filter(id => id.startsWith(TOOL_PREFIX));
     return (
         <Modal title={tr('도구 단축키')} onClose={onClose} width={400} maxHeight="80vh" z={1001}
@@ -420,27 +402,73 @@ export function ToolKeysModal({ keymap, setKeymap, defaultKeys, keyLabels, confl
             <div style={{ fontSize: 11, color: '#888', marginBottom: 10 }}>
                 {rebinding ? tr('원하는 키를 누르세요 (Esc = 취소)') : tr('바꿀 항목을 누르세요')}
             </div>
-            {Object.entries(conflicts || {}).map(([key, actions]) => (
-                <div key={key} style={{ fontSize: 11, color: '#e0a84e', padding: '4px 0' }}>
-                    <AlertTriangle size={11} style={{ verticalAlign: '-1px' }} /> {tr('{0} 키가 겹칩니다: {1} — 하나만 동작합니다.', key, actions.map(a => tr(keyLabels[a] || a)).join(', '))}
-                </div>
-            ))}
-            {ids.map(id => (
-                <div key={id} className="key-row" style={{ display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)', padding: '6px 0' }}>
-                    <span style={{ flex: 1, color: '#ddd' }}>{tr(keyLabels[id])}</span>
-                    <button className="button" style={{ height: 30, minWidth: 110, justifyContent: 'center', fontFamily: 'monospace' }}
-                        onClick={() => setRebinding(rebinding === id ? null : id)}>
-                        {rebinding === id ? tr('키 입력 대기…') : (keymap[id] || tr('(없음)'))}
-                    </button>
-                    {keymap[id] !== defaultKeys[id] && (
-                        <button className="small-btn" title={tr('기본값으로')} onClick={() => saveKeymap({ ...keymap, [id]: defaultKeys[id] })}>{tr('되돌리기')}</button>
-                    )}
-                </div>
-            ))}
+            <KeyConflicts conflicts={conflicts} keyLabels={keyLabels} />
+            <KeyRows ids={ids} keymap={keymap} defaultKeys={defaultKeys} keyLabels={keyLabels}
+                rebinding={rebinding} setRebinding={setRebinding} setKeymap={setKeymap} />
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6, marginTop: 12 }}>
-                <button className="button" onClick={() => saveKeymap({ ...keymap, ...Object.fromEntries(ids.map(id => [id, defaultKeys[id]])) })}>{tr('도구 기본값')}</button>
+                <button className="button" onClick={() => setKeymap({ ...keymap, ...Object.fromEntries(ids.map(id => [id, defaultKeys[id]])) })}>{tr('도구 기본값')}</button>
                 <button className="button button-primary" onClick={onClose}>{tr('닫기')}</button>
             </div>
         </Modal>
     );
+}/**
+ * Which keys are bound to more than one thing.
+ *
+ * Both keymap editors showed this and both wrote it out, which is how the two lists came to
+ * differ in ways nobody chose.
+ *
+ * @param {object} props
+ * @param {Record<string, string[]>} props.conflicts
+ * @param {Record<string, string>} props.keyLabels
+ */
+function KeyConflicts({ conflicts, keyLabels }) {
+    return Object.entries(conflicts || {}).map(([key, actions]) => (
+        <div key={key} style={{ fontSize: 11, color: '#e0a84e', padding: '4px 0' }}>
+            <AlertTriangle size={11} style={{ verticalAlign: '-1px' }} />{' '}
+            {tr('{0} 키가 겹칩니다: {1} — 하나만 동작합니다.', key, actions.map(a => tr(keyLabels[a] || a)).join(', '))}
+        </div>
+    ));
 }
+
+/**
+ * The bindings, one row each: what it does, the key it is on, and a way back to the default.
+ *
+ * The two editors drew these separately and had drifted apart: the tool list showed its key in a
+ * monospace font and the general list did not, and the general list highlighted the row being
+ * rebound while the tool list did not. Neither difference was a decision. Both good halves are
+ * kept here, so both lists now do both.
+ *
+ * A list rather than a single row because the caller would otherwise have to put a `key` on a
+ * component, which this project's type checking does not allow - inside, the key sits on the div
+ * where it belongs.
+ *
+ * @param {object} props
+ * @param {string[]} props.ids the bindings to show, in order
+ * @param {Record<string, string>} props.keymap
+ * @param {Record<string, string>} props.defaultKeys
+ * @param {Record<string, string>} props.keyLabels
+ * @param {string|null} props.rebinding the binding waiting for a keypress, if any
+ * @param {(id: string|null) => void} props.setRebinding
+ * @param {(next: Record<string, string>) => void} props.setKeymap
+ */
+function KeyRows({ ids, keymap, defaultKeys, keyLabels, rebinding, setRebinding, setKeymap }) {
+    return ids.map(id => {
+        const waiting = rebinding === id;
+        return (
+            <div key={id} className="key-row" style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0', borderBottom: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)' }}>
+                <span style={{ flex: 1, color: '#ddd' }}>{tr(keyLabels[id])}</span>
+                <button className="button"
+                    style={{ height: 30, minWidth: 110, justifyContent: 'center', fontFamily: 'monospace', background: waiting ? 'var(--accent)' : undefined }}
+                    onClick={() => setRebinding(waiting ? null : id)}>
+                    {waiting ? tr('키 입력 대기…') : (keymap[id] || tr('(없음)'))}
+                </button>
+                {keymap[id] !== defaultKeys[id] && (
+                    <button className="small-btn" title={tr('기본값으로')}
+                        onClick={() => setKeymap({ ...keymap, [id]: defaultKeys[id] })}>{tr('되돌리기')}</button>
+                )}
+            </div>
+        );
+    });
+}
+
+

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -3,7 +3,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { keyOf, matchShortcut, loadKeymap, toolFromAction, findConflicts, DEFAULT_KEYS, KEY_LABELS } from '../src/core/shortcuts.js';
+import { keyOf, matchShortcut, keymapFrom, toolFromAction, findConflicts, DEFAULT_KEYS, KEY_LABELS } from '../src/core/shortcuts.js';
 
 const ev = (key, mods = {}) => ({ key, ctrlKey: false, metaKey: false, altKey: false, shiftKey: false, ...mods });
 
@@ -59,27 +59,34 @@ test('matchShortcut: a key event round-trips to its action', () => {
     assert.equal(matchShortcut(DEFAULT_KEYS, keyOf(ev('0', { metaKey: true }))), 'resetView', 'and on a Mac');
 });
 
-test('loadKeymap: a shortcut added since the user last saved is still reachable', () => {
-    // Their file has only the bindings that existed then; the rest must come from the defaults.
-    const storage = { getItem: () => JSON.stringify({ undo: 'z' }) };
-    const km = loadKeymap(storage);
-    assert.equal(km.undo, 'z', 'their change wins');
-    assert.equal(km.zoomIn, DEFAULT_KEYS.zoomIn, 'and the newer binding is present');
+test('keymapFrom: a shortcut added since the user last saved is still reachable', () => {
+    // A binding the user removed should stay removed; one that never existed has to come from
+    // the defaults or there would be no way to reach it.
+    const km = keymapFrom({ undo: 'q' });
+    assert.equal(km.undo, 'q', 'what was saved wins');
+    assert.equal(km.redo, DEFAULT_KEYS.redo, 'what was not saved comes from the defaults');
 });
 
-test('loadKeymap: unreadable or absent storage falls back to the defaults', () => {
-    assert.deepEqual(loadKeymap({ getItem: () => null }), DEFAULT_KEYS);
-    assert.deepEqual(loadKeymap({ getItem: () => 'not json' }), DEFAULT_KEYS);
-    assert.deepEqual(loadKeymap({ getItem: () => { throw new Error('blocked'); } }), DEFAULT_KEYS,
-        'private mode can make localStorage throw');
-    assert.deepEqual(loadKeymap({ getItem: () => '"a string"' }), DEFAULT_KEYS);
+test('keymapFrom: anything that is not an object is treated as absent', () => {
+    // Reading and guarding storage is readStored's job now; this only has to survive what it
+    // is handed, including what a hand-edited value might be.
+    assert.deepEqual(keymapFrom(null), DEFAULT_KEYS);
+    assert.deepEqual(keymapFrom(undefined), DEFAULT_KEYS);
+    assert.deepEqual(keymapFrom('a string'), DEFAULT_KEYS);
+    assert.deepEqual(keymapFrom(42), DEFAULT_KEYS);
+    assert.deepEqual(keymapFrom(['q']), DEFAULT_KEYS, 'an array is not a keymap');
 });
 
-test('loadKeymap: returns a copy, so editing it cannot corrupt the defaults', () => {
-    const km = loadKeymap({ getItem: () => null });
-    km.undo = 'changed';
-    assert.equal(DEFAULT_KEYS.undo, 'j');
+test('keymapFrom: an emptied binding stays empty rather than coming back', () => {
+    assert.equal(keymapFrom({ undo: '' }).undo, '');
 });
+
+test('keymapFrom: returns a copy, so editing it cannot corrupt the defaults', () => {
+    const km = keymapFrom(null);
+    km.undo = 'zzz';
+    assert.notEqual(DEFAULT_KEYS.undo, 'zzz');
+});
+
 
 test('every binding has a label, and every label a binding', () => {
     assert.deepEqual(Object.keys(DEFAULT_KEYS).sort(), Object.keys(KEY_LABELS).sort());


### PR DESCRIPTION
## What the duplication had already cost

Two modals let you rebind keys — the settings one and the tool-shortcut one — and both drew the same thing from scratch: the conflict list, and a row per binding with its label, its key and a way back to the default.

The two copies had drifted, in ways nobody chose:

| | settings list | tool list |
|---|---|---|
| key shown in monospace | no | **yes** |
| row waiting for a keypress highlighted | **yes** | no |

`KeyRows` and `KeyConflicts` are shared now and keep **both** good halves, so both lists do both.

## Three writers, one key

The keymap was also written to localStorage in three places: App, and again inside each modal, each with its own try/catch. App owns it through `useStored`, and the modals just call `setKeymap`. **There is no localStorage left in `Modals.jsx`.**

`loadKeymap` read storage itself, which is exactly why there was a second guard to keep in step. It becomes `keymapFrom(value)` — the rule about what a stored keymap *means*, with the reading and the guarding left to `readStored`. Its tests move with it and gain two cases the old shape could not express: an array is not a keymap, and a binding the user emptied stays empty rather than coming back from the defaults.

## Two hook warnings, fixed rather than baselined

The setters now come from a custom hook. The linter knows a `useState` setter is stable and cannot know that about one handed back from `useStored`, so two effects started reporting a missing dependency. They are stable, so listing them is simply true — and the warning count is back at the baseline rather than one above it.

## Verified

`npm run check` green — 618 tests, hook warnings back to 12.

`KeyRows` renders the list rather than a single row on purpose: a `key` on a component is not something this project's type checking accepts, and inside the component the key sits on the `div` where it belongs.

## Worth a hand check

The keymap now persists from one place instead of three, so: rebind a shortcut, rebind a **tool** shortcut, hit "revert to default" on each, then reload and confirm both stuck. Both lists should now show their keys in monospace and highlight the row that is waiting for a keypress.
