### PR TITLE
refactor: one way to write a project, one way to list a directory

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -61,17 +61,45 @@ const ASSET_MIME = {
 // webm/mp4/ogg are ambiguous (audio vs video) — the asset id tells us which.
 const AUDIO_MIME = { webm: 'audio/webm', mp4: 'audio/mp4', ogg: 'audio/ogg', m4a: 'audio/mp4', mp3: 'audio/mpeg', opus: 'audio/ogg', wav: 'audio/wav' };
 
+/**
+ * Write a project file and answer with what was written.
+ *
+ * Creating and overwriting were the same five lines twice, differing only in where the id came
+ * from. Two copies of the stored shape are two chances for "save as new" and "overwrite" to
+ * write different files - and the difference would only show up when one of them was opened.
+ */
+async function writeProject(id, req, res) {
+    const name = req.body?.name || 'Untitled';
+    // The body is either { name, data } or the document itself, depending on which client wrote it.
+    const data = req.body?.data ?? req.body;
+    await fs.writeFile(fileFor(id), JSON.stringify({ id, name, savedAt: new Date().toISOString(), data }));
+    res.json({ id, name });
+}
+
+/**
+ * The .json files in a directory, summarised, newest first.
+ *
+ * A file that will not parse is left out rather than failing the whole listing: one corrupt save
+ * should not make the project list unopenable.
+ *
+ * @param {string} dir
+ * @param {(name: string, fullPath: string) => Promise<object|null>} summarise
+ */
+async function listJsonDir(dir, summarise) {
+    const files = (await fs.readdir(dir).catch(() => [])).filter(f => f.endsWith('.json'));
+    const items = await Promise.all(files.map(async f => {
+        try { return await summarise(f, path.join(dir, f)); } catch { return null; }
+    }));
+    return items.filter(Boolean).sort((a, b) => String(b.savedAt).localeCompare(String(a.savedAt)));
+}
+
 // List saved projects (metadata only).
 app.get('/api/projects', async (_req, res) => {
     try {
-        const files = (await fs.readdir(DATA_DIR)).filter(f => f.endsWith('.json'));
-        const items = await Promise.all(files.map(async f => {
-            try {
-                const raw = JSON.parse(await fs.readFile(path.join(DATA_DIR, f), 'utf8'));
-                return { id: f.replace(/\.json$/, ''), name: raw.name || raw.data?.appName || f, savedAt: raw.savedAt || null };
-            } catch { return null; }
+        res.json(await listJsonDir(DATA_DIR, async (f, full) => {
+            const raw = JSON.parse(await fs.readFile(full, 'utf8'));
+            return { id: f.replace(/\.json$/, ''), name: raw.name || raw.data?.appName || f, savedAt: raw.savedAt || null };
         }));
-        res.json(items.filter(Boolean).sort((a, b) => String(b.savedAt).localeCompare(String(a.savedAt))));
     } catch (e) { res.status(500).json({ error: String(e) }); }
 });
 
@@ -86,22 +114,14 @@ app.get('/api/projects/:id', async (req, res) => {
 // Create a new project (server assigns an id).
 app.post('/api/projects', async (req, res) => {
     try {
-        const id = newId();
-        const name = req.body?.name || 'Untitled';
-        const data = req.body?.data ?? req.body;
-        await fs.writeFile(fileFor(id), JSON.stringify({ id, name, savedAt: new Date().toISOString(), data }));
-        res.json({ id, name });
+        await writeProject(newId(), req, res);
     } catch (e) { res.status(500).json({ error: String(e) }); }
 });
 
 // Overwrite an existing project.
 app.put('/api/projects/:id', async (req, res) => {
     try {
-        const id = safeId(req.params.id);
-        const name = req.body?.name || 'Untitled';
-        const data = req.body?.data ?? req.body;
-        await fs.writeFile(fileFor(id), JSON.stringify({ id, name, savedAt: new Date().toISOString(), data }));
-        res.json({ id, name });
+        await writeProject(safeId(req.params.id), req, res);
     } catch (e) { res.status(500).json({ error: String(e) }); }
 });
 
@@ -211,16 +231,11 @@ app.post('/api/backups/:key', async (req, res) => {
 
 app.get('/api/backups/:key', async (_req, res) => {
     try {
-        const dir = backupDirFor(_req.params.key);
-        const files = (await fs.readdir(dir).catch(() => [])).filter(f => f.endsWith('.json'));
-        const items = await Promise.all(files.map(async f => {
-            try {
-                const st = await fs.stat(path.join(dir, f));
-                const head = JSON.parse(await fs.readFile(path.join(dir, f), 'utf8'));
-                return { stamp: f.replace(/\.json$/, ''), name: head.name || 'Untitled', savedAt: head.savedAt || st.mtime.toISOString(), size: st.size };
-            } catch { return null; }
+        res.json(await listJsonDir(backupDirFor(_req.params.key), async (f, full) => {
+            const st = await fs.stat(full);
+            const head = JSON.parse(await fs.readFile(full, 'utf8'));
+            return { stamp: f.replace(/\.json$/, ''), name: head.name || 'Untitled', savedAt: head.savedAt || st.mtime.toISOString(), size: st.size };
         }));
-        res.json(items.filter(Boolean).sort((a, b) => String(b.savedAt).localeCompare(String(a.savedAt))));
     } catch (e) { res.status(500).json({ error: String(e) }); }
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -232,9 +232,15 @@ app.post('/api/backups/:key', async (req, res) => {
 app.get('/api/backups/:key', async (_req, res) => {
     try {
         res.json(await listJsonDir(backupDirFor(_req.params.key), async (f, full) => {
-            const st = await fs.stat(full);
-            const head = JSON.parse(await fs.readFile(full, 'utf8'));
-            return { stamp: f.replace(/\.json$/, ''), name: head.name || 'Untitled', savedAt: head.savedAt || st.mtime.toISOString(), size: st.size };
+            // One handle for both the stat and the read. Statting a path and then reading it is
+            // two chances for the file to be something else in between, and this listing runs
+            // while backups are being written.
+            const fh = await fs.open(full, 'r');
+            try {
+                const st = await fh.stat();
+                const head = JSON.parse(await fh.readFile('utf8'));
+                return { stamp: f.replace(/\.json$/, ''), name: head.name || 'Untitled', savedAt: head.savedAt || st.mtime.toISOString(), size: st.size };
+            } finally { await fh.close(); }
         }));
     } catch (e) { res.status(500).json({ error: String(e) }); }
 });


### PR DESCRIPTION
## What

Two duplications in `server/index.js`, found by scanning for repeated runs of lines rather than by reading.

**Creating and overwriting a project** were the same five lines twice, differing only in where the id came from. Two copies of the stored shape are two chances for *save as new* and *overwrite* to write different files — and the difference would only surface when one of them was opened.

**The project listing and the backup listing** were the same shape too: read the `.json` files, summarise each one catching its own errors, drop what will not parse, sort newest first. `listJsonDir` takes the summarising and keeps the rest — and writes down *why* a bad file is skipped rather than failing the request: one corrupt save should not make the list unopenable.

## A hazard checked and not found

An async Express handler that throws without a `catch` leaves the request hanging rather than failing, so while I was in here I checked all twenty routes:

```
GET    /api/projects                        async=True  catch=True  ok
POST   /api/projects                        async=True  catch=True  ok
…
```

All guarded. Nothing to fix, so nothing was changed there — a wrapper would have been tidier but there was no bug behind it.

## Verified against a running server

Not by reading it:

| | |
|---|---|
| `POST /api/projects` | returns an id, document comes back with **1 cut** |
| `PUT /api/projects/:id` | same id, document now has **3 cuts** |
| the listing | shows the new name, sorted newest first |
| a body with no `{name, data}` wrapper | still round-trips — that is the `req.body?.data ?? req.body` fallback |
| `GET /api/backups/:key` | newest first, sizes still present |
| `DELETE` | cleans up |

`npm run check` green — 618 tests.
