### PR TITLE
fix: a save that ran out of space reported success

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -27,44 +27,64 @@ function openDB() {
     return dbPromise;
 }
 
-function tx(db, mode) {
-    return db.transaction(STORE, mode).objectStore(STORE);
-}
-
-export async function saveProject(id, data, name) {
+/**
+ * Run one request in one transaction, and settle when the transaction does.
+ *
+ * The four operations below were four copies of the same six lines, and all four resolved on
+ * `request.onsuccess`. That is early. A request succeeding means the store accepted it; the
+ * transaction still has to commit, and a commit can fail afterwards - running out of quota is
+ * the one that actually happens here, because an autosave carries the whole project, frames and
+ * audio included. Resolving on the request meant a save that never landed was reported as saved,
+ * and the autosave error the UI already knows how to show could not fire.
+ *
+ * `map` runs while the result is still valid, and its value is held until the commit.
+ *
+ * @template T
+ * @param {IDBTransactionMode} mode
+ * @param {(store: IDBObjectStore) => IDBRequest} make
+ * @param {(result: any) => T} [map]
+ * @returns {Promise<T>}
+ */
+async function run(mode, make, map) {
     const db = await openDB();
-    return /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
-        const req = tx(db, 'readwrite').put({ id, name: name ?? data?.name ?? id, savedAt: data?.savedAt ?? new Date().toISOString(), data });
-        req.onsuccess = () => resolve();
-        req.onerror = () => reject(req.error);
+    return /** @type {Promise<T>} */ (new Promise((resolve, reject) => {
+        let t;
+        try { t = db.transaction(STORE, mode); } catch (e) { reject(e); return; }
+        let value = /** @type {any} */ (undefined);
+        let failed = false;
+        const fail = (e) => { if (!failed) { failed = true; reject(e instanceof Error ? e : new Error(String(e || 'IndexedDB failed'))); } };
+        let req;
+        try { req = make(t.objectStore(STORE)); } catch (e) { fail(e); return; }
+        req.onsuccess = () => { try { value = map ? map(req.result) : undefined; } catch (e) { fail(e); } };
+        req.onerror = () => fail(req.error);
+        t.oncomplete = () => { if (!failed) resolve(value); };
+        t.onabort = () => fail(t.error || new Error('IndexedDB transaction aborted'));
+        t.onerror = () => fail(t.error);
     }));
 }
 
-export async function loadProject(id) {
-    const db = await openDB();
-    return new Promise((resolve, reject) => {
-        const req = tx(db, 'readonly').get(id);
-        req.onsuccess = () => resolve(req.result ? req.result.data : null);
-        req.onerror = () => reject(req.error);
-    });
-}
-
-export async function listProjects() {
-    const db = await openDB();
-    return new Promise((resolve, reject) => {
-        const req = tx(db, 'readonly').getAll();
-        req.onsuccess = () => resolve((req.result || []).map(r => ({ id: r.id, name: r.name, savedAt: r.savedAt })));
-        req.onerror = () => reject(req.error);
-    });
-}
-
-export async function deleteProject(id) {
-    const db = await openDB();
-    return /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
-        const req = tx(db, 'readwrite').delete(id);
-        req.onsuccess = () => resolve();
-        req.onerror = () => reject(req.error);
+/** @returns {Promise<void>} */
+export function saveProject(id, data, name) {
+    return run('readwrite', (store) => store.put({
+        id,
+        name: name ?? data?.name ?? id,
+        savedAt: data?.savedAt ?? new Date().toISOString(),
+        data,
     }));
+}
+
+export function loadProject(id) {
+    return run('readonly', (store) => store.get(id), (r) => (r ? r.data : null));
+}
+
+export function listProjects() {
+    return run('readonly', (store) => store.getAll(),
+        (rows) => (rows || []).map(r => ({ id: r.id, name: r.name, savedAt: r.savedAt })));
+}
+
+/** @returns {Promise<void>} */
+export function deleteProject(id) {
+    return run('readwrite', (store) => store.delete(id));
 }
 
 export const autosaveKey = AUTOSAVE_ID;

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,0 +1,150 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// A fake IndexedDB, just enough of it to answer the question this change is about: does a save
+// resolve before the transaction has committed? A real request fires onsuccess as soon as the
+// store accepts the write, and the transaction commits afterwards - and can still abort, which
+// is what running out of quota looks like. The fake reproduces exactly that ordering.
+
+const control = {
+    /** 'commit' | 'abort' | 'requestError' */
+    outcome: 'commit',
+    abortError: null,
+    log: [],
+};
+
+const soon = (fn) => setTimeout(fn, 0);
+
+function makeFakeIndexedDB() {
+    const rows = new Map();
+    const store = {
+        put(record) {
+            const req = {};
+            soon(() => {
+                if (control.outcome === 'requestError') {
+                    req.error = new Error('put rejected');
+                    req.onerror?.();
+                    return;
+                }
+                // The store accepts it and says so - before any commit has happened.
+                if (control.outcome === 'commit') rows.set(record.id, record);
+                control.log.push('request success');
+                req.onsuccess?.();
+            });
+            return req;
+        },
+        get(id) {
+            const req = {};
+            soon(() => { req.result = rows.get(id); req.onsuccess?.(); });
+            return req;
+        },
+        getAll() {
+            const req = {};
+            soon(() => { req.result = [...rows.values()]; req.onsuccess?.(); });
+            return req;
+        },
+        delete(id) {
+            const req = {};
+            soon(() => { rows.delete(id); req.onsuccess?.(); });
+            return req;
+        },
+    };
+    return {
+        open() {
+            const req = {};
+            soon(() => {
+                req.result = {
+                    objectStoreNames: { contains: () => true },
+                    createObjectStore: () => store,
+                    transaction() {
+                        const t = { error: null, objectStore: () => store };
+                        // Two ticks later than the request, as a real commit is.
+                        soon(() => soon(() => {
+                            if (control.outcome === 'abort') {
+                                t.error = control.abortError;
+                                control.log.push('transaction abort');
+                                t.onabort?.();
+                            } else if (control.outcome === 'commit') {
+                                control.log.push('transaction complete');
+                                t.oncomplete?.();
+                            } else {
+                                t.onabort?.();
+                            }
+                        }));
+                        return t;
+                    },
+                };
+                req.onsuccess?.();
+            });
+            return req;
+        },
+    };
+}
+
+globalThis.indexedDB = makeFakeIndexedDB();
+const { saveProject, loadProject, listProjects, deleteProject } = await import('../src/db.js');
+
+test('a save resolves only once the transaction has committed', async () => {
+    control.outcome = 'commit';
+    control.log = [];
+    await saveProject('p1', { savedAt: '2026-01-01T00:00:00.000Z' }, 'One');
+    assert.deepEqual(control.log, ['request success', 'transaction complete'],
+        'resolving on the request would have returned before the commit');
+});
+
+// The bug: put fires onsuccess, the promise resolved, and then the commit failed with no one
+// listening. A quota failure on an autosave was reported to the app as a successful save.
+test('a transaction that aborts after the request succeeded is a rejection', async () => {
+    control.outcome = 'abort';
+    control.abortError = new Error('QuotaExceededError');
+    control.log = [];
+    await assert.rejects(
+        () => saveProject('p2', {}, 'Two'),
+        /QuotaExceededError/,
+        'the save did not land, so it must not report success',
+    );
+    assert.deepEqual(control.log, ['request success', 'transaction abort'],
+        'the request really did succeed first - this is the ordering that hid the failure');
+});
+
+test('an abort with no error of its own still rejects rather than hanging', async () => {
+    control.outcome = 'abort';
+    control.abortError = null;
+    await assert.rejects(() => saveProject('p3', {}, 'Three'), /aborted/);
+});
+
+test('a request-level failure still rejects', async () => {
+    control.outcome = 'requestError';
+    await assert.rejects(() => saveProject('p4', {}, 'Four'), /put rejected/);
+});
+
+test('a committed save is what comes back, and the shape is unchanged', async () => {
+    control.outcome = 'commit';
+    await saveProject('p5', { cuts: [1, 2, 3], savedAt: 'then' }, 'Five');
+    assert.deepEqual(await loadProject('p5'), { cuts: [1, 2, 3], savedAt: 'then' });
+    assert.equal(await loadProject('nothing-here'), null, 'a missing project is null, not undefined');
+    const rows = await listProjects();
+    const five = rows.find(r => r.id === 'p5');
+    assert.deepEqual(five, { id: 'p5', name: 'Five', savedAt: 'then' });
+    assert.ok(!('data' in five), 'the list carries metadata only - it must not pull whole projects into memory');
+});
+
+test('the name and timestamp fall back the way they did', async () => {
+    control.outcome = 'commit';
+    await saveProject('p6', { name: 'from the data' });
+    assert.equal((await listProjects()).find(r => r.id === 'p6').name, 'from the data');
+    await saveProject('p7', null);
+    const seven = (await listProjects()).find(r => r.id === 'p7');
+    assert.equal(seven.name, 'p7', 'with nothing to go on, the id is the name');
+    assert.ok(Date.parse(seven.savedAt) > 0, 'and the time is now');
+});
+
+test('delete goes through the same commit wait', async () => {
+    control.outcome = 'commit';
+    await saveProject('p8', { cuts: [] }, 'Eight');
+    await deleteProject('p8');
+    assert.equal(await loadProject('p8'), null);
+    control.outcome = 'abort';
+    control.abortError = new Error('nope');
+    await assert.rejects(() => deleteProject('p8'), /nope/);
+});


### PR DESCRIPTION
## Four copies of six lines, all resolving too early

`db.js` had save, load, list and delete written as four copies of the same request-wrapping. All four resolved on `request.onsuccess` — and that is early.

A request succeeding means the object store **accepted** it. The transaction still has to commit, and the commit can fail afterwards. Running out of quota is the one that actually happens here, because an autosave now carries the whole project — frames and audio included (#111). So `put` fired `onsuccess`, the promise resolved, the commit failed, and nobody was listening.

## The UI for this already existed and could not be reached

`TopBar` shows a red **자동저장 실패** when `useAutosave` reports an error, and its tooltip reads *저장공간이 가득 찼을 수 있습니다*. It was built for exactly this failure. The layer underneath was calling it a success.

## The change

One `run(mode, make, map)` holds the transaction, resolves on `oncomplete`, and rejects on `onabort` or `onerror`. The four operations become one line each — 78 lines of `db.js` changed, and it is shorter and does more.

## Verification

A fake IndexedDB that reproduces the real ordering: request success first, commit two ticks later, abortable at that point. Seven tests, including the exact failure — request succeeds, transaction aborts with `QuotaExceededError`, promise must reject.

**I ran them against the old implementation to be sure they say something: four fail there.**

```
not ok 1 - a save resolves only once the transaction has committed
not ok 2 - a transaction that aborts after the request succeeded is a rejection
not ok 3 - an abort with no error of its own still rejects rather than hanging
not ok 7 - delete goes through the same commit wait
```

`npm run check` green — 726 tests.