### PR TITLE
refactor: name the three shapes a 왕복 can take, and share the cap

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -394,6 +394,8 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `targetCanvasFor` | Which canvas a video import should land in. A vertical clip dropped into a landscape canvas is mostly empty margin, so the import can match the source instead, or be pinned to one of the two shapes people actually publish. |
 | `TEXT_ANIM_DEFAULT` | - emphasis: a looping accent (pulse/shake/wave) |
 | `triwave` | Triangle wave 0->1->0 (period 2); used for ping-pong path following. |
+| `SWING` | The three shapes a return animation can take. `through` passes the resting position and goes out the other side, which is what the layer presets are made of - 둥실둥실 bobs above and below. `there` and `along` go out to the target and back and never past the start. One cycle is one whole trip in all three, so speed means the same thing to each. |
+| `swing` | A return animation's progress for one of those shapes, or 0 once it has run out of repeats. Settling at 0 rather than mid-wave is where a whole trip would have ended anyway. |
 
 ## `src/canvas/textLayout.js`
 

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -1171,7 +1171,7 @@ export function computeCutAnim(ac, time, cw = CANVAS_W, ch = CANVAS_H) {
         // Ping-pong (return): oscillates back to the original; speed is cycles across the cut,
         // count caps how many.
         let prog;
-        if (a.deformReturn) { const cyc = (a.deformSpeed || 1) * t; prog = (a.deformCount > 0 && cyc >= a.deformCount) ? 0 : Math.sin(2 * Math.PI * cyc); }
+        if (a.deformReturn) prog = swing(SWING.through, t, a.deformSpeed, a.deformCount);
         else prog = applyEase(t, a.ease, a.easePower);
         const f = 1 + a.deformAmount * prog;
         if (a.deformAxis === 'x') sx *= f; else sy *= f;
@@ -1181,7 +1181,7 @@ export function computeCutAnim(ac, time, cw = CANVAS_W, ch = CANVAS_H) {
         // out and back (0→1→0) at `speed` cycles, capped by `count`.
         const t = Math.max(0, Math.min(1, lt / dur));
         let prog;
-        if (a.moveReturn) { const cyc = (a.moveSpeed || 1) * t; prog = (a.moveCount > 0 && cyc >= a.moveCount) ? 0 : (1 - Math.cos(2 * Math.PI * cyc)) / 2; }
+        if (a.moveReturn) prog = swing(SWING.there, t, a.moveSpeed, a.moveCount);
         else prog = applyEase(t, a.ease, a.easePower);
         tx += (a.moveX || 0) * prog; ty += (a.moveY || 0) * prog;
     }
@@ -1238,6 +1238,42 @@ export function applyEase(t, type, power = 2) {
 
 // Triangle wave 0->1->0 (period 2); used for ping-pong path following.
 export function triwave(x) { const m = ((x % 2) + 2) % 2; return m < 1 ? m : 2 - m; }
+
+// The three shapes a "왕복" (return) animation can take, and the cap they share.
+//
+// Four call sites wrote this out, each with its own arithmetic, and they do not all mean the same
+// thing - which is the point of naming them rather than merging them:
+//
+//   SWING.through   -1..1   past the resting position and out the other side. What the layer
+//                           presets are: 둥실둥실 bobs above and below, 숨쉬기 breathes in as
+//                           well as out. A one-way version of these would not read as floating.
+//   SWING.there     0..1    out to the target and back, never past the start. The cut's move.
+//   SWING.along     0..1    the same trip, at constant speed - for following a drawn path, where
+//                           there is nothing on the far side of the first point to travel to.
+//
+// One cycle is one whole trip in every case, so `speed` means the same thing to all three.
+export const SWING = {
+    through: (cycles) => Math.sin(2 * Math.PI * cycles),
+    there: (cycles) => (1 - Math.cos(2 * Math.PI * cycles)) / 2,
+    along: (cycles) => triwave(2 * cycles),
+};
+
+/**
+ * A return animation's progress, or 0 once it has run out of repeats.
+ *
+ * @param {(cycles: number) => number} shape one of SWING
+ * @param {number} t how far through the cut, 0..1
+ * @param {number} [speed] trips across the cut
+ * @param {number} [count] how many trips before it settles; 0 or less means forever
+ * @returns {number}
+ */
+export function swing(shape, t, speed = 1, count = 0) {
+    const cycles = (speed || 1) * t;
+    // Settling at 0 rather than wherever the wave happened to be: every shape passes through 0 at
+    // the end of a whole trip, so this is where it would have stopped anyway.
+    if (count > 0 && cycles >= count) return 0;
+    return shape(cycles);
+}
 // Sample a polyline path at normalized position s in [0,1].
 export function samplePath(path, s) {
     const n = path.length;
@@ -1609,7 +1645,7 @@ export function computeLayerAnim(layer, ac, time, cw = CANVAS_W, ch = CANVAS_H) 
         alpha = Math.max(0, Math.min(1, k.op ?? 1));
         prog = t;
     } else {
-        if (a.mode === 'return') { const cyc = speed * t; prog = (count > 0 && cyc >= count) ? 0 : Math.sin(2 * Math.PI * cyc); }
+        if (a.mode === 'return') prog = swing(SWING.through, t, speed, count);
         else prog = applyEase(t, a.ease, a.easePower);
         tx = (a.tx || 0) * prog; ty = (a.ty || 0) * prog;
         rot = (a.rot || 0) * prog * Math.PI / 180;
@@ -1617,7 +1653,7 @@ export function computeLayerAnim(layer, ac, time, cw = CANVAS_W, ch = CANVAS_H) 
     }
     if (!keys && a.path && a.path.length > 1) {
         let s;
-        if (a.mode === 'return') { let x = 2 * speed * t; if (count > 0 && x >= 2 * count) x = 0; s = triwave(x); }
+        if (a.mode === 'return') s = swing(SWING.along, t, speed, count);
         else s = applyEase(t, a.ease, a.easePower);
         const p0 = a.path[0], pt = samplePath(a.path, s);
         tx += pt.x - p0.x; ty += pt.y - p0.y;

--- a/test/swing.test.js
+++ b/test/swing.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SWING, swing, triwave } from '../src/canvas/canvasUtils.js';
+
+// This was a naming change, not a motion change, so the test that matters is that every call site
+// still computes exactly what it computed before. The four originals are written out here
+// verbatim and compared across the range - if a shape drifts, this is what says so.
+
+const OLD = {
+    // computeCutAnim, deform
+    deform: (t, speed, count) => { const cyc = (speed || 1) * t; return (count > 0 && cyc >= count) ? 0 : Math.sin(2 * Math.PI * cyc); },
+    // computeCutAnim, move
+    move: (t, speed, count) => { const cyc = (speed || 1) * t; return (count > 0 && cyc >= count) ? 0 : (1 - Math.cos(2 * Math.PI * cyc)) / 2; },
+    // computeLayerAnim, transform
+    layer: (t, speed, count) => { const cyc = speed * t; return (count > 0 && cyc >= count) ? 0 : Math.sin(2 * Math.PI * cyc); },
+    // computeLayerAnim, path
+    path: (t, speed, count) => { let x = 2 * speed * t; if (count > 0 && x >= 2 * count) x = 0; return triwave(x); },
+};
+
+const SAMPLES = [];
+for (let i = 0; i <= 40; i++) SAMPLES.push(i / 40);
+
+const across = (fn, old, speed, count) => {
+    for (const t of SAMPLES) {
+        assert.ok(Math.abs(fn(t) - old(t, speed, count)) < 1e-12,
+            `t=${t} speed=${speed} count=${count}: ${fn(t)} vs ${old(t, speed, count)}`);
+    }
+};
+
+for (const speed of [0.5, 1, 2, 3.5]) {
+    for (const count of [0, 1, 2, 5]) {
+        test(`the deform swing is unchanged (speed ${speed}, count ${count})`, () => {
+            across(t => swing(SWING.through, t, speed, count), OLD.deform, speed, count);
+        });
+        test(`the cut move swing is unchanged (speed ${speed}, count ${count})`, () => {
+            across(t => swing(SWING.there, t, speed, count), OLD.move, speed, count);
+        });
+        test(`the layer transform swing is unchanged (speed ${speed}, count ${count})`, () => {
+            across(t => swing(SWING.through, t, speed, count), OLD.layer, speed, count);
+        });
+        test(`the path swing is unchanged (speed ${speed}, count ${count})`, () => {
+            across(t => swing(SWING.along, t, speed, count), OLD.path, speed, count);
+        });
+    }
+}
+
+test('a missing speed is one trip, as it was', () => {
+    for (const t of SAMPLES) {
+        assert.equal(swing(SWING.through, t, 0, 0), swing(SWING.through, t, 1, 0));
+        assert.equal(swing(SWING.through, t, undefined, 0), swing(SWING.through, t, 1, 0));
+    }
+});
+
+// The shapes differ on purpose, and this is the difference: two of them never pass the resting
+// position, one goes out the other side. The layer presets - 둥실둥실, 숨쉬기 - are the reason.
+test('through goes both ways; there and along do not', () => {
+    const lows = { through: 0, there: 0, along: 0 };
+    const highs = { through: 0, there: 0, along: 0 };
+    for (const t of SAMPLES) {
+        for (const k of Object.keys(lows)) {
+            const v = SWING[k](t);
+            lows[k] = Math.min(lows[k], v);
+            highs[k] = Math.max(highs[k], v);
+        }
+    }
+    assert.ok(lows.through < -0.99, 'through must reach the far side');
+    assert.equal(lows.there, 0);
+    assert.equal(lows.along, 0);
+    for (const k of Object.keys(highs)) assert.ok(highs[k] > 0.99, `${k} must reach the target`);
+});
+
+test('one cycle is one whole trip for all three, so speed means the same thing', () => {
+    for (const shape of Object.values(SWING)) {
+        assert.ok(Math.abs(shape(0)) < 1e-12, 'starts at rest');
+        assert.ok(Math.abs(shape(1)) < 1e-12, 'a whole trip ends at rest');
+        assert.ok(Math.abs(shape(2)) < 1e-12, 'and so does the next');
+    }
+});
+
+test('running out of repeats settles at rest rather than mid-swing', () => {
+    assert.equal(swing(SWING.through, 0.9, 2, 1), 0);
+    assert.equal(swing(SWING.there, 0.9, 2, 1), 0);
+    assert.equal(swing(SWING.along, 0.9, 2, 1), 0);
+    assert.notEqual(swing(SWING.through, 0.4, 2, 1), 0, 'and not before the cap is reached');
+});


### PR DESCRIPTION
## What I expected to find, and what was actually there

Four call sites implement "return" (왕복) animation, each with its own arithmetic:

| | formula | range |
|---|---|---|
| cut deform | `sin(2πc)` | **−1..1** |
| cut move | `(1 − cos(2πc)) / 2` | 0..1 |
| layer transform | `sin(2πc)` | **−1..1** |
| layer path | `triwave(2·speed·t)` | 0..1 |

I went at this expecting one checkbox with two meanings — a layer with `ty: 50` swings to −50 as well, where the same setting on a cut only goes 0→50→0.

**It is not a bug.** The layer presets are the argument against changing it: 둥실둥실 bobs above *and below* its resting position, 숨쉬기 breathes in as well as out, 좌우 흐름 drifts both ways. A one-way version of those would not read as floating or breathing. The cut's move is genuinely the other thing — go over there and come back. And a path cannot go negative, because there is nothing on the far side of its first point to travel to.

So the shapes stay exactly as they are and get names instead — `SWING.through`, `.there`, `.along` — each with the reason next to it. The repeat cap, which really was the same four times, is written once.

## Verification

This is a naming change, so the only thing worth testing is that the arithmetic is untouched. All four originals are written out verbatim in `swing.test.js` and compared across 41 points at four speeds and four repeat counts — 68 assertions.

And I checked the tests can actually fail rather than trusting a green run: changing `triwave(2 * cycles)` to `triwave(cycles)` drops 17 of them.

`npm run check` green — 712 tests.