### PR TITLE
refactor: state nobody reads, and one way to mint an id

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -136,6 +136,7 @@ two of those sites had already worked the collision around by hand with `Date.no
 | | |
 |---|---|
 | `nextId` | The clock, or one past the last id when the clock has not moved. Monotonic within a session, which is all that is needed, and still roughly the clock so ids keep sorting by when they were made. |
+| `randomId` | A unique string id, optionally prefixed: the clock in base 36 plus eight random characters. The clock keeps ids sorting by creation; the random tail is what makes them unique, since a video import mints one per frame inside the same millisecond. |
 | `resetIds` | Reset the counter. For tests only, so one test's calls cannot change what another sees. |
 
 ## `src/core/lassoOps.js`

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ import ColorPanel, { RECENT_SLOTS } from './ui/ColorPanel';
 import { TopBar } from './ui/TopBar';
 import { CutLayerPanel } from './ui/CutLayerPanel';
 import { useStored } from './hooks/useStored.js';
-import { nextId } from './core/ids.js';
+import { nextId, randomId } from './core/ids.js';
 import { clampZoom } from './core/viewZoom.js';
 import { arrayCodec, onOffCodec, oneZeroCodec, numberCodec } from './core/persist.js';
 import { TextEditor } from './ui/TextEditor';
@@ -66,7 +66,7 @@ import {
     layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas,
     flattenForCanvas, flattenLayersInUiOrder, layerSig, applyCutAnim, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, swayWeightAt, morphPrepare,
     accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
-    targetCanvasFor, imageDataCanvas, cutProgress,
+    targetCanvasFor, imageDataCanvas, cutProgress, seekTarget,
 } from './canvas/canvasUtils';
 
 /**
@@ -286,7 +286,6 @@ export default function App() {
     const [autoSceneDetect, setAutoSceneDetect] = useStored('mv_auto_scene', true, onOffCodec);
     const videoElRef = useRef(null);      // hidden <video> element that decodes/plays the overlay
     const videoBlobRef = useRef(null);    // the video Blob, for saving
-    const videoSeekTokRef = useRef(0);    // paused-seek token so a stale 'seeked' doesn't repaint
     const [videoImport, setVideoImport] = useState(null); // {file, fps, maxFrames} dialog
     const [recentVideos, setRecentVideos] = useState([]); // fetched/opened videos, reusable without re-downloading
     const [videoBusy, setVideoBusy] = useState(null); // {done, total} while extracting
@@ -324,7 +323,6 @@ export default function App() {
         encode: JSON.stringify,
     });
     const [activePalette, setActivePalette] = useState(0);
-    const [paletteEdit, setPaletteEdit] = useState(false); // when on, tapping a swatch deletes it (for tablets)
     const addToPalette = (c) => setPalettes(ps => ps.map((p, i) => i === activePalette && !p.colors.some(x => x.toLowerCase() === c.toLowerCase()) ? { ...p, colors: [...p.colors, c] } : p));
     const removeFromPalette = (ci) => setPalettes(ps => ps.map((p, i) => i === activePalette ? { ...p, colors: p.colors.filter((_, j) => j !== ci) } : p));
     const addPalette = () => { setPalettes(ps => [...ps, { name: tr('팔레트 {0}', ps.length + 1), colors: [] }]); setActivePalette(palettes.length); };
@@ -366,7 +364,6 @@ export default function App() {
     const canvasRef = useRef(null);
     const liveCanvasRef = useRef(null);   // overlay for the in-progress stroke (drawn without touching layer state)
     const liveStrokeRef = useRef(null);   // the stroke currently being drawn
-    const liveClearTokRef = useRef(0);
     const liveClearPendingRef = useRef(false); // after a commit, clear the overlay only once the layer cache has drawn the new stroke,
     // which avoids a flicker or a vanishing line
     const lineStartRef = useRef(null);    // start point of the line tool
@@ -434,7 +431,6 @@ export default function App() {
     const tlTouchRef = useRef(new Map());
     const tlPinchRef = useRef(null);
     const [serverProjects, setServerProjects] = useState(null); // null = picker closed
-    const [serverBusy, setServerBusy] = useState(false);
     const [localProjects, setLocalProjects] = useState(null); // IndexedDB project picker
     const localIdRef = useRef(null);
     const localNameRef = useRef('');
@@ -545,7 +541,7 @@ export default function App() {
     const [cameraCapture, setCameraCapture] = useState(null); // {cutId} while drawing a camera path
 
     const storeBitmap = (imageData) => {
-        const id = Date.now().toString(36) + Math.random().toString(36).slice(2);
+        const id = randomId();
         bitmapStoreRef.current.set(id, { imageData, imageBitmap: null });
         // Best-effort bitmap for fast preview; fall back to ImageData rendering if this fails.
         createImageBitmap(imageData).then(bmp => {
@@ -563,7 +559,7 @@ export default function App() {
     // ImageBitmap at import is what OOMs a big video (hundreds of full-res bitmaps resident).
     // The bitmap is decoded lazily on first display and released under an LRU cap.
     const storeBitmapBlob = async (blob, w = 0, h = 0) => {
-        const id = Date.now().toString(36) + Math.random().toString(36).slice(2);
+        const id = randomId();
         const ext = (blob.type.match(/image\/(\w+)/)?.[1] || 'webp');
         bitmapStoreRef.current.set(id, { imageData: null, imageBitmap: null, blob, ext, w, h });
         return id;
@@ -897,7 +893,8 @@ export default function App() {
         const v = videoElRef.current; if (!v || !videoOverlay) return;
         if (currentTime >= videoOverlay.startTime && currentTime < videoOverlay.endTime) {
             const exp = (currentTime - videoOverlay.startTime) + videoOverlay.offset;
-            if (Math.abs(v.currentTime - exp) > 0.03) { try { v.currentTime = exp; } catch { } }
+            const want = seekTarget(exp, v.duration);
+            if (Math.abs(v.currentTime - want) > 0.03) { try { v.currentTime = want; } catch { } }
         }
     }, [currentTime, isPlaying, videoOverlay]);
 
@@ -1366,7 +1363,6 @@ export default function App() {
         }
     };
     const doServerSave = async (forceNew = false) => {
-        setServerBusy(true);
         try {
             const assetSink = [];
             const data = await buildData(true, assetSink); // frames/audio externalized → small JSON
@@ -1393,7 +1389,7 @@ export default function App() {
         } catch (e) {
             console.error('[import]', e);
             setAppError(tr('서버 저장 실패: ') + e.message + '\n' + tr('(API 서버가 실행 중인지 확인하세요. 큰 프로젝트는 저장에 시간이 걸립니다.)'));
-        } finally { setServerBusy(false); setLoadProgress(null); }
+        } finally { setLoadProgress(null); }
     };
     const openServerList = async () => {
         try { setServerProjects(await apiFetch('/api/projects')); }
@@ -1426,7 +1422,7 @@ export default function App() {
             let k = null;
             try { k = localStorage.getItem('mv_backup_key'); } catch { }
             if (!k) {
-                k = 'bk_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+                k = randomId('bk_');
                 try { localStorage.setItem('mv_backup_key', k); } catch { }
             }
             backupKeyRef.current = k;
@@ -1530,7 +1526,7 @@ export default function App() {
             if (!forceNew && localIdRef.current) { await saveProject(localIdRef.current, data, localNameRef.current || 'Untitled'); alert(tr('로컬에 저장했습니다.')); return; }
             const name = window.prompt(tr('로컬 저장 이름:'), localNameRef.current || 'MV Project');
             if (!name) return;
-            const id = 'l_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+            const id = randomId('l_');
             await saveProject(id, data, name);
             localIdRef.current = id; localNameRef.current = name;
             alert(tr('로컬에 저장했습니다.'));

--- a/src/core/ids.js
+++ b/src/core/ids.js
@@ -30,6 +30,26 @@ export function nextId() {
 }
 
 /**
+ * A unique string id, optionally prefixed.
+ *
+ * The clock in base 36 followed by eight random characters. The clock keeps ids sorting by
+ * creation and makes them readable in a saved file; the random tail is what actually makes them
+ * unique, because several of these are minted inside one millisecond routinely - importing a
+ * video mints one per frame.
+ *
+ * This existed five times over in four shapes: tails of `slice(2)`, `slice(2, 6)` and
+ * `slice(2, 7)`, and one that wrote the clock in decimal rather than base 36. Four different
+ * collision odds for one idea, none of them chosen on purpose. The prefix is cosmetic: nothing
+ * reads it back, it is there so a stray id in a debugger says what it belongs to.
+ *
+ * @param {string} [prefix]
+ * @returns {string}
+ */
+export function randomId(prefix = '') {
+    return prefix + Date.now().toString(36) + Math.random().toString(36).slice(2, 10);
+}
+
+/**
  * Reset the counter. For tests only, so one test's calls cannot make another's assertions
  * depend on how many ids were handed out before it ran.
  */

--- a/src/ui/AnimPanels.jsx
+++ b/src/ui/AnimPanels.jsx
@@ -2,6 +2,7 @@ import { Circle } from 'lucide-react';
 import React from 'react';
 import { ANIM_DEFAULT, LAYER_ANIM_DEFAULT } from '../canvas/canvasUtils';
 import { CAMERA_DEFAULT, CAMERA_PRESETS, resolveCamera } from '../core/camera.js';
+import { randomId } from '../core/ids.js';
 import { NumField } from './NumField';
 import { tr } from '../i18n';
 
@@ -184,7 +185,7 @@ export function LayerAnimPanel({ cut, layer, updLayerAnim, updLayers, pathCaptur
         // The id is what lets React follow a key that changes position: the list is kept sorted,
         // so editing a %  moves the row, and with an index for a key React would instead hand the
         // focused input the next key's values mid-edit.
-        setKeys(cur ? keys.map(k => k === cur ? { ...k, ...val } : k) : [...keys, { id: 'k' + Date.now() + Math.random().toString(36).slice(2, 6), ...val }]);
+        setKeys(cur ? keys.map(k => k === cur ? { ...k, ...val } : k) : [...keys, { id: randomId('k'), ...val }]);
     };
     const updKey = (i, o) => setKeys(keys.map((k, j) => j === i ? { ...k, ...o } : k));
     return (


### PR DESCRIPTION
## Dead state in App.jsx

Four declarations nothing on either side touches:

| | why it is dead |
|---|---|
| `paletteEdit` | *"tapping a swatch deletes it (for tablets)"* — the colour panel has no user palettes any more, only recent colours. A flag for a feature that left. |
| `serverBusy` | set true and false around every server save, read nowhere: two renders of the whole app per save for a value no one asks for. `loadProgress`, set beside it, is what the UI shows. |
| `videoSeekTokRef` | *"paused-seek token so a stale `seeked` doesn't repaint"* — the race it names cannot happen. `onseeked` only bumps a tick, and the repaint draws whichever frame the element holds at that moment; nothing is captured against the time it was requested for. |
| `liveClearTokRef` | never mentioned again. |

## One real fix, found while reading the effect above

The paused-seek effect set `v.currentTime = exp` unclamped. `endTime` is user-trimmable, so `exp` can land at or past the video's own duration — which fires no `seeked` in some browsers, leaving the canvas on the previous frame. Now goes through `seekTarget`, the same clamp the frame importer and the scene detector already share (#100).

## `randomId`

The string id existed five times over in four shapes: tails of `slice(2)`, `slice(2, 6)` and `slice(2, 7)`, plus one writing the clock in decimal rather than base 36. Four collision odds for one idea, none chosen on purpose. Prefixes are kept — they are readable in a debugger — and nothing parses them back, which I checked before touching them.

## Two scans that found nothing

Recorded so they are not redone:

- No call site in `App.jsx` passes a prop its component does not take (17 checkable sites).
- Every write to the bitmap store mints a fresh id rather than mutating an entry — which is what makes undo work at all, since a snapshot holds `{cuts, audioData, numTracks}` and the pixels live outside it.

`npm run check` green: 634 tests.