### PR TITLE
fix: the exports run the range playback runs

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -197,6 +197,17 @@ Typing into a number field without the value fighting the cursor.
 | `commitNumber` | The value to settle on when the field is left: unreadable text falls back to the old value. |
 | `liveNumber` | The value to report while typing; null means "not a number yet, hold on". Intermediate states like "", "-", "." and "1e" hold rather than snapping to zero. |
 
+## `src/core/playRange.js`
+
+Where the content starts and where it ends. Answered in three places with three different answers
+before this: playback counted cuts, audio and the reference video; the screen recording left out
+the reference video it was capturing; the frame and GIF export counted only the cuts and always
+began at zero.
+
+| | |
+|---|---|
+| `playRange` | The time range to play, or export. A selected part wins outright; otherwise the range spans everything that occupies time. An empty project gives 0..0, so callers read that as nothing to do rather than testing for emptiness themselves. |
+
 ## `src/core/partOps.js`
 
 Parts: groups of cuts made from an import or a selection.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ import {
 import { cloneCutContents as cloneCutContentsPure } from './core/cutClone.js';
 import { DEFAULT_KEYS, KEY_LABELS, keyOf, matchShortcut, keymapFrom, toolFromAction, findConflicts } from './core/shortcuts.js';
 import { derivePartsFrom, deriveVideoBatches } from './core/partOps.js';
+import { playRange } from './core/playRange.js';
 import {
     cutsReducer, replaceCuts, addCuts, updateCut, setCutAnim, setCutCamera, clearCut,
     updateLayer, setLayerAnim, moveLayers, upsertText, moveText, deleteText, toggleTextVisible as toggleTextVisibleAction,
@@ -781,17 +782,15 @@ export default function App() {
     // leaves nowhere to place anything before the audio is loaded.
     const maxTime = Math.max(TIMELINE_MIN_SPAN, audioData?.endTime ?? audioDuration, videoOverlay?.endTime ?? 0, ...cuts.map(c => c.endTime)) + TIMELINE_TAIL_PAD;
 
-    // Actual content bounds (where cuts/audio live) — playback & loop run between these,
-    // not out to maxTime (which has empty padding for the timeline ruler).
-    const contentEnd = Math.max(0, audioData?.endTime ?? 0, videoOverlay?.endTime ?? 0, ...cuts.map(c => c.endTime));
-    const contentStart = (cuts.length || videoOverlay) ? Math.max(0, Math.min(videoOverlay?.startTime ?? Infinity, ...cuts.map(c => c.startTime), audioData?.startTime ?? Infinity)) : 0;
+    // Content bounds - playback and loop run between these, not out to maxTime, which has empty
+    // padding for the timeline ruler.
     // Parts (scenes): cuts grouped by partId. Each video import is one part; cuts can also be
     // grouped manually. Selecting a part scopes playback (and dims the rest) to it.
     const parts = derivePartsFrom(cuts, tr('파트'));
     const activePart = activePartId ? parts.find(p => p.id === activePartId) : null;
-    // Playback runs within the active part when one is selected, else across all content.
-    const playStart = activePart ? activePart.start : contentStart;
-    const playEnd = activePart ? activePart.end : contentEnd;
+    // Playback runs within the active part when one is selected, else across all content. The
+    // exports use the same two numbers - see playRange.js for what that fixed.
+    const { start: playStart, end: playEnd } = playRange({ cuts, audio: audioData, video: videoOverlay, part: activePart });
 
     // Playback owns the clock: isPlaying, currentTime, and the refs the rAF loop reads instead
     // of state so it never runs on a stale closure. Everything passed in is an input - playback
@@ -3672,8 +3671,12 @@ export default function App() {
     // holding the previous frame the way playback does.
     const handleExportFrames = async () => {
         const canvas = canvasRef.current; if (!canvas) return;
-        const ctMax = Math.max(...cuts.map(c => c.endTime), 0);
-        if (ctMax <= 0) { alert(tr('내보낼 콘텐츠가 없습니다.')); return; }
+        // The range playback uses, so what you watch is what comes out: it starts where the
+        // content starts rather than at zero, and it follows the selected part the way playback
+        // and the dimming already do. Exporting from zero meant a project whose first cut sits at
+        // three seconds began with three seconds of nothing.
+        const from = playStart, to = playEnd;
+        if (to <= from) { alert(tr('내보낼 콘텐츠가 없습니다.')); return; }
         // A GIF at 30fps is enormous and plays no better; twelve is what hand-drawn animation
         // usually runs at anyway. A PNG sequence is going into an editor, so it keeps the full
         // rate.
@@ -3688,7 +3691,7 @@ export default function App() {
         const gh = Math.max(1, Math.round(CANVAS_H * gifScale));
         // One scratch canvas for the whole export rather than one a frame.
         const gifScratch = { current: null };
-        const total = Math.max(1, Math.round(ctMax * fps));
+        const total = Math.max(1, Math.round((to - from) * fps));
         // Every frame is held in memory until the file is built, so the cap is about RAM, not
         // patience: a thousand 1080p frames is already a few hundred megabytes.
         if (total > 1000 && !confirm(tr('{0}프레임을 내보냅니다. 메모리를 많이 쓰고 오래 걸립니다. 계속할까요?').replace('{0}', String(total)))) return;
@@ -3699,7 +3702,7 @@ export default function App() {
         const entries = [];
         try {
             for (let i = 0; i < total; i++) {
-                const t = i / fps;
+                const t = from + i / fps;
                 // Wait for what this frame needs rather than painting without it.
                 const scene = evaluateFrame(cuts, t, { playing: true, currentCutId, cw: CANVAS_W, ch: CANVAS_H });
                 const missing = pendingBitmapIds(scene.cuts.map(e => e.cut), bitmapStoreRef.current);
@@ -3758,12 +3761,14 @@ export default function App() {
         if (typeof canvas.captureStream !== 'function' || typeof window.MediaRecorder === 'undefined') {
             alert(tr('이 환경에서는 내보내기를 지원하지 않습니다.\nPC 브라우저(Chrome 등)에서 실행해 주세요.')); return;
         }
-        const ctMax = Math.max(...cuts.map(c => c.endTime), audioData?.endTime ?? 0);
-        if (ctMax <= 0) { alert(tr('내보낼 콘텐츠가 없습니다.')); return; }
+        // Same range as the frame export and as playback. This used to be its own third answer
+        // to "where does the content end" - cuts and audio, but not the reference video, which is
+        // on the canvas being recorded.
+        if (playEnd <= playStart) { alert(tr('내보낼 콘텐츠가 없습니다.')); return; }
         const candidates = ['video/mp4;codecs=h264', 'video/mp4', 'video/webm;codecs=vp9', 'video/webm;codecs=vp8', 'video/webm'];
         const mimeType = candidates.find(t => { try { return MediaRecorder.isTypeSupported(t); } catch { return false; } }) || '';
         const ext = mimeType.startsWith('video/mp4') ? 'mp4' : 'webm';
-        alert(tr('녹화가 시작됩니다.')); setCurrentTime(0); if (audioRef.current) audioRef.current.currentTime = 0;
+        alert(tr('녹화가 시작됩니다.')); setCurrentTime(playStart); if (audioRef.current) audioRef.current.currentTime = audioData ? Math.max(0, (playStart - audioData.startTime) + audioData.offset) : playStart;
         const stream = canvas.captureStream(30), tracks = [...stream.getVideoTracks()];
         if (audioRef.current && audioUrl && !audioSourceRef.current) { try { audioCtxRef.current = new (window.AudioContext || window.webkitAudioContext)(); audioDestRef.current = audioCtxRef.current.createMediaStreamDestination(); audioSourceRef.current = audioCtxRef.current.createMediaElementSource(audioRef.current); audioSourceRef.current.connect(audioDestRef.current); audioSourceRef.current.connect(audioCtxRef.current.destination); } catch (e) { } }
         if (audioDestRef.current) tracks.push(...audioDestRef.current.stream.getAudioTracks());
@@ -3774,7 +3779,7 @@ export default function App() {
         const chunks = [];
         mr.ondataavailable = e => { if (e.data.size > 0) chunks.push(e.data); };
         mr.onstop = () => { downloadBlob(new Blob(chunks, { type: blobType }), `mv_export.${ext}`); alert(tr('완료!')); isExporting.current = false; };
-        exportEndRef.current = ctMax; isExporting.current = true; mediaRecorderRef.current = mr; mr.start(); setIsPlaying(true);
+        exportEndRef.current = playEnd; isExporting.current = true; mediaRecorderRef.current = mr; mr.start(); setIsPlaying(true);
     };
 
     const renderLayers = (cut, parentId = null, depth = 0) => {

--- a/src/core/playRange.js
+++ b/src/core/playRange.js
@@ -1,0 +1,48 @@
+// Where the content starts and where it ends.
+//
+// This was answered in three places with three different answers. Playback used cuts, audio and
+// the reference video. The screen recording used cuts and audio, but not the reference video -
+// which is drawn on the very canvas it captures. The frame and GIF export used the cuts alone,
+// and always began at zero rather than where the content begins, so a project whose first cut
+// sits at three seconds exported three seconds of nothing before anything happened.
+//
+// None of those three was written down as a decision; they are the same idea typed out three
+// times, drifting. So: one function, and the exports run the range playback runs. What you watch
+// is what comes out, including the selected part - which playback already scopes to, and which
+// the timeline already dims the rest of.
+
+/**
+ * The time range to play, or export.
+ *
+ * A selected part wins outright: it is the range, and the media outside it is not part of what
+ * the user is looking at. With no part selected the range spans everything that occupies time -
+ * the cuts, the audio clip, and the reference video.
+ *
+ * An empty project gives {start: 0, end: 0}, which callers read as nothing to do rather than
+ * having to test for emptiness themselves.
+ *
+ * @param {object} opts
+ * @param {Array<{startTime: number, endTime: number}>} [opts.cuts]
+ * @param {{startTime?: number, endTime?: number} | null} [opts.audio]
+ * @param {{startTime?: number, endTime?: number} | null} [opts.video] the reference video overlay
+ * @param {{start: number, end: number} | null} [opts.part] the selected part, if there is one
+ * @returns {{start: number, end: number}}
+ */
+export function playRange({ cuts, audio, video, part } = {}) {
+    if (part && Number.isFinite(part.start) && Number.isFinite(part.end) && part.end > part.start) {
+        return { start: Math.max(0, part.start), end: part.end };
+    }
+    const list = (Array.isArray(cuts) ? cuts : []).filter(c => c && Number.isFinite(c.startTime) && Number.isFinite(c.endTime));
+    const starts = list.map(c => c.startTime);
+    const ends = list.map(c => c.endTime);
+    if (audio && Number.isFinite(audio.startTime)) starts.push(audio.startTime);
+    if (audio && Number.isFinite(audio.endTime)) ends.push(audio.endTime);
+    if (video && Number.isFinite(video.startTime)) starts.push(video.startTime);
+    if (video && Number.isFinite(video.endTime)) ends.push(video.endTime);
+    if (!ends.length) return { start: 0, end: 0 };
+    const end = Math.max(0, ...ends);
+    // Only meaningful if something is actually there: a project with no content starts at zero
+    // rather than at Infinity.
+    const start = starts.length ? Math.max(0, Math.min(...starts)) : 0;
+    return { start: Math.min(start, end), end };
+}

--- a/test/playRange.test.js
+++ b/test/playRange.test.js
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { playRange } from '../src/core/playRange.js';
+
+// The bugs this replaces, stated as the cases that used to come out wrong:
+//   - the frame and GIF export began at zero, not where the content begins
+//   - the screen recording ended at the last cut or the audio, never at the reference video
+//   - neither export knew about the selected part, which playback scopes to
+
+const cut = (startTime, endTime) => ({ startTime, endTime });
+
+test('an empty project is nothing to do, not Infinity', () => {
+    assert.deepEqual(playRange({}), { start: 0, end: 0 });
+    assert.deepEqual(playRange({ cuts: [] }), { start: 0, end: 0 });
+    assert.deepEqual(playRange(), { start: 0, end: 0 });
+});
+
+test('the range starts where the content starts, not at zero', () => {
+    const r = playRange({ cuts: [cut(3, 5), cut(5, 8)] });
+    assert.equal(r.start, 3, 'exporting from 0 here gave three seconds of blank frames');
+    assert.equal(r.end, 8);
+});
+
+test('cuts out of order do not decide the bounds by their position in the array', () => {
+    const r = playRange({ cuts: [cut(5, 8), cut(1, 2), cut(3, 5)] });
+    assert.deepEqual(r, { start: 1, end: 8 });
+});
+
+test('audio past the last cut extends the end', () => {
+    const r = playRange({ cuts: [cut(0, 4)], audio: { startTime: 0, endTime: 12 } });
+    assert.equal(r.end, 12);
+});
+
+test('the reference video counts too - it is on the canvas being recorded', () => {
+    const r = playRange({ cuts: [cut(0, 4)], video: { startTime: 0, endTime: 9 } });
+    assert.equal(r.end, 9, 'the recorder used to stop at 4 while the canvas kept showing video');
+});
+
+test('audio or video starting before the first cut moves the start back', () => {
+    assert.equal(playRange({ cuts: [cut(6, 9)], audio: { startTime: 2, endTime: 9 } }).start, 2);
+    assert.equal(playRange({ cuts: [cut(6, 9)], video: { startTime: 1, endTime: 9 } }).start, 1);
+});
+
+test('a selected part is the range, whatever else is on the timeline', () => {
+    const r = playRange({
+        cuts: [cut(0, 4), cut(10, 14)],
+        audio: { startTime: 0, endTime: 30 },
+        part: { start: 10, end: 14 },
+    });
+    assert.deepEqual(r, { start: 10, end: 14 }, 'export used to run the whole timeline regardless');
+});
+
+test('a part with no width is ignored rather than exporting nothing', () => {
+    const r = playRange({ cuts: [cut(0, 4)], part: { start: 2, end: 2 } });
+    assert.deepEqual(r, { start: 0, end: 4 });
+});
+
+test('negative times are clamped, and the start never passes the end', () => {
+    assert.equal(playRange({ cuts: [cut(-5, 3)] }).start, 0);
+    assert.equal(playRange({ cuts: [cut(-9, -2)] }).end, 0);
+    const r = playRange({ cuts: [cut(-9, -2)] });
+    assert.ok(r.start <= r.end, 'a start past the end would make the frame count negative');
+});
+
+test('junk in the timeline does not become NaN in the range', () => {
+    const r = playRange({
+        cuts: [cut(0, 4), null, { startTime: NaN, endTime: 7 }, { startTime: 1 }],
+        audio: { endTime: undefined },
+        video: null,
+    });
+    assert.deepEqual(r, { start: 0, end: 4 });
+});


### PR DESCRIPTION
## Three answers to one question

"Where does the content start and end" was computed in three places, none of them written down as a decision:

| | counts | range |
|---|---|---|
| playback | cuts, audio, reference video | `contentStart` .. `contentEnd` |
| screen recording | cuts, audio | `0` .. `ctMax` |
| frames / GIF | cuts | `0` .. `ctMax` |

Four things fall out of that:

1. **The frame and GIF export began at zero**, not where the content begins — so a project whose first cut sits at three seconds exported three seconds of nothing.
2. **The recording ended at the last cut or the audio, never at the reference video** — which is drawn on the very canvas being captured, so it stopped while there was still picture.
3. **Neither export knew about the selected part.** Playback scopes to it and the timeline dims everything else; export ignored all of that.
4. **The recorder's `setCurrentTime(0)` did nothing.** `playbackStartFrom` sends a playhead sitting before the range to the *anchor* instead, and the anchor is the selected cut's start — so recording a project that began at three seconds started wherever the user happened to be standing. It now resets to the range's own start, and takes the audio element with it, which the old reset to `0` also got wrong whenever the audio clip carried an offset.

One `playRange` in core; the exports use the two numbers playback already had.

## One deliberate behaviour change, flagged

**With a part selected, export now covers that part** rather than the whole timeline. That is what playback and the dimming already say a selection means, and there is no separate "export this part" control — but it is a repair I chose, not one the old code implied, and it is one line to reverse if you would rather export always ran the whole timeline.

## What is actually verified

Ten tests on the range itself: an empty project (0..0, not `Infinity`), cuts out of array order, audio and video extending either end, a zero-width part, negative times, and junk in the timeline that must not turn into `NaN` in a frame count.

The wiring — that the two export paths now use it — is verified by reading, not by test. There is no headless path to a `MediaRecorder`, and I am not claiming coverage I do not have.

`npm run check` green — 644 tests.