### PR TITLE
fix: the backup was written safely and the project it protects was not

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -68,11 +68,28 @@ const AUDIO_MIME = { webm: 'audio/webm', mp4: 'audio/mp4', ogg: 'audio/ogg', m4a
  * from. Two copies of the stored shape are two chances for "save as new" and "overwrite" to
  * write different files - and the difference would only show up when one of them was opened.
  */
-async function writeProject(id, req, res) {
+async function writeProject(rawId, req, res) {
+    // Sanitised here rather than by one of the two callers, so it is done once and the id written
+    // into the file always matches the filename fileFor builds from it. Every path builder does
+    // its own safeId as well; a caller doing it too made the ones that did not look unguarded.
+    const id = safeId(rawId);
     const name = req.body?.name || 'Untitled';
     // The body is either { name, data } or the document itself, depending on which client wrote it.
     const data = req.body?.data ?? req.body;
-    await fs.writeFile(fileFor(id), JSON.stringify({ id, name, savedAt: new Date().toISOString(), data }));
+    // Temp file then rename, the same way a backup is written, and for the same reason its
+    // comment gives: a crash or a full disk part-way through must not leave a half-written file.
+    // Only the backup had it. The project - the thing a backup exists to protect - was written
+    // straight over the previous copy, so an interrupted save destroyed the good one. That this
+    // happens is not hypothetical: listJsonDir below already skips files that will not parse,
+    // "so one corrupt save should not make the project list unopenable". This is where they came
+    // from.
+    //
+    // The temp name ends in .json.tmp, which the .json filters everywhere else already skip, so
+    // one left behind by a failed rename is inert rather than showing up as a project.
+    const target = fileFor(id);
+    const tmp = `${target}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify({ id, name, savedAt: new Date().toISOString(), data }));
+    await fs.rename(tmp, target);
     res.json({ id, name });
 }
 
@@ -121,7 +138,7 @@ app.post('/api/projects', async (req, res) => {
 // Overwrite an existing project.
 app.put('/api/projects/:id', async (req, res) => {
     try {
-        await writeProject(safeId(req.params.id), req, res);
+        await writeProject(req.params.id, req, res);
     } catch (e) { res.status(500).json({ error: String(e) }); }
 });
 


### PR DESCRIPTION
## The safety net was crash-safe; the thing it protects was not

`server/index.js` writes a **backup** to a temp file and renames it, with a comment saying why:

> Write to a temp file then rename: a crash mid-write can never leave a half-written snapshot that would fail to parse on restore.

`writeProject` wrote straight over the previous copy. So an interrupted or out-of-space save destroyed the good copy and left an unparseable one in its place.

**This is not hypothetical, and the file already says so.** Twenty lines below `writeProject`, `listJsonDir` skips files that will not parse —

> A file that will not parse is left out rather than failing the whole listing: one corrupt save should not make the project list unopenable.

The workaround for the symptom was written. The cause was left alone. Now the project write goes through the same temp-then-rename as the backup. The temp name ends `.json.tmp`, which every `.json` filter here already skips, so one left behind by a failed rename is inert rather than appearing as a project.

## Verified against the running server

Not by reading:

```
PUT  200 {"id":"roundtrip-test","name":"Round Trip"}
GET  200 {"appName":"EasyMVMaker","cuts":[1,2,3]}
LIST [{"id":"roundtrip-test","name":"Round Trip","savedAt":"..."}]
left over .tmp files: 0
```

## Also: `safeId` moved inside `writeProject`

It was applied by one of the two callers, which made the paths that *don't* apply it look unguarded. They are not — `fileFor` and `assetsDirFor` each call it — but working that out took longer than it should have, and that is the whole cost of an inconsistent guard. (For the record, this also re-confirms the reasoning behind the three dismissed CodeQL alerts: every path really does go through `safeId`.)

Doing it inside also means the id written *into* the file always matches the filename built from it, which the caller-side version did not guarantee. Confirmed with a PUT to `../../escaped`: it lands as `escaped.json` inside the data directory, and the id recorded in it is `escaped`.

`npm run check` green — 726 tests.