### PR TITLE
fix: a video seek that could hang the import, and one cut transform

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -326,6 +326,7 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `applyEase` | The easing curves. Everything animated should go through this rather than its own. |
 | `bucketFillTransparentRegion` | Flood fill across the transparent region under a point, with a tolerance and an optional spread so the fill creeps under the anti-aliased edge of a line instead of leaving a halo. |
 | `CANVAS_W` | The document's pixel size, 1920x1080. The canvas element is scaled by CSS; drawing coordinates are always these. |
+| `applyCutAnim` | Put a cut animation onto a context; the caller owns the save/restore. Written out at both places that draw a cut - the artwork and the text over it - and if the two disagreed about the pivot, an animation would slide a text off its own drawing. |
 | `computeCutAnim` | at rest (no transform), so callers can skip the save/transform fast-path. |
 | `computeLayerAnim` | A layer (part) animation resolved to one instant: the offset, rotation, scale, alpha and sway to draw it with. |
 | `computeTextAnim` | A text animation resolved to one instant. Returns the entrance, exit and emphasis values, how much of the string is revealed, and — when the characters own the entrance — the progress they divide between them. |

--- a/HELPERS.md
+++ b/HELPERS.md
@@ -342,6 +342,8 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `dilateMask` | Grow a bitmask outwards by r pixels (square structuring element, done separably so it stays O(w*h) whatever r is). Used to bleed a bucket fill under the line that bounds it. |
 | `dist` | Distance between two points. |
 | `drawStrokesOnCtx` | Draw a list of strokes onto a context: the one place that knows what each tool looks like. Clears first unless told not to, and takes the boiling options so a roughened layer draws its own phase. |
+| `openVideoFile` | Open a video file for frame-by-frame reading: the element, its duration, a clamped seek and a release. Both readers set one up the same way and tore it down the same way, and two copies of an object URL's lifetime is two chances to leak one. |
+| `seekTarget` | Where a seek should land. Never the very last frame: seeking to exactly the duration fires no `seeked` event in some browsers, so the promise waiting for one never settles and the import stops halfway with no error. |
 | `extractVideoFrames` | Pull frames out of a video file at a given rate, optionally over a range, scaled, encoded as WebP or PNG, with near-duplicate frames merged. Reports progress and can be stopped part way. |
 | `fitRect` | Letterbox rect: fit source into destination preserving aspect ratio. |
 | `flattenForCanvas` | The layers to draw, bottom first, with folders resolved and hidden branches dropped. |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,7 +63,7 @@ import {
     DEFAULT_CUT_DURATION, CANVAS_W as CANVAS_W_DEFAULT, CANVAS_H as CANVAS_H_DEFAULT, FONT_PRESETS, fontGroups,
     pointInPolygon, dist, safeArray, hexToRgb, bucketFillTransparentRegion,
     layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas,
-    flattenForCanvas, flattenLayersInUiOrder, layerSig, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, swayWeightAt, morphPrepare,
+    flattenForCanvas, flattenLayersInUiOrder, layerSig, applyCutAnim, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, swayWeightAt, morphPrepare,
     accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
     targetCanvasFor, imageDataCanvas, cutProgress,
 } from './canvas/canvasUtils';
@@ -3129,9 +3129,7 @@ export default function App() {
             ctx.save();
             if (anim) {
                 ctx.globalAlpha = anim.alpha;
-                ctx.translate(CANVAS_W / 2 + anim.tx, CANVAS_H / 2 + anim.ty);
-                ctx.scale(anim.sx, anim.sy);
-                ctx.translate(-CANVAS_W / 2, -CANVAS_H / 2);
+                applyCutAnim(ctx, anim, CANVAS_W, CANVAS_H);
             }
             // Draw bottom -> top so the topmost layer (UI top) is visually on top.
             for (let i = groups.length - 1; i >= 0; i--) {
@@ -3214,11 +3212,10 @@ export default function App() {
         // Text objects live outside paint layers ("text layer").
         scene.cuts.forEach(({ anim, texts }) => {
             ctx.save();
-            if (anim) {
-                ctx.translate(CANVAS_W / 2 + anim.tx, CANVAS_H / 2 + anim.ty);
-                ctx.scale(anim.sx, anim.sy);
-                ctx.translate(-CANVAS_W / 2, -CANVAS_H / 2);
-            }
+            // The alpha is not set here the way it is for the artwork: a text has its own
+            // opacity, so drawTextObject multiplies the two rather than being handed a context
+            // that already has one applied.
+            applyCutAnim(ctx, anim, CANVAS_W, CANVAS_H);
             for (const { text, anim: ta } of texts) {
                 drawTextObject(ctx, text, {
                     anim: ta,

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -878,21 +878,69 @@ export function fitRect(sw, sh, dw, dh) {
 // Decode a video file into evenly spaced frames (ImageData at the project resolution) by
 // seeking. Returns { frames, fps, duration }. onProgress(done, total) for UI feedback.
 /**
+ * Where a seek should actually land.
+ *
+ * Never the very last frame: seeking to exactly `duration` fires no `seeked` event in some
+ * browsers, and the promise waiting for one then never settles - an import that stops halfway
+ * with no error. The scene detector had learnt this and clamped; the frame extractor had not,
+ * and it steps right up to the end of the range it was given.
+ *
+ * @param {number} t
+ * @param {number} duration
+ * @returns {number}
+ */
+export function seekTarget(t, duration) {
+    if (!Number.isFinite(duration) || duration <= 0) return 0;
+    return Math.max(0, Math.min(t, duration - 0.02));
+}
+
+/**
+ * Open a video file for frame-by-frame reading.
+ *
+ * Both readers - the frame importer and the scene detector - set up the same element the same
+ * way, waited for metadata the same way, and tore it down the same way. Two copies of an object
+ * URL's lifetime is two chances to leak one, and they had already drifted over the seek clamp
+ * above.
+ *
+ * The caller decides what an unusable duration means: the importer treats it as an error, the
+ * detector shrugs and reports no cuts, and that difference is deliberate.
+ *
+ * @param {File|Blob} file
+ * @returns {Promise<{video: HTMLVideoElement, duration: number,
+ *   seek: (t: number) => Promise<void>, release: () => void}>}
+ */
+export async function openVideoFile(file) {
+    const url = URL.createObjectURL(file);
+    const video = document.createElement('video');
+    video.muted = true; video.playsInline = true; video.preload = 'auto'; video.src = url;
+    const release = () => { URL.revokeObjectURL(url); video.src = ''; };
+    try {
+        await /** @type {Promise<void>} */ (new Promise((res, rej) => {
+            video.onloadedmetadata = () => res();
+            video.onerror = () => rej(new Error(tr('영상을 읽을 수 없습니다 (형식 미지원)')));
+        }));
+    } catch (e) {
+        release();          // the element never became usable, so nothing else will free the URL
+        throw e;
+    }
+    const duration = video.duration;
+    const seek = (t) => /** @type {Promise<void>} */ (new Promise((res) => {
+        const on = () => { video.removeEventListener('seeked', on); res(); };
+        video.addEventListener('seeked', on);
+        video.currentTime = seekTarget(t, duration);
+    }));
+    return { video, duration, seek, release };
+}
+
+/**
  * @param {File|Blob} file
  * @param {{fps?:number, maxFrames?:number, start?:number, end?:number|null, scale?:number,
  *   quality?:number, dedupe?:string|number, nativeRes?:boolean, format?:string,
  *   width?:number, height?:number, onProgress?:Function, shouldStop?:Function}} [opts]
  */
 export async function extractVideoFrames(file, { fps = 6, maxFrames = 0, start = 0, end = null, width, height, scale = 1, quality = 0.82, dedupe = 'exact', nativeRes = false, format = 'webp', onProgress, shouldStop } = {}) {
-    const url = URL.createObjectURL(file);
-    const video = document.createElement('video');
-    video.muted = true; video.playsInline = true; video.preload = 'auto'; video.src = url;
+    const { video, duration, seek, release } = await openVideoFile(file);
     try {
-        await /** @type {Promise<void>} */ (new Promise((res, rej) => {
-            video.onloadedmetadata = () => res();
-            video.onerror = () => rej(new Error(tr('영상을 읽을 수 없습니다 (형식 미지원)')));
-        }));
-        const duration = video.duration;
         if (!isFinite(duration) || duration <= 0) throw new Error(tr('영상 길이를 알 수 없습니다'));
         const to = Math.min(end ?? duration, duration);
         const step = 1 / Math.max(0.1, fps);
@@ -915,11 +963,6 @@ export async function extractVideoFrames(file, { fps = 6, maxFrames = 0, start =
         const ctx = cnv.getContext('2d');
         ctx.imageSmoothingEnabled = true; ctx.imageSmoothingQuality = 'high'; // crisp resampling when scaling
         const r = useNative ? { x: 0, y: 0, w: fw, h: fh } : fitRect(vW, vH, fw, fh);
-        const seek = (t) => /** @type {Promise<void>} */ (new Promise((res) => {
-            const on = () => { video.removeEventListener('seeked', on); res(); };
-            video.addEventListener('seeked', on);
-            video.currentTime = t;
-        }));
         const toBlob = format === 'png'
             ? () => new Promise((res) => cnv.toBlob(res, 'image/png'))                    // lossless
             : () => new Promise((res) => cnv.toBlob(b => b ? res(b) : cnv.toBlob(res, 'image/jpeg', quality), 'image/webp', quality));
@@ -997,8 +1040,7 @@ export async function extractVideoFrames(file, { fps = 6, maxFrames = 0, start =
         }
         return { frames, holds, skipped, fps, duration, width: fw, height: fh };
     } finally {
-        URL.revokeObjectURL(url);
-        video.src = '';
+        release();
     }
 }
 
@@ -1011,18 +1053,14 @@ export async function extractVideoFrames(file, { fps = 6, maxFrames = 0, start =
  *   refine?:boolean, onProgress?:Function, shouldStop?:Function}} [opts]
  */
 export async function detectSceneCuts(file, { start = 0, end = null, step = 0.2, threshold = 14, refine = true, onProgress, shouldStop } = {}) {
-    const url = URL.createObjectURL(file);
-    const video = document.createElement('video');
-    video.muted = true; video.playsInline = true; video.preload = 'auto'; video.src = url;
+    const { video, duration: dur, seek, release } = await openVideoFile(file);
     try {
-        await /** @type {Promise<void>} */ (new Promise((res, rej) => { video.onloadedmetadata = () => res(); video.onerror = () => rej(new Error('scene-detect: cannot read video')); }));
-        const dur = video.duration; if (!isFinite(dur) || dur <= 0) return [];
+        if (!isFinite(dur) || dur <= 0) return [];
         const to = Math.min(end ?? dur, dur), from = Math.max(0, Math.min(start, to - 0.05));
         const sw = 48, sh = 48, c = document.createElement('canvas'); c.width = sw; c.height = sh; // finer signature = more accurate
         const cx = c.getContext('2d', { willReadFrequently: true });
         const sig = () => { cx.drawImage(video, 0, 0, sw, sh); const d = cx.getImageData(0, 0, sw, sh).data, o = new Uint8Array(sw * sh); for (let i = 0, j = 0; j < o.length; i += 4, j++) o[j] = (d[i] * 0.299 + d[i + 1] * 0.587 + d[i + 2] * 0.114) | 0; return o; };
         const diff = (a, b) => { let s = 0; for (let i = 0; i < a.length; i++) s += Math.abs(a[i] - b[i]); return s / a.length; };
-        const seek = (t) => /** @type {Promise<void>} */ (new Promise((res) => { const on = () => { video.removeEventListener('seeked', on); res(); }; video.addEventListener('seeked', on); video.currentTime = Math.max(0, Math.min(t, dur - 0.02)); }));
         // Binary-search the exact moment the picture stops matching the pre-cut frame → precise boundary.
         const refineCut = async (refSig, a, b) => {
             for (let k = 0; k < 6; k++) { const mid = (a + b) / 2; await seek(mid); if (diff(refSig, sig()) > threshold) b = mid; else a = mid; }
@@ -1046,7 +1084,7 @@ export async function detectSceneCuts(file, { start = 0, end = null, step = 0.2,
             if (t >= to) break;
         }
         return cuts;
-    } finally { URL.revokeObjectURL(url); video.src = ''; }
+    } finally { release(); }
 }
 
 export function flattenForCanvas(layers) {

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -1125,6 +1125,26 @@ export function layerSig(layer, rough = null) {
 
 export const ANIM_DEFAULT = { inType: 'none', inDur: 0.4, inDir: 'left', outType: 'none', outDur: 0.4, outDir: 'right', deformAxis: 'x', deformAmount: 0, deformReturn: false, deformSpeed: 1, deformCount: 0, moveX: 0, moveY: 0, moveReturn: false, moveSpeed: 1, moveCount: 0, ease: 'linear', easePower: 2 };
 
+/**
+ * Put a cut's animation onto a 2D context. The caller owns the save/restore.
+ *
+ * Move, scale and rotate all pivot on the centre of the frame, which is why the origin goes there
+ * and comes back. Written out at both places that draw a cut - the artwork and the text over it -
+ * and if the two ever disagreed about the pivot, a cut animation would slide its text off its
+ * drawing, which reads as a text placement bug rather than an animation one.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {{tx:number, ty:number, sx:number, sy:number} | null | undefined} anim
+ * @param {number} [cw]
+ * @param {number} [ch]
+ */
+export function applyCutAnim(ctx, anim, cw = CANVAS_W, ch = CANVAS_H) {
+    if (!anim) return;
+    ctx.translate(cw / 2 + anim.tx, ch / 2 + anim.ty);
+    ctx.scale(anim.sx, anim.sy);
+    ctx.translate(-cw / 2, -ch / 2);
+}
+
 // Per-cut animation state at a given absolute time. Returns null when the cut is
 // at rest (no transform), so callers can skip the save/transform fast-path.
 export function computeCutAnim(ac, time, cw = CANVAS_W, ch = CANVAS_H) {

--- a/test/canvasUtils.test.js
+++ b/test/canvasUtils.test.js
@@ -14,7 +14,7 @@ import {
     pointInPolygon, dist, safeArray, hexToRgb, fitRect, layerKey, strokeSig,
     applyEase, triwave, swayWeightAt, sampleWave, sampleKeys, targetCanvasFor,
     computeCutAnim, flattenLayersInUiOrder, sizeCanvas, dilateMask, FONT_PRESETS, fontGroups,
-cutDuration, cutProgress, scratchCanvas , layerSig} from '../src/canvas/canvasUtils.js';
+cutDuration, cutProgress, scratchCanvas , layerSig, seekTarget} from '../src/canvas/canvasUtils.js';
 
 const near = (a, b, eps = 1e-9) => assert.ok(Math.abs(a - b) < eps, `${a} ≈ ${b}`);
 
@@ -430,4 +430,36 @@ test('layerSig reproduces both expressions it replaced, byte for byte', () => {
             }
         }
     }
+});
+
+// --- seekTarget ---------------------------------------------------------------------------------
+
+test('a seek never lands on the very last frame', () => {
+    // Seeking to exactly the duration fires no `seeked` event in some browsers, so the promise
+    // waiting for one never settles and the import stops halfway with no error. The scene
+    // detector clamped; the frame extractor did not, and it steps right up to the end.
+    assert.ok(seekTarget(10, 10) < 10);
+    assert.equal(seekTarget(10, 10), 9.98);
+    assert.equal(seekTarget(99, 10), 9.98, 'past the end clamps too');
+});
+
+test('a seek inside the video is left alone', () => {
+    assert.equal(seekTarget(0, 10), 0);
+    assert.equal(seekTarget(3.5, 10), 3.5);
+    assert.equal(seekTarget(9.97, 10), 9.97);
+});
+
+test('a negative time becomes the start', () => {
+    assert.equal(seekTarget(-1, 10), 0);
+});
+
+test('a duration that makes no sense seeks to the start rather than somewhere negative', () => {
+    for (const bad of [0, -5, NaN, Infinity, undefined, null]) {
+        assert.equal(seekTarget(3, /** @type {any} */(bad)), 0, `duration ${bad}`);
+    }
+});
+
+test('a video shorter than the clamp still seeks inside itself', () => {
+    const t = seekTarget(1, 0.01);
+    assert.ok(t >= 0 && t <= 0.01, `${t} is outside a 0.01s video`);
 });

--- a/test/canvasUtils.test.js
+++ b/test/canvasUtils.test.js
@@ -14,7 +14,7 @@ import {
     pointInPolygon, dist, safeArray, hexToRgb, fitRect, layerKey, strokeSig,
     applyEase, triwave, swayWeightAt, sampleWave, sampleKeys, targetCanvasFor,
     computeCutAnim, flattenLayersInUiOrder, sizeCanvas, dilateMask, FONT_PRESETS, fontGroups,
-cutDuration, cutProgress, scratchCanvas , layerSig, seekTarget} from '../src/canvas/canvasUtils.js';
+cutDuration, cutProgress, scratchCanvas , layerSig, seekTarget, applyCutAnim} from '../src/canvas/canvasUtils.js';
 
 const near = (a, b, eps = 1e-9) => assert.ok(Math.abs(a - b) < eps, `${a} ≈ ${b}`);
 
@@ -462,4 +462,58 @@ test('a duration that makes no sense seeks to the start rather than somewhere ne
 test('a video shorter than the clamp still seeks inside itself', () => {
     const t = seekTarget(1, 0.01);
     assert.ok(t >= 0 && t <= 0.01, `${t} is outside a 0.01s video`);
+});
+
+// --- applyCutAnim -------------------------------------------------------------------------------
+
+/** A context that records what was asked of it, which is all this needs to be checked. */
+const recorder = () => {
+    const calls = [];
+    return {
+        calls,
+        translate: (x, y) => calls.push(['translate', x, y]),
+        scale: (x, y) => calls.push(['scale', x, y]),
+    };
+};
+
+test('a cut animation pivots on the centre of the frame', () => {
+    const ctx = recorder();
+    applyCutAnim(ctx, { tx: 0, ty: 0, sx: 2, sy: 2 }, 1920, 1080);
+    assert.deepEqual(ctx.calls, [
+        ['translate', 960, 540],
+        ['scale', 2, 2],
+        ['translate', -960, -540],
+    ]);
+});
+
+test('the move is added to the centre, not applied after the scale', () => {
+    // Order matters: scaling first would multiply the offset by the scale.
+    const ctx = recorder();
+    applyCutAnim(ctx, { tx: 100, ty: -50, sx: 2, sy: 2 }, 1000, 800);
+    assert.deepEqual(ctx.calls[0], ['translate', 600, 350]);
+    assert.deepEqual(ctx.calls[1], ['scale', 2, 2]);
+});
+
+test('a cut with no animation touches the context at all', () => {
+    for (const nothing of [null, undefined]) {
+        const ctx = recorder();
+        applyCutAnim(ctx, nothing, 1920, 1080);
+        assert.deepEqual(ctx.calls, [], 'a save/restore around nothing is still cheap, a transform is not');
+    }
+});
+
+test('the artwork and the text over it get the same transform', () => {
+    // The whole point of sharing this: if the two disagreed about the pivot, a cut animation
+    // would slide its text off its drawing.
+    const anim = { tx: 12, ty: -7, sx: 1.4, sy: 0.9 };
+    const a = recorder(), b = recorder();
+    applyCutAnim(a, anim, 1920, 1080);
+    applyCutAnim(b, anim, 1920, 1080);
+    assert.deepEqual(a.calls, b.calls);
+});
+
+test('a non-uniform scale is passed through as given', () => {
+    const ctx = recorder();
+    applyCutAnim(ctx, { tx: 0, ty: 0, sx: 0.5, sy: 2 }, 100, 100);
+    assert.deepEqual(ctx.calls[1], ['scale', 0.5, 2]);
 });


### PR DESCRIPTION
Two duplications found by scanning for repeated runs of lines. One was hiding a bug.

## 1. A video seek that could hang the import

Two readers open a video file frame by frame — the frame importer and the scene detector — and both set up the element, waited for metadata and tore it down with their own copy of the same twelve lines. They had drifted, and the difference was a bug:

```js
detector:  video.currentTime = Math.max(0, Math.min(t, dur - 0.02));
importer:  video.currentTime = t;
```

Seeking to **exactly** the duration fires no `seeked` event in some browsers, so the promise waiting for one never settles. The importer steps right up to the end of whatever range it was given, so importing a whole video could stop halfway **with no error and no way to tell why**.

The detector had learnt this. The importer had not. That is the argument for chasing duplication rather than long functions: one copy gets the fix, the other keeps the bug.

`openVideoFile(file)` hands back the element, its duration, one clamped seek, and a release. Two copies of an object URL's lifetime is two chances to leak one — and the failure path only worked by accident: if metadata never arrived, the throw escaped through a `try` whose `finally` happened to wrap it. Neither copy said that was the plan; the helper now releases explicitly when the element never becomes usable.

`seekTarget(t, duration)` is separate and pure so the clamp is testable.

The callers keep their own answer to an unusable duration — the importer treats it as an error, the detector reports no cuts. That difference is deliberate and stays.

## 2. One cut-animation transform

Both places that draw a cut wrote the same three lines: the artwork, and the text over it.

If the two ever disagreed about the pivot, a cut animation would **slide its text off its own drawing** — which reads as a text placement bug rather than an animation one, and would be looked for in entirely the wrong file.

The alpha is deliberately *not* part of this. The artwork gets it on the context; a text has its own opacity, so `drawTextObject` multiplies the two instead.

## Verified

`npm run check` green — 628 tests, 10 new.

On the clamp: a seek never lands on the last frame (`seekTarget(10, 10) === 9.98`), past the end clamps, a time inside is left alone, a negative time becomes the start, and `0` / `-5` / `NaN` / `Infinity` / `undefined` / `null` as a duration all seek to the start rather than somewhere negative.

On the transform, using a recording context: the pivot is the centre of the frame, the move is added to the centre rather than applied after the scale (scaling first would multiply the offset), no animation touches the context at all, and — the property worth pinning — **the artwork and the text get the identical transform**.

## Worth a hand check

Import a clip **as frames** and let it run to the end: that is the seek that could hang. Scene detection on the same clip should behave as before. And a cut with a move/scale animation should carry its text with it.
