### PR TITLE
refactor: nothing touches localStorage directly any more, and a tighter hook baseline

### DIFF
--- a/scripts/hook-baseline.json
+++ b/scripts/hook-baseline.json
@@ -1,5 +1,4 @@
 {
-  "App.jsx:react-hooks/exhaustive-deps": 11,
-  "usePlayback.js:react-hooks/exhaustive-deps": 1,
-  "ColorPanel.jsx:react-hooks/exhaustive-deps": 1
+  "App.jsx:react-hooks/exhaustive-deps": 8,
+  "usePlayback.js:react-hooks/exhaustive-deps": 1
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import { CutLayerPanel } from './ui/CutLayerPanel';
 import { useStored } from './hooks/useStored.js';
 import { nextId, randomId } from './core/ids.js';
 import { clampZoom } from './core/viewZoom.js';
-import { arrayCodec, onOffCodec, oneZeroCodec, numberCodec } from './core/persist.js';
+import { readStored, writeStored, arrayCodec, onOffCodec, oneZeroCodec, numberCodec } from './core/persist.js';
 import { TextEditor } from './ui/TextEditor';
 import { ToolsPanel } from './ui/ToolsPanel';
 import { Timeline } from './ui/Timeline';
@@ -194,15 +194,17 @@ const TOOL_TYPES = [
 function LayerThumbnail({ layer, cutId, layerCanvasCache }) {
     const ref = useRef(null);
     const key = layerKey(cutId, layer.id);
+    // Read outside the effect so the dependency is a value the linter can check, rather than an
+    // expression it has to give up on - which is what hid 'key' and the cache itself from it.
+    const layerCanvas = layerCanvasCache[key];
     useEffect(() => {
         const c = ref.current; if (!c) return;
         const ctx = c.getContext('2d');
         ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, 56, 31);
-        const layerCanvas = layerCanvasCache[key];
         if (layerCanvas) {
             ctx.drawImage(layerCanvas, 0, 0, 56, 31);
         }
-    }, [layer, layerCanvasCache[key]]);
+    }, [layer, layerCanvas]);
     return <canvas ref={ref} width={56} height={31} style={{ width: 42, height: 23, borderRadius: 3, background: '#fff', flexShrink: 0, border: '1px solid hsl(var(--ui-h) var(--ui-s) 22%)' }} />;
 }
 
@@ -1433,11 +1435,10 @@ export default function App() {
     const getBackupKey = () => {
         if (serverIdRef.current) return serverIdRef.current; // group under the server project if there is one
         if (!backupKeyRef.current) {
-            let k = null;
-            try { k = localStorage.getItem('mv_backup_key'); } catch { }
+            let k = readStored('mv_backup_key', '');
             if (!k) {
                 k = randomId('bk_');
-                try { localStorage.setItem('mv_backup_key', k); } catch { }
+                writeStored('mv_backup_key', k);
             }
             backupKeyRef.current = k;
         }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -14,6 +14,7 @@
 // that exact shape came up during the conversion.
 
 import { JA } from './i18n.ja.js';
+import { readStored, writeStored } from './core/persist.js';
 
 /** The languages with a dictionary. Korean needs none: it is the key. */
 export const LANGS = ['en', 'ko', 'ja'];
@@ -24,15 +25,8 @@ export const getLang = () => lang;
 export const setLangValue = (l) => { lang = LANGS.includes(l) ? l : 'en'; };
 // English is the default: the repository, the README and the screenshots are English, so a
 // first-time visitor should land in English. The others are one click away and are remembered.
-export const loadLang = () => {
-    try {
-        const saved = localStorage.getItem('mv_lang');
-        return LANGS.includes(saved) ? saved : 'en';
-    } catch { return 'en'; }
-};
-export const saveLang = (l) => {
-    try { localStorage.setItem('mv_lang', l); } catch { }
-};
+export const loadLang = () => readStored('mv_lang', 'en', (raw) => (LANGS.includes(raw) ? raw : undefined));
+export const saveLang = (l) => writeStored('mv_lang', l);
 
 /**
  * Look one string up in one dictionary, allowing for the padding some call sites add.

--- a/src/ui/AnimPanels.jsx
+++ b/src/ui/AnimPanels.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { ANIM_DEFAULT, LAYER_ANIM_DEFAULT } from '../canvas/canvasUtils';
 import { CAMERA_DEFAULT, CAMERA_PRESETS, resolveCamera } from '../core/camera.js';
 import { randomId } from '../core/ids.js';
+import { readStored, writeStored, arrayCodec } from '../core/persist.js';
 import { NumField } from './NumField';
 import { tr } from '../i18n';
 
@@ -167,8 +168,8 @@ const MOVE_PRESETS = [
 
 // Per-layer ("part") animation (move/rotate/scale/path + ping-pong/speed/count/easing).
 // Presets the user saved: same shape as the built-in ones, kept in the browser.
-const loadCustomPresets = () => { try { const v = JSON.parse(localStorage.getItem('mv_move_presets')); return Array.isArray(v) ? v : []; } catch { return []; } };
-const saveCustomPresets = (list) => { try { localStorage.setItem('mv_move_presets', JSON.stringify(list)); } catch { } };
+const loadCustomPresets = () => readStored('mv_move_presets', [], arrayCodec.decode);
+const saveCustomPresets = (list) => writeStored('mv_move_presets', list, arrayCodec.encode);
 
 export function LayerAnimPanel({ cut, layer, updLayerAnim, updLayers, pathCapture, setPathCapture, cutProgress = 0 }) {
     const a = { ...LAYER_ANIM_DEFAULT, ...layer.anim };

--- a/src/ui/ColorPanel.jsx
+++ b/src/ui/ColorPanel.jsx
@@ -54,7 +54,7 @@ function ColorWheel({ color, onPick, size = 168 }) {
             ctx.arc(cx, cy, (R_OUT + R_IN) / 2, (a - 0.7) * Math.PI / 180, (a + 0.7) * Math.PI / 180);
             ctx.stroke();
         }
-    }, [WHEEL, RING]);
+    }, [WHEEL, RING, R_OUT, R_IN]);
 
     // The square is redrawn whenever the hue changes.
     React.useEffect(() => {


### PR DESCRIPTION
## Three preferences that still went round `persist.js`

`persist.js` was written to be the one place that reads and writes localStorage, after a missing guard on **one** copy of a copied idiom stopped the app mounting in a private window. Three preferences never moved over:

| | what it was doing by hand |
|---|---|
| saved move presets | parse JSON, check it is an array — which is `arrayCodec`, exactly |
| language | read and validate against `LANGS` — which is the validating decode `persist.js` documents: an unknown value is treated as absent, not adopted |
| automatic-backup key | read, and write one if absent |

All three had their guard, so none of them *was* the bug. But that bug was a missing guard on the copy nobody looked at, and three copies is three chances to leave it off again. `grep localStorage src/` now finds one comment.

**Checked against a stub localStorage**, not just the build: a saved language comes back, an unknown one falls back to English, `saveLang` round-trips, a presets entry of the wrong shape reads as empty — and with no localStorage at all (Node), `loadLang()` returns `'en'` and `saveLang` does not throw.

## Hook baseline: 12 → 9

- **ColorPanel's hue ring** listed `[WHEEL, RING]` while using `R_OUT` and `R_IN`. Both are plain numbers derived from those two alone, so naming them cannot make the effect run more often — it is the same value whenever `WHEEL` and `RING` are. ColorPanel is out of the baseline entirely now.
- **The layer thumbnail** depended on `layerCanvasCache[key]`, an expression the linter gives up on — which is what hid `key` and the cache itself from it. Read once above the effect, it becomes a value the linter can check. Two warnings for one line.

The other eight stay, and 2869 is the instructive one: two of its three missing dependencies are safe numbers, but the third is `layerCanvasCache` — which that effect *sets*. Adding it is the "Maximum update depth exceeded" loop `hook-baseline.mjs` warns about, and the linter reports all three as a single warning, so there is no half of it worth taking.

`npm run check` green — 634 tests.