### PR TITLE
fix: the brush-smaller shortcut did nothing at size 2

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -23,6 +23,20 @@ Which stored bitmaps are still reachable, for garbage collection.
 | `collectUsedBitmapIds` | Every bitmap id still referenced by anything that can bring it back: the cuts, the undo history, the cut clipboard, the lasso clipboard and the live selection. Freeing something an undo still needs is not a leak, it is an undo that comes back blank. |
 | `unusedBitmapIds` | Ids present in the store that nothing references any more. |
 
+## `src/core/brushSize.js`
+
+How wide a brush may be, and how a keystroke changes it. The range was written twice - once for
+typing a size, once for the shortcut - which is the shape the canvas zoom bug had before one copy
+was edited and the other was not.
+
+| | |
+|---|---|
+| `BRUSH_MIN` | One pixel. |
+| `BRUSH_MAX` | Two hundred. The slider stops at 80 on purpose and shows `min(80, size)` past that, because a slider spanning the whole range puts every ordinary size in its first fifth. |
+| `clampBrush` | A width the app will accept: a whole number inside the range, and never NaN. |
+| `brushUp` | A quarter wider, plus one. The plus one is not decoration - 1 x 1.25 rounds back to 1, so without it the shortcut does nothing at the sizes where a single pixel matters most. |
+| `brushDown` | The mirror of it, which was missing: 2 / 1.25 rounds back to 2, so the shortcut for a smaller brush did nothing at all at size 2. Takes at least one pixel off, so the key always moves. |
+
 ## `src/core/camera.js`
 
 Camera moves: presets, drawn paths, and the transform they resolve to.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ import { cloneCutContents as cloneCutContentsPure } from './core/cutClone.js';
 import { DEFAULT_KEYS, KEY_LABELS, keyOf, matchShortcut, keymapFrom, toolFromAction, findConflicts } from './core/shortcuts.js';
 import { derivePartsFrom, deriveVideoBatches } from './core/partOps.js';
 import { playRange } from './core/playRange.js';
+import { clampBrush, brushUp, brushDown } from './core/brushSize.js';
 import {
     cutsReducer, replaceCuts, addCuts, updateCut, setCutAnim, setCutCamera, clearCut,
     updateLayer, setLayerAnim, moveLayers, upsertText, moveText, deleteText, toggleTextVisible as toggleTextVisibleAction,
@@ -368,6 +369,12 @@ export default function App() {
     const [pressureOn, setPressureOn] = useStored('mv_pressure', true, onOffCodec);
     const [eraserSize, setEraserSize] = useState(20);
     const [opacity, setOpacity] = useState(1.0);
+    // The width the current tool draws with. The eraser keeps its own, so switching to it and
+    // back does not lose the size you were drawing with - which is why every caller has to ask
+    // which tool it is before reading or writing a size, and why that question is asked here
+    // once rather than at each of them.
+    const toolSize = tool === 'eraser' ? eraserSize : brushSize;
+    const setToolSize = (n) => { const v = clampBrush(n); if (tool === 'eraser') setEraserSize(v); else setBrushSize(v); };
     const [expandedCuts, setExpandedCuts] = useState(new Set());
     const [collapsedCutIds, setCollapsedCutIds] = useState(new Set());
     const [renamingCutId, setRenamingCutId] = useState(null);
@@ -854,8 +861,8 @@ export default function App() {
                 else if (hit === 'zoomIn') zoomCanvas(1.25);
                 else if (hit === 'zoomOut') zoomCanvas(1 / 1.25);
                 else if (hit === 'resetView') resetView();
-                else if (hit === 'brushUp') { const s = tool === 'eraser' ? eraserSize : brushSize; const n = Math.min(200, Math.round(s * 1.25) + 1); tool === 'eraser' ? setEraserSize(n) : setBrushSize(n); }
-                else if (hit === 'brushDown') { const s = tool === 'eraser' ? eraserSize : brushSize; const n = Math.max(1, Math.round(s / 1.25)); tool === 'eraser' ? setEraserSize(n) : setBrushSize(n); }
+                else if (hit === 'brushUp') setToolSize(brushUp(toolSize));
+                else if (hit === 'brushDown') setToolSize(brushDown(toolSize));
                 return;
             }
             if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) { e.preventDefault(); globalUndo(); }
@@ -3929,8 +3936,7 @@ export default function App() {
             softMode={softMode} setSoftMode={setSoftMode}
             rulerMode={rulerMode} setRulerMode={setRulerMode} commitCurve={commitCurve}
             mosaicBlock={mosaicBlock} setMosaicBlock={setMosaicBlock}
-            brushSize={brushSize} setBrushSize={setBrushSize}
-            eraserSize={eraserSize} setEraserSize={setEraserSize}
+            toolSize={toolSize} setToolSize={setToolSize}
             pressureOn={pressureOn} setPressureOn={setPressureOn} />
     );
 

--- a/src/core/brushSize.js
+++ b/src/core/brushSize.js
@@ -1,0 +1,52 @@
+// How wide a brush may be, and how a keystroke changes it.
+//
+// The range was written twice: the panel clamped 1..200 when you typed or picked a preset, and
+// the keyboard shortcut clamped 1..200 again on its own. They agree today. The canvas zoom range
+// also agreed, in two places, right up until it did not - and then zooming to 16x with a button
+// and turning the wheel one notch snapped back to 8x, because the other copy had never heard of
+// 16. Two copies of a range is that bug waiting for someone to edit one of them.
+//
+// The slider is deliberately not part of this: it stops at 80 and shows `Math.min(80, size)` for
+// anything larger, because a slider that spans the whole range makes every ordinary size land in
+// the first fifth of it. That is a decision about the control, not about the brush.
+
+export const BRUSH_MIN = 1;
+export const BRUSH_MAX = 200;
+
+/**
+ * A brush width the app will accept: a whole number inside the range.
+ *
+ * @param {number} n
+ * @returns {number}
+ */
+export function clampBrush(n) {
+    return Math.max(BRUSH_MIN, Math.min(BRUSH_MAX, Math.round(n) || BRUSH_MIN));
+}
+
+/**
+ * The next width up, for the shortcut.
+ *
+ * A quarter wider, plus one. The plus one is not decoration: a size of 1 multiplied by 1.25 is
+ * 1.25, which rounds back to 1, so without it the shortcut does nothing at the sizes where a
+ * single pixel matters most.
+ *
+ * @param {number} size
+ * @returns {number}
+ */
+export function brushUp(size) {
+    return clampBrush(Math.round(size * 1.25) + 1);
+}
+
+/**
+ * The next width down.
+ *
+ * The mirror of the above, and it was missing: 2 / 1.25 is 1.6, which rounds back to 2, so the
+ * shortcut for a smaller brush did nothing at all at size 2. Taking at least one pixel off means
+ * the key always does something, all the way down to the minimum.
+ *
+ * @param {number} size
+ * @returns {number}
+ */
+export function brushDown(size) {
+    return clampBrush(Math.min(size - 1, Math.round(size / 1.25)));
+}

--- a/src/ui/ToolsPanel.jsx
+++ b/src/ui/ToolsPanel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Layers, Undo, Redo, Trash, Repeat, ClipboardPaste, Pipette } from 'lucide-react';
 import { NumField } from './NumField';
 import { tr } from '../i18n';
+import { BRUSH_MIN, BRUSH_MAX } from '../core/brushSize.js';
 
 // TOOLS panel: the tool grid, the colour swatch, and whatever settings the current tool has.
 //
@@ -18,8 +19,7 @@ function ToolSettings({
     softMode = undefined, setSoftMode = undefined,
     rulerMode = undefined, setRulerMode = undefined, commitCurve = undefined,
     mosaicBlock = undefined, setMosaicBlock = undefined,
-    brushSize = undefined, setBrushSize = undefined,
-    eraserSize = undefined, setEraserSize = undefined,
+    toolSize = undefined, setToolSize = undefined,
     pressureOn = true, setPressureOn = undefined,
 }) {
     if (tool === 'soft') {
@@ -54,17 +54,14 @@ function ToolSettings({
             <span style={{ fontSize: 9, color: '#888', textAlign: 'center' }}>{tr('화면 위를 드래그')}</span>
         </>);
     }
-    // Everything else is a brush of some width. The eraser keeps its own, so switching to it and
-    // back does not lose the size you were drawing with.
-    const curSize = tool === 'eraser' ? eraserSize : brushSize;
-    const setSize = (v) => {
-        const n = Math.max(1, Math.min(200, Math.round(v) || 1));
-        if (tool === 'eraser') setEraserSize(n); else setBrushSize(n);
-    };
+    // Everything else is a brush of some width. Which size belongs to which tool is App's
+    // question - it owns both pieces of state - and it was being answered here as well, with a
+    // second copy of the range to go with it.
+    const curSize = toolSize, setSize = setToolSize;
     return (<>
         <span className="slider-label">{tool === 'eraser' ? tr('지우개') : 'Size'}</span>
         <div style={{ display: 'flex', alignItems: 'center', gap: 2, justifyContent: 'center' }}>
-            <NumField value={curSize} onChange={setSize} min={1} max={200} width={46} style={{ textAlign: 'center' }} />
+            <NumField value={curSize} onChange={setSize} min={BRUSH_MIN} max={BRUSH_MAX} width={46} style={{ textAlign: 'center' }} />
             <span style={{ fontSize: 10, color: '#888' }}>px</span>
         </div>
         <div className="size-grid" style={{ margin: '4px 0' }}>

--- a/test/brushSize.test.js
+++ b/test/brushSize.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { BRUSH_MIN, BRUSH_MAX, clampBrush, brushUp, brushDown } from '../src/core/brushSize.js';
+
+test('the range holds, from either direction', () => {
+    assert.equal(clampBrush(0), BRUSH_MIN);
+    assert.equal(clampBrush(-40), BRUSH_MIN);
+    assert.equal(clampBrush(9999), BRUSH_MAX);
+    assert.equal(clampBrush(BRUSH_MIN), BRUSH_MIN);
+    assert.equal(clampBrush(BRUSH_MAX), BRUSH_MAX);
+});
+
+test('a width is always a whole number, and never NaN', () => {
+    assert.equal(clampBrush(7.4), 7);
+    assert.equal(clampBrush(7.6), 8);
+    assert.equal(clampBrush(NaN), BRUSH_MIN);
+    assert.equal(clampBrush(undefined), BRUSH_MIN);
+});
+
+// The bug: 2 / 1.25 is 1.6, which rounds back to 2. The shortcut for a smaller brush did nothing
+// at all at size 2, and the way up had a +1 for exactly this reason with nothing to match it.
+test('the shortcut always moves, at every size in the range', () => {
+    for (let s = BRUSH_MIN; s <= BRUSH_MAX; s++) {
+        if (s < BRUSH_MAX) assert.ok(brushUp(s) > s, `up from ${s} went to ${brushUp(s)}`);
+        if (s > BRUSH_MIN) assert.ok(brushDown(s) < s, `down from ${s} stayed at ${brushDown(s)}`);
+    }
+});
+
+test('size 2 in particular, which is where it was stuck', () => {
+    assert.equal(brushDown(2), 1);
+    assert.equal(Math.round(2 / 1.25), 2, 'the old formula, for the record');
+});
+
+test('the ends hold rather than stepping out of range', () => {
+    assert.equal(brushDown(BRUSH_MIN), BRUSH_MIN);
+    assert.equal(brushUp(BRUSH_MAX), BRUSH_MAX);
+});
+
+test('stepping up then down does not run away in either direction', () => {
+    let s = 5;
+    for (let i = 0; i < 40; i++) s = brushUp(s);
+    assert.equal(s, BRUSH_MAX);
+    for (let i = 0; i < 200; i++) s = brushDown(s);
+    assert.equal(s, BRUSH_MIN);
+});
+
+test('the way up is unchanged - only the way down was broken', () => {
+    const old = (s) => Math.max(1, Math.min(200, Math.round(s * 1.25) + 1));
+    for (let s = BRUSH_MIN; s <= BRUSH_MAX; s++) assert.equal(brushUp(s), old(s), `up from ${s}`);
+});


### PR DESCRIPTION
## The range was written twice, and reading the copies side by side found a real bug

The brush range, 1..200, lived in two places: the panel clamped it when you typed a size or picked a preset, and the keyboard shortcut clamped it again on its own. They agreed. So did the canvas zoom range, in two places, right up until someone edited one of them — and then zooming to 16× with a button and turning the wheel one notch snapped back to 8×.

**Going up** is `round(s * 1.25) + 1`. The `+ 1` is deliberate: `1 × 1.25` is `1.25`, which rounds back to `1`, so without it the key does nothing at the sizes where a single pixel matters most.

**Going down** had no counterpart — and `2 / 1.25` is `1.6`, which rounds back to `2`. **The shortcut for a smaller brush did nothing at all at size 2.** It now takes at least one pixel off, so the key always moves.

## Verification

- A test walks **every size from 1 to 200** and asserts both directions actually change the number.
- The way up is untouched, and a second test compares it to the old formula at all 200 sizes to prove that.
- Plus the ends, non-integers, and NaN.

## While there

"Which size belongs to which tool" was being answered in both files as well. App owns `brushSize` and `eraserSize`, so it now hands down one `toolSize` and one setter instead of four props, and `ToolsPanel` stops re-deriving what its parent already knows.

The slider's 80 stop is left alone — it is deliberate, shows `min(80, size)` past that, and is a decision about the control rather than about the brush. That reasoning is now written next to `BRUSH_MAX` instead of being implicit.

`npm run check` green — 719 tests.