### PR TITLE
fix: the loader applied none of the limits the rest of the app applies

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -37,6 +37,18 @@ was edited and the other was not.
 | `brushUp` | A quarter wider, plus one. The plus one is not decoration - 1 x 1.25 rounds back to 1, so without it the shortcut does nothing at the sizes where a single pixel matters most. |
 | `brushDown` | The mirror of it, which was missing: 2 / 1.25 rounds back to 2, so the shortcut for a smaller brush did nothing at all at size 2. Takes at least one pixel off, so the key always moves. |
 
+## `src/core/canvasSize.js`
+
+How large a project's canvas is allowed to be. The custom-size prompt already clamped to these two
+numbers as literals; the loader clamped nothing, so the limits applied to what a person can type
+and not to what a file can say - and a file is the easier of the two to get a wrong number into.
+
+| | |
+|---|---|
+| `CANVAS_MIN_EDGE` | 64px. Below this there is nothing to draw on. |
+| `CANVAS_MAX_EDGE` | 8192px. A canvas costs width x height x 4 bytes and is held more than once, so 8192 square is already 268MB a copy. |
+| `clampCanvasSize` | A size the app can actually allocate, or null when there isn't one here. Half a size counts as none: a width with no height gives a canvas of NaN, which fails far away from here. |
+
 ## `src/core/camera.js`
 
 Camera moves: presets, drawn paths, and the transform they resolve to.
@@ -311,6 +323,7 @@ Reading a saved project, including ones written by older versions.
 |---|---|
 | `makeLoadProgress` | Throttled progress for a load: no bar for a small project, at most a hundred repaints for a large one. |
 | `migrateCuts` | Bring saved cuts up to the current shape. Written as spread-then-override so a field the file already has always wins, and adding a new default here can never overwrite real data in an existing project. |
+| `MAX_TRACKS` | The most timeline tracks a project may claim. Every track is a rendered row, so this is a rendering budget rather than a rule about music videos - nothing in the app creates this many, but a file can still say so. |
 | `projectSettings` | What the app should look like after opening this project, with defaults for anything absent. |
 
 ## `src/core/shortcuts.js`

--- a/src/core/canvasSize.js
+++ b/src/core/canvasSize.js
@@ -1,0 +1,34 @@
+// How large a project's canvas is allowed to be.
+//
+// The custom-size prompt in TopBar already clamped to these two numbers, written as literals. The
+// loader did not clamp at all, so the limits applied to what a person can type and not to what a
+// file can say - and a file is the easier of the two to get a wrong number into: hand-edited,
+// written by an older version, or half-corrupted.
+//
+// A canvas is allocated as width * height * 4 bytes, twice over in places (the layer cache, the
+// scratch canvas), so the ceiling is not decoration. 8192 square is 268MB a copy; ten times that
+// in each direction is not a big canvas, it is a tab that stops responding.
+
+/** Smallest edge, in px. Below this there is nothing to draw on. */
+export const CANVAS_MIN_EDGE = 64;
+/** Largest edge, in px. */
+export const CANVAS_MAX_EDGE = 8192;
+
+/**
+ * A canvas size the app can actually allocate, or null if there isn't one here.
+ *
+ * Null rather than a default, because the caller knows better what to do without one: opening a
+ * project keeps the canvas it already has, which is what a file that predates saved canvas sizes
+ * needs. Half a size is treated as none at all - a width with no height would give NaN, and a
+ * canvas of NaN fails far away from here.
+ *
+ * @param {unknown} w
+ * @param {unknown} h
+ * @returns {{w: number, h: number} | null}
+ */
+export function clampCanvasSize(w, h) {
+    const nw = Number(w), nh = Number(h);
+    if (!Number.isFinite(nw) || !Number.isFinite(nh) || nw <= 0 || nh <= 0) return null;
+    const fit = (n) => Math.round(Math.max(CANVAS_MIN_EDGE, Math.min(CANVAS_MAX_EDGE, n)));
+    return { w: fit(nw), h: fit(nh) };
+}

--- a/src/core/projectFormat.js
+++ b/src/core/projectFormat.js
@@ -15,18 +15,49 @@
 //     plain layer at the root
 //   - texts arrived later still, so older cuts have no texts array at all
 
-/** What the app should look like after opening this project, with defaults for anything absent. */
+import { clampPps } from './timelineZoom.js';
+import { clampCanvasSize } from './canvasSize.js';
+
+/**
+ * The most timeline tracks a project may claim.
+ *
+ * Every track is a row the timeline renders, so this is a rendering budget rather than a rule
+ * about music videos. Nothing in the app creates this many; a file can still say so.
+ */
+export const MAX_TRACKS = 64;
+
+/** At least one track to put a cut on, at most MAX_TRACKS. Anything unreadable is the default 2. */
+function clampTracks(n) {
+    const t = Math.round(Number(n));
+    if (!Number.isFinite(t)) return 2;
+    return Math.max(1, Math.min(MAX_TRACKS, t));
+}
+
+/**
+ * What the app should look like after opening this project, with defaults for anything absent.
+ *
+ * This is the boundary where a file becomes app state, and it was the one place that applied none
+ * of the limits the app applies everywhere else. The custom-size prompt clamps what a person can
+ * type; the timeline clamps what a pinch or a wheel can reach. A file went straight in. A file is
+ * the easier of the two to get a wrong number into - hand-edited, written by an older version, or
+ * half-corrupted - and the failures land far from here: a pps of 0 renders every cut at zero
+ * width, a negative numTracks puts cuts on track -1 where nothing draws them, and a canvas of
+ * 100000 square asks for forty gigabytes.
+ */
 export function projectSettings(data) {
     const cuts = Array.isArray(data?.cuts) ? data.cuts : [];
-    const w = data?.canvas?.w, h = data?.canvas?.h;
     return {
-        // Only a complete size counts: half of one would give a canvas of NaN.
-        canvas: (w && h) ? { w, h } : null,
-        numTracks: data?.numTracks || 2,
+        // Half a size is treated as none at all: a width with no height gives a canvas of NaN.
+        canvas: clampCanvasSize(data?.canvas?.w, data?.canvas?.h),
+        // Absent and wrong are different, and `||` cannot tell them apart - which is what the
+        // onion-skin flags below are tested for. So absence is `??`, and a value that is present
+        // but unusable is clamped rather than replaced: a stored zoom of 0 becomes the smallest
+        // zoom the timeline can be read at, not the default someone else would have picked.
+        numTracks: clampTracks(data?.numTracks ?? 2),
         currentCutId: cuts[0]?.id ?? 1,
         onionPrev: data?.onionPrev ?? false,
         onionNext: data?.onionNext ?? false,
-        pps: data?.pps ?? 50,
+        pps: clampPps(data?.pps ?? 50),
     };
 }
 

--- a/src/ui/TopBar.jsx
+++ b/src/ui/TopBar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ChevronDown, Download, Upload, Film, Settings, AlertTriangle, DatabaseBackup } from 'lucide-react';
 import { tr } from '../i18n';
 import { Logo } from './Logo.jsx';
+import { clampCanvasSize } from '../core/canvasSize.js';
 
 // Top menu bar: the File and Media menus, resolution, canvas zoom, save state, Export.
 export function TopBar({
@@ -90,7 +91,7 @@ export function TopBar({
                         if (!s) return;
                         const m = s.match(/(\d+)\s*[xX*,\s]\s*(\d+)/);
                         if (!m) { alert(tr('예: 1920x1080')); return; }
-                        setCanvasSize({ w: Math.max(64, Math.min(8192, +m[1])), h: Math.max(64, Math.min(8192, +m[2])) });
+                        setCanvasSize(clampCanvasSize(m[1], m[2]) || { w: 1920, h: 1080 });
                     } else {
                         const [w, h] = e.target.value.split('x').map(Number);
                         setCanvasSize({ w, h });

--- a/test/canvasSize.test.js
+++ b/test/canvasSize.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { clampCanvasSize, CANVAS_MIN_EDGE, CANVAS_MAX_EDGE } from '../src/core/canvasSize.js';
+
+test('an ordinary size passes through untouched', () => {
+    assert.deepEqual(clampCanvasSize(1920, 1080), { w: 1920, h: 1080 });
+    assert.deepEqual(clampCanvasSize(CANVAS_MIN_EDGE, CANVAS_MAX_EDGE), { w: CANVAS_MIN_EDGE, h: CANVAS_MAX_EDGE });
+});
+
+test('a canvas nobody can allocate is brought back to the ceiling', () => {
+    assert.deepEqual(clampCanvasSize(100000, 100000), { w: CANVAS_MAX_EDGE, h: CANVAS_MAX_EDGE });
+    assert.deepEqual(clampCanvasSize(1e12, 20), { w: CANVAS_MAX_EDGE, h: CANVAS_MIN_EDGE });
+});
+
+test('half a size is no size, because a width with no height gives NaN', () => {
+    assert.equal(clampCanvasSize(1920, undefined), null);
+    assert.equal(clampCanvasSize(undefined, 1080), null);
+    assert.equal(clampCanvasSize(undefined, undefined), null);
+    assert.equal(clampCanvasSize(null, null), null);
+});
+
+test('nonsense is no size rather than a canvas of NaN', () => {
+    assert.equal(clampCanvasSize('wide', 'tall'), null);
+    assert.equal(clampCanvasSize(NaN, 1080), null);
+    assert.equal(clampCanvasSize(Infinity, 1080), null);
+    assert.equal(clampCanvasSize(0, 0), null);
+    assert.equal(clampCanvasSize(-1920, -1080), null);
+});
+
+test('numeric strings work, because the size prompt hands over match groups', () => {
+    assert.deepEqual(clampCanvasSize('1920', '1080'), { w: 1920, h: 1080 });
+    assert.deepEqual(clampCanvasSize('4', '4'), { w: CANVAS_MIN_EDGE, h: CANVAS_MIN_EDGE });
+});
+
+test('a size is always whole pixels', () => {
+    assert.deepEqual(clampCanvasSize(1920.4, 1080.6), { w: 1920, h: 1081 });
+});

--- a/test/projectFormat.test.js
+++ b/test/projectFormat.test.js
@@ -5,7 +5,9 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { projectSettings, migrateCuts, makeLoadProgress } from '../src/core/projectFormat.js';
+import { projectSettings, migrateCuts, makeLoadProgress, MAX_TRACKS } from '../src/core/projectFormat.js';
+import { PPS_MIN, PPS_MAX } from '../src/core/timelineZoom.js';
+import { CANVAS_MAX_EDGE } from '../src/core/canvasSize.js';
 
 // ── settings ───────────────────────────────────────────────────────────────
 test('projectSettings: takes what the file says', () => {
@@ -30,10 +32,40 @@ test('projectSettings: fills in everything an older file never wrote', () => {
 
 test('projectSettings: onion skin off is honoured, not treated as missing', () => {
     // `||` here would silently turn a deliberate false back on at every load.
-    const s = projectSettings({ cuts: [], onionPrev: false, onionNext: false, pps: 0 });
+    const s = projectSettings({ cuts: [], onionPrev: false, onionNext: false });
     assert.equal(s.onionPrev, false);
     assert.equal(s.onionNext, false);
-    assert.equal(s.pps, 0, 'a real zoom of zero is kept as written');
+});
+
+// This assertion used to read "a real zoom of zero is kept as written", guarding the same `||`
+// mistake as the flags above. But zero is not a real zoom: PPS_MIN is 10 because "below ten pixels
+// a second the cuts are too small to grab", so keeping a stored 0 restores a timeline that cannot
+// be used. Absence and wrongness are handled apart now - `??` for the first, a clamp for the
+// second - so the rule the test was written for still holds.
+test('projectSettings: a stored zoom of zero becomes the smallest usable one, not the default', () => {
+    assert.equal(projectSettings({ cuts: [], pps: 0 }).pps, PPS_MIN);
+    assert.equal(projectSettings({ cuts: [] }).pps, 50, 'and an absent one is still the default');
+});
+
+test('projectSettings: a zoom no gesture could reach is brought back into range', () => {
+    assert.equal(projectSettings({ cuts: [], pps: 99999 }).pps, PPS_MAX);
+    assert.equal(projectSettings({ cuts: [], pps: 'abc' }).pps, PPS_MIN);
+    assert.equal(projectSettings({ cuts: [], pps: 80 }).pps, 80, 'an ordinary one is untouched');
+});
+
+test('projectSettings: track counts a timeline can actually render', () => {
+    assert.equal(projectSettings({ cuts: [], numTracks: 0 }).numTracks, 1, 'a cut needs somewhere to sit');
+    assert.equal(projectSettings({ cuts: [], numTracks: -5 }).numTracks, 1,
+        'negative would put cuts on track -1, where nothing draws them');
+    assert.equal(projectSettings({ cuts: [], numTracks: 9999 }).numTracks, MAX_TRACKS,
+        'every track is a rendered row');
+    assert.equal(projectSettings({ cuts: [] }).numTracks, 2, 'absent is the default, not the floor');
+    assert.equal(projectSettings({ cuts: [], numTracks: 3 }).numTracks, 3);
+});
+
+test('projectSettings: a canvas nobody could allocate is brought back to the ceiling', () => {
+    assert.deepEqual(projectSettings({ cuts: [], canvas: { w: 100000, h: 100000 } }).canvas,
+        { w: CANVAS_MAX_EDGE, h: CANVAS_MAX_EDGE });
 });
 
 test('projectSettings: half a canvas size is no canvas size', () => {


### PR DESCRIPTION
## The one place a file becomes app state, clamping nothing

`projectSettings` is that boundary. The custom-size prompt clamps what a person can *type*. The timeline clamps what a pinch or a wheel can *reach*. A file went straight in — and a file is the easier of the two to get a wrong number into: hand-edited, written by an older version, or half-corrupted.

The failures all land far from the loader:

| stored value | what happens |
|---|---|
| `pps: 0` | every cut renders at zero width |
| `numTracks: -5` | cuts sit on track −1, where nothing draws them |
| `canvas: 100000×100000` | asks for forty gigabytes |

`clampPps` already existed and was not used here. The canvas limits existed as **two literals inside TopBar's size prompt**; they are now `canvasSize.js`, which both sides use. `MAX_TRACKS` is new — a rendering budget rather than a rule about music videos: nothing in the app makes that many tracks, but a file can say so.

## One existing test changed, and that is the interesting part

It asserted a stored `pps: 0` **"is kept as written"**, guarding the mistake of writing `||` where `??` is meant — the same mistake that would flip a deliberate onion-skin `false` back on.

That rule is right. But zero is not a real zoom: `PPS_MIN` is 10 precisely because *"below ten pixels a second the cuts are too small to grab"*, so honouring a stored 0 restores a timeline that cannot be used.

So **absence and wrongness are handled apart now** — `??` for the first, a clamp for the second. That keeps the rule the test was written for and stops the value it happened to be testing with. A stored 0 becomes the smallest usable zoom rather than someone else's default; an absent one is still 50. The test says that now, with the reasoning beside it.

## Exercised at the boundary

```
pps 0     -> 10     tracks 0    -> 1    canvas 100000 -> 8192
pps 99999 -> 300    tracks -5   -> 1    canvas {w only} -> null
pps 'abc' -> 10     tracks 9999 -> 64   absent -> 50 / 2 / null
pps 80    -> 80     tracks 3    -> 3    canvas 1920x1080 -> unchanged
```

`npm run check` green — 736 tests.