### PR TITLE
refactor: server projects and their backups leave App

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -23,6 +23,20 @@ Which stored bitmaps are still reachable, for garbage collection.
 | `collectUsedBitmapIds` | Every bitmap id still referenced by anything that can bring it back: the cuts, the undo history, the cut clipboard, the lasso clipboard and the live selection. Freeing something an undo still needs is not a leak, it is an undo that comes back blank. |
 | `unusedBitmapIds` | Ids present in the store that nothing references any more. |
 
+## `src/core/api.js`
+
+Talking to the local project server. The only thing these add to `fetch` is the check `fetch` does
+not do: a 404 or a 500 is a perfectly good response as far as it is concerned, and it rejects only
+when the network itself fails. That is not hypothetical tidiness - before the asset path had this
+check, a 404 came back as a Blob of `{"error":"not found"}` and was written into a project as a
+frame's image data.
+
+| | |
+|---|---|
+| `apiFetch` | A JSON endpoint, or throw on any status that is not ok. |
+| `fetchAsset` | One stored binary asset - a frame, the audio, the reference video - as a Blob, or throw. |
+| `putAsset` | Upload one asset as a Blob rather than base64, throwing the caller's own message so it can be localised and numbered. A legacy dataURL is fetched back into a Blob first. |
+
 ## `src/core/brushSize.js`
 
 How wide a brush may be, and how a keystroke changes it. The range was written twice - once for
@@ -500,6 +514,17 @@ Debounced background saving, so a refresh or a crash never costs work.
 | | |
 |---|---|
 | `useAutosave` | Saves `doc` after a quiet period. Waits for `ready()` - crash recovery has to decide first, or a new empty document overwrites the autosave the user is about to be offered - and skips while `busy()`. Failures come back as `error` rather than being swallowed. |
+
+## `src/hooks/useServerStorage.js`
+
+Keeping projects on the local API server, and the rotating backups of them. Two hundred lines that
+never touch cuts, layers, strokes, the canvas or the timeline - which is what made this the first
+thing worth cutting out of App: not that it was the biggest concern in there, but that the cut was
+the narrowest.
+
+| | |
+|---|---|
+| `useServerStorage` | Save, open and delete server projects; snapshot every five minutes and rotate. Takes `buildData` and `restore` as functions rather than reaching for the document itself, because building one reads most of App's state and restoring one writes most of it - threading either in would make the seam wider than the thing it separates. |
 
 ## `src/hooks/useServerProbe.js`
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,8 @@ import { fmt, parseClock } from './core/timeCode.js';
 import { useHistory } from './hooks/useHistory.js';
 import { usePlayback } from './hooks/usePlayback.js';
 import { useServerProbe } from './hooks/useServerProbe.js';
+import { useServerStorage } from './hooks/useServerStorage.js';
+import { fetchAsset } from './core/api.js';
 import { useAutosave } from './hooks/useAutosave.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
 import { playbackStartFrom } from './core/playbackStart.js';
@@ -339,7 +341,6 @@ export default function App() {
     // looks like it simply did nothing - which is exactly why one bug here took so long to find.
     const [appError, setAppError] = useState(null);
     const [toast, setToast] = useState(null);            // unobtrusive notice
-    const [backupProg, setBackupProg] = useState(null);  // automatic-backup progress, shown in the corner
     useEffect(() => { if (!toast) return; const t = setTimeout(() => setToast(null), 3000); return () => clearTimeout(t); }, [toast]);
     const videoStopRef = useRef(false);
     const isExporting = useRef(false);
@@ -479,7 +480,6 @@ export default function App() {
     const pinchRef = useRef(null);
     const tlTouchRef = useRef(new Map());
     const tlPinchRef = useRef(null);
-    const [serverProjects, setServerProjects] = useState(null); // null = picker closed
     const [localProjects, setLocalProjects] = useState(null); // IndexedDB project picker
     const localIdRef = useRef(null);
     const localNameRef = useRef('');
@@ -491,16 +491,11 @@ export default function App() {
     // whatever was on screen: frames from project 1 appearing in project 2. Each job takes a copy
     // of this when it starts and drops its result if it no longer matches.
     const docEpochRef = useRef(0);
-    const serverIdRef = useRef(null);
-    const serverNameRef = useRef('');
     const cutDragMovedRef = useRef(false); // distinguishes a click (select) from a real drag (move)
     const cutDragArmedRef = useRef(false); // long-press must arm before a touch can drag a cut
     const cutDragTimerRef = useRef(null);
     const [animLayer, setAnimLayer] = useState(null); // {cutId, layerId} whose part-anim panel is open
     const [jitterLayer, setJitterLayer] = useState(null); // {cutId, layerId} whose boiling-settings panel is open
-    const [backupAt, setBackupAt] = useState(null);      // time of the last server backup
-    const [backupBusy, setBackupBusy] = useState(false);
-    const [backupList, setBackupList] = useState(null);  // null = the list is closed
     // A transparent canvas is a different document, not a different view: the frame really has
     // no background, and the checkerboard behind it is CSS on the element rather than pixels.
     // Painting the checkerboard in would put it in every export.
@@ -514,9 +509,6 @@ export default function App() {
 
     const [storageInfo, setStorageInfo] = useState(null); // local storage usage
     const [loadProgress, setLoadProgress] = useState(null); // {label, done, total}; total 0 means the length is unknown
-    const backupKeyRef = useRef(null);
-    const backupBusyRef = useRef(false);
-    const lastBackupSigRef = useRef('');
     // The lang state exists only to trigger a redraw; lookups read the module variable.
     // Nothing here is memoised, so changing it re-renders the whole tree in the new language.
     const [lang, setLang] = useState(loadLang);
@@ -1317,6 +1309,23 @@ export default function App() {
         } finally { setLoadProgress(null); restoreBusyRef.current = false; }
         return true;
     };
+
+    // Server projects and their rotating backups. Called here rather than beside the other hooks
+    // because it needs buildData and restore, and both are defined above this point - a hook may
+    // be called anywhere in the body as long as it is called unconditionally and in the same
+    // order every render, and this is the first place both exist.
+    const {
+        serverProjects, setServerProjects,
+        backupAt, backupBusy, backupList, setBackupList, backupProg,
+        serverIdRef, serverNameRef, forgetProject,
+        doServerSave, openServerList, doServerOpen, doServerDelete,
+        doServerBackup, openBackupList, doBackupRestore, doBackupDelete,
+    } = useServerStorage({
+        serverAvailable, buildData, restore,
+        setLoadProgress, setAppError, setToast,
+        liveRef, localNameRef,
+    });
+
     const doSave = async (asNew = false) => {
         const json = JSON.stringify(await buildData(), null, 2);
         if ('showSaveFilePicker' in window && (asNew || !fileHandleRef.current)) {
@@ -1374,7 +1383,7 @@ export default function App() {
         setNumTracks(2); setCurrentCutId(1); setCurrentTime(0); setExpandedCuts(new Set());
         setCopiedCut(null); setSelectedCutIds(new Set()); setActivePartId(null);
         setLayerCanvasCache({});
-        serverIdRef.current = null; serverNameRef.current = '';
+        forgetProject();
         detachMedia(audioRef.current);
         audioB64Ref.current = null; dispatchMedia(clearAudio());
         videoBlobRef.current = null; dispatchMedia(clearVideo()); setSceneCfg(null);
@@ -1435,181 +1444,6 @@ export default function App() {
             if (doc) await restore(doc); else resetToEmpty();
         }
     };
-
-    // Fetch one stored asset, or throw.
-    //
-    // fetch only rejects on a network failure: a 404 is a perfectly good response, and calling
-    // .blob() on it succeeds. The server answers a missing asset with 404 {"error":"not found"},
-    // so without this check that JSON became the frame's image data - and the silent catch around
-    // the call never fired, because nothing threw. The project opened with blank frames and no
-    // explanation, and for the audio it was worse: the error page ended up in audioB64Ref and was
-    // written into the next .emv file.
-    const fetchAsset = async (url) => {
-        const res = await fetch(url);
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.blob();
-    };
-
-    // --- Server-side project storage (separate from local download / .emv file) ---
-    const apiFetch = async (url, opts) => {
-        const res = await fetch(url, opts);
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json();
-    };
-    // Upload externalized frame assets one at a time (binary, no base64) so peak memory is a
-    // single frame — this is what keeps big/original-quality projects from OOMing on save.
-    const uploadAssets = async (id, assetSink) => {
-        const total = assetSink.length;
-        for (let i = 0; i < total; i++) {
-            const a = assetSink[i];
-            // Prefer the Blob (uploads directly, no decode); fall back to a legacy dataURL.
-            const blob = a.blob || await (await fetch(a.url)).blob();
-            const res = await fetch(`/api/projects/${id}/asset/${a.id}?ext=${encodeURIComponent(a.ext)}`, {
-                method: 'PUT', headers: { 'Content-Type': blob.type || 'application/octet-stream' }, body: blob,
-            });
-            if (!res.ok) throw new Error(tr('프레임 업로드 실패 ({0}/{1})', i + 1, total));
-            if (total > 12) setLoadProgress({ label: tr('서버에 올리는 중'), done: i + 1, total });
-        }
-    };
-    const doServerSave = async (forceNew = false) => {
-        try {
-            const assetSink = [];
-            const data = await buildData(true, assetSink); // frames/audio externalized → small JSON
-            let id = (!forceNew && serverIdRef.current) ? serverIdRef.current : null;
-            let name = serverNameRef.current || 'Untitled';
-            if (!id) {
-                name = window.prompt(tr('서버에 저장할 프로젝트 이름:'), serverNameRef.current || 'MV Project');
-                if (!name) return;
-                // Create the record first (just to get an id); the real data is committed LAST.
-                const r = await apiFetch('/api/projects', {
-                    method: 'POST', headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ name, data: { appName: 'EasyMVMaker', pending: true } }),
-                });
-                id = r.id; serverIdRef.current = r.id; serverNameRef.current = r.name;
-            }
-            // Upload assets BEFORE writing the manifest, so an interrupted save never leaves the
-            // project JSON pointing at frames/audio that aren't on disk (which caused 404s + blanks).
-            if (assetSink.length) await uploadAssets(id, assetSink);
-            await apiFetch(`/api/projects/${id}`, {
-                method: 'PUT', headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name, data }),
-            });
-            alert(tr('서버에 저장했습니다.'));
-        } catch (e) {
-            console.error('[import]', e);
-            setAppError(tr('서버 저장 실패: ') + e.message + '\n' + tr('(API 서버가 실행 중인지 확인하세요. 큰 프로젝트는 저장에 시간이 걸립니다.)'));
-        } finally { setLoadProgress(null); }
-    };
-    const openServerList = async () => {
-        try { setServerProjects(await apiFetch('/api/projects')); }
-        catch (e) { alert(tr('서버 목록을 불러오지 못했습니다: ') + e.message + '\n' + tr('(API 서버 실행 확인: npm run dev)')); }
-    };
-    const doServerOpen = async (id, name) => {
-        try {
-            const data = await apiFetch(`/api/projects/${id}`);
-            // Only claim the identity if the document actually went in - otherwise the next save
-            // would write this project's id over whatever is really on screen.
-            if (!await restore(data, `/api/projects/${id}`)) return; // assets come from this project
-            serverIdRef.current = id; serverNameRef.current = name || '';
-            setServerProjects(null);
-        } catch (e) { alert(tr('서버에서 열기 실패: ') + e.message); }
-    };
-    const doServerDelete = async (id) => {
-        if (!window.confirm(tr('이 프로젝트를 서버에서 삭제할까요?'))) return;
-        try {
-            await apiFetch(`/api/projects/${id}`, { method: 'DELETE' });
-            if (serverIdRef.current === id) { serverIdRef.current = null; serverNameRef.current = ''; }
-            openServerList();
-        } catch (e) { alert(tr('삭제 실패: ') + e.message); }
-    };
-
-    // --- Rotating server backups of the autosave (a safety net separate from Save) ---------
-    // The local IndexedDB autosave protects against a crash/refresh; this protects against the
-    // browser profile itself being lost or a project being overwritten. Snapshots are kept as
-    // separate timestamped files server-side and rotated, so you can roll back.
-    const getBackupKey = () => {
-        if (serverIdRef.current) return serverIdRef.current; // group under the server project if there is one
-        if (!backupKeyRef.current) {
-            let k = readStored('mv_backup_key', '');
-            if (!k) {
-                k = randomId('bk_');
-                writeStored('mv_backup_key', k);
-            }
-            backupKeyRef.current = k;
-        }
-        return backupKeyRef.current;
-    };
-    // Skip frames the server already has — otherwise every backup of a video project would
-    // re-upload hundreds of MB. Assets are keyed by bitmapId, so presence means identical.
-    const uploadAssetsDeduped = async (key, assetSink, onProgress) => {
-        let have = new Set();
-        try { have = new Set((await apiFetch(`/api/projects/${key}/assets`)).map(String)); } catch { }
-        const todo = assetSink.filter(a => !have.has(String(a.id)));
-        for (let i = 0; i < todo.length; i++) {
-            const a = todo[i];
-            const blob = a.blob || await (await fetch(a.url)).blob();
-            const res = await fetch(`/api/projects/${key}/asset/${a.id}?ext=${encodeURIComponent(a.ext)}`, {
-                method: 'PUT', headers: { 'Content-Type': blob.type || 'application/octet-stream' }, body: blob,
-            });
-            if (!res.ok) throw new Error(tr('에셋 업로드 실패 ({0}/{1})', i + 1, todo.length));
-            setBackupProg({ done: i + 1, total: todo.length });
-            onProgress?.(i + 1, todo.length);
-        }
-        return todo.length;
-    };
-    // The automatic backup runs itself every five minutes, so it must never block the screen.
-    // It used to raise a full-screen progress overlay, which stopped all work while it ran.
-    const doServerBackup = async (silent = true) => {
-        if (!serverAvailable || backupBusyRef.current) return;
-        backupBusyRef.current = true; setBackupBusy(true); setBackupProg(null);
-        try {
-            const key = getBackupKey();
-            const assetSink = [];
-            const data = await buildData(true, assetSink); // frames and audio go out as separate assets, keeping the JSON small
-            if (assetSink.length) await uploadAssetsDeduped(key, assetSink);
-            await apiFetch(`/api/backups/${key}`, {
-                method: 'POST', headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name: serverNameRef.current || localNameRef.current || tr('자동 백업'), data }),
-            });
-            setBackupAt(Date.now());
-            if (!silent) setToast(tr('서버에 백업했습니다.'));
-        } catch (e) {
-            if (!silent) setAppError(tr('서버 백업 실패: ') + e.message);
-        } finally { backupBusyRef.current = false; setBackupBusy(false); setBackupProg(null); }
-    };
-    const openBackupList = async () => {
-        try { setBackupList(await apiFetch(`/api/backups/${getBackupKey()}`)); }
-        catch (e) { alert(tr('백업 목록을 불러오지 못했습니다: ') + e.message); }
-    };
-    const doBackupRestore = async (stamp) => {
-        if (!window.confirm(tr('이 백업으로 되돌릴까요? 현재 작업 내용은 사라집니다.'))) return;
-        try {
-            const key = getBackupKey();
-            const data = await apiFetch(`/api/backups/${key}/${stamp}`);
-            if (!await restore(data, `/api/projects/${key}`)) return; // assets come from the same key
-            setBackupList(null);
-        } catch (e) { alert(tr('백업 복구 실패: ') + e.message); }
-    };
-    const doBackupDelete = async (stamp) => {
-        if (!window.confirm(tr('이 백업을 삭제할까요?'))) return;
-        try { await apiFetch(`/api/backups/${getBackupKey()}/${stamp}`, { method: 'DELETE' }); openBackupList(); }
-        catch (e) { alert(tr('삭제 실패: ') + e.message); }
-    };
-    // Periodic backup. Reads the newest state through a ref: putting `cuts` in the deps would
-    // restart the timer on every stroke, so it would never actually fire while you draw.
-    const backupFnRef = useRef(null);
-    backupFnRef.current = doServerBackup;
-    useEffect(() => {
-        if (!serverAvailable) return;
-        const id = setInterval(() => {
-            const cs = liveRef.current?.cuts || [];
-            const sig = cs.length + ':' + cs.map(c => safeArray(c.layers).reduce((n, l) => n + safeArray(l.strokes).length, 0)).join(',');
-            if (sig === lastBackupSigRef.current) return; // nothing changed, so skip
-            lastBackupSigRef.current = sig;
-            backupFnRef.current?.(true);
-        }, 5 * 60 * 1000);
-        return () => clearInterval(id);
-    }, [serverAvailable]);
 
     // Ask the browser to make local storage persistent, so the IndexedDB autosave isn't
     // silently evicted under storage pressure (the main way local-only work gets lost).

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -1,0 +1,60 @@
+// Talking to the local project server.
+//
+// Two wrappers around fetch, and the only thing they add is the check fetch does not do: a 404 or
+// a 500 is a perfectly good response as far as fetch is concerned, and it rejects only when the
+// network itself fails. Every call here wants the opposite - a response that is not ok is a
+// failure, and should be thrown rather than parsed.
+//
+// That is not a hypothetical tidy-up. Before the check existed on the asset path, a 404 from the
+// store came back as a Blob of `{"error":"not found"}` and was written into a project as the
+// frame's image data.
+//
+// These live outside App because both App and the server-storage hook need them, and neither owns
+// them: there is no state here, only fetch and a status code.
+
+/**
+ * A JSON endpoint, or throw.
+ *
+ * @param {string} url
+ * @param {RequestInit} [opts]
+ * @returns {Promise<any>}
+ */
+export async function apiFetch(url, opts) {
+    const res = await fetch(url, opts);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+}
+
+/**
+ * One stored binary asset - a video frame, the audio, the reference video - or throw.
+ *
+ * @param {string} url
+ * @returns {Promise<Blob>}
+ */
+export async function fetchAsset(url) {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.blob();
+}
+
+/**
+ * Upload one asset, or throw with a message naming which of how many failed.
+ *
+ * Sends the Blob directly rather than a dataURL: base64 is a third larger and has to be decoded
+ * on both ends. A legacy dataURL is fetched back into a Blob first, which is why `url` is still
+ * accepted alongside `blob`.
+ *
+ * @param {string} base the project or backup key's asset path, e.g. `/api/projects/p_abc`
+ * @param {{id: string, ext: string, blob?: Blob, url?: string}} asset
+ * @param {string} failMessage thrown as-is, so the caller can localise and number it
+ * @returns {Promise<void>}
+ */
+export async function putAsset(base, asset, failMessage) {
+    const blob = asset.blob || await (await fetch(asset.url)).blob();
+    const res = await fetch(`${base}/asset/${asset.id}?ext=${encodeURIComponent(asset.ext)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': blob.type || 'application/octet-stream' },
+        body: blob,
+    });
+    if (!res.ok) throw new Error(failMessage);
+}

--- a/src/hooks/useServerStorage.js
+++ b/src/hooks/useServerStorage.js
@@ -1,0 +1,226 @@
+// Keeping projects on the local API server, and the rotating backups of them.
+//
+// Two related jobs that were spread through App:
+//
+//   Save / Open / Delete   a project the user names, on the server, with its frames and audio
+//                          stored beside it as separate binary assets rather than base64
+//   Backups                a snapshot every five minutes, kept as timestamped files and rotated,
+//                          so a lost browser profile or an overwritten project is recoverable
+//
+// They belong together because they share an identity - a project saved to the server backs up
+// under its own id, and an unsaved one backs up under a key of its own - and because both go
+// through the same asset upload.
+//
+// What stays in App, and why: buildData and restore. Building a document reads most of App's
+// state, and restoring one writes most of it. Threading either of those in here would mean
+// threading in everything they touch, and the seam would be wider than the thing it separates.
+// They arrive as two functions instead, which is the whole of what this needs from the document.
+//
+// The 200-odd lines this holds do not touch cuts, layers, strokes, the canvas or the timeline.
+// That is what made it the first thing worth cutting out of App: not that it was the biggest,
+// but that the cut was the narrowest.
+
+import { useState, useRef, useEffect } from 'react';
+import { apiFetch, putAsset } from '../core/api.js';
+import { readStored, writeStored } from '../core/persist.js';
+import { randomId } from '../core/ids.js';
+import { safeArray } from '../canvas/canvasUtils.js';
+import { tr } from '../i18n.js';
+
+/** How often the automatic backup wakes up. */
+const BACKUP_EVERY_MS = 5 * 60 * 1000;
+
+/**
+ * @param {object} opts
+ * @param {boolean} opts.serverAvailable whether the API answered its probe
+ * @param {(includeAudio?: boolean, assetSink?: any[], blobsOk?: boolean) => Promise<any>} opts.buildData
+ * @param {(data: any, assetBase?: string|null) => Promise<boolean>} opts.restore false if the
+ *   document did not go in, in which case the caller must not record the project's identity
+ * @param {(p: any) => void} opts.setLoadProgress
+ * @param {(m: string) => void} opts.setAppError
+ * @param {(m: string) => void} opts.setToast
+ * @param {{current: any}} opts.liveRef the newest document, read without re-running the timer
+ * @param {{current: string}} opts.localNameRef a name to fall back on for an unnamed backup
+ */
+export function useServerStorage({
+    serverAvailable, buildData, restore,
+    setLoadProgress, setAppError, setToast,
+    liveRef, localNameRef,
+}) {
+    const [serverProjects, setServerProjects] = useState(/** @type {any} */(null)); // null = picker closed
+    const [backupAt, setBackupAt] = useState(/** @type {number|null} */(null));
+    const [backupBusy, setBackupBusy] = useState(false);
+    const [backupList, setBackupList] = useState(/** @type {any} */(null));        // null = list closed
+    const [backupProg, setBackupProg] = useState(/** @type {any} */(null));
+
+    const serverIdRef = useRef(/** @type {string|null} */(null));
+    const serverNameRef = useRef('');
+    const backupKeyRef = useRef(/** @type {string|null} */(null));
+    const backupBusyRef = useRef(false);
+    const lastBackupSigRef = useRef('');
+
+    /** Forget which server project is open, so the next save asks for a name. */
+    const forgetProject = () => { serverIdRef.current = null; serverNameRef.current = ''; };
+
+    // Upload externalized frame assets one at a time (binary, no base64) so peak memory is a
+    // single frame — this is what keeps big/original-quality projects from OOMing on save.
+    const uploadAssets = async (id, assetSink) => {
+        const total = assetSink.length;
+        for (let i = 0; i < total; i++) {
+            await putAsset(`/api/projects/${id}`, assetSink[i], tr('프레임 업로드 실패 ({0}/{1})', i + 1, total));
+            if (total > 12) setLoadProgress({ label: tr('서버에 올리는 중'), done: i + 1, total });
+        }
+    };
+
+    const doServerSave = async (forceNew = false) => {
+        try {
+            const assetSink = [];
+            const data = await buildData(true, assetSink); // frames/audio externalized → small JSON
+            let id = (!forceNew && serverIdRef.current) ? serverIdRef.current : null;
+            let name = serverNameRef.current || 'Untitled';
+            if (!id) {
+                name = window.prompt(tr('서버에 저장할 프로젝트 이름:'), serverNameRef.current || 'MV Project');
+                if (!name) return;
+                // Create the record first (just to get an id); the real data is committed LAST.
+                const r = await apiFetch('/api/projects', {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name, data: { appName: 'EasyMVMaker', pending: true } }),
+                });
+                id = r.id; serverIdRef.current = r.id; serverNameRef.current = r.name;
+            }
+            // Upload assets BEFORE writing the manifest, so an interrupted save never leaves the
+            // project JSON pointing at frames/audio that aren't on disk (which caused 404s + blanks).
+            if (assetSink.length) await uploadAssets(id, assetSink);
+            await apiFetch(`/api/projects/${id}`, {
+                method: 'PUT', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, data }),
+            });
+            alert(tr('서버에 저장했습니다.'));
+        } catch (e) {
+            console.error('[import]', e);
+            setAppError(tr('서버 저장 실패: ') + e.message + '\n' + tr('(API 서버가 실행 중인지 확인하세요. 큰 프로젝트는 저장에 시간이 걸립니다.)'));
+        } finally { setLoadProgress(null); }
+    };
+
+    const openServerList = async () => {
+        try { setServerProjects(await apiFetch('/api/projects')); }
+        catch (e) { alert(tr('서버 목록을 불러오지 못했습니다: ') + e.message + '\n' + tr('(API 서버 실행 확인: npm run dev)')); }
+    };
+
+    const doServerOpen = async (id, name) => {
+        try {
+            const data = await apiFetch(`/api/projects/${id}`);
+            // Only claim the identity if the document actually went in - otherwise the next save
+            // would write this project's id over whatever is really on screen.
+            if (!await restore(data, `/api/projects/${id}`)) return; // assets come from this project
+            serverIdRef.current = id; serverNameRef.current = name || '';
+            setServerProjects(null);
+        } catch (e) { alert(tr('서버에서 열기 실패: ') + e.message); }
+    };
+
+    const doServerDelete = async (id) => {
+        if (!window.confirm(tr('이 프로젝트를 서버에서 삭제할까요?'))) return;
+        try {
+            await apiFetch(`/api/projects/${id}`, { method: 'DELETE' });
+            if (serverIdRef.current === id) forgetProject();
+            openServerList();
+        } catch (e) { alert(tr('삭제 실패: ') + e.message); }
+    };
+
+    // --- Rotating server backups of the autosave (a safety net separate from Save) ---------
+    // The local IndexedDB autosave protects against a crash/refresh; this protects against the
+    // browser profile itself being lost or a project being overwritten. Snapshots are kept as
+    // separate timestamped files server-side and rotated, so you can roll back.
+    const getBackupKey = () => {
+        if (serverIdRef.current) return serverIdRef.current; // group under the server project if there is one
+        if (!backupKeyRef.current) {
+            let k = readStored('mv_backup_key', '');
+            if (!k) {
+                k = randomId('bk_');
+                writeStored('mv_backup_key', k);
+            }
+            backupKeyRef.current = k;
+        }
+        return backupKeyRef.current;
+    };
+
+    // Skip frames the server already has — otherwise every backup of a video project would
+    // re-upload hundreds of MB. Assets are keyed by bitmapId, so presence means identical.
+    const uploadAssetsDeduped = async (key, assetSink, onProgress) => {
+        let have = new Set();
+        try { have = new Set((await apiFetch(`/api/projects/${key}/assets`)).map(String)); } catch { }
+        const todo = assetSink.filter(a => !have.has(String(a.id)));
+        for (let i = 0; i < todo.length; i++) {
+            await putAsset(`/api/projects/${key}`, todo[i], tr('에셋 업로드 실패 ({0}/{1})', i + 1, todo.length));
+            setBackupProg({ done: i + 1, total: todo.length });
+            onProgress?.(i + 1, todo.length);
+        }
+        return todo.length;
+    };
+
+    // The automatic backup runs itself every five minutes, so it must never block the screen.
+    // It used to raise a full-screen progress overlay, which stopped all work while it ran.
+    const doServerBackup = async (silent = true) => {
+        if (!serverAvailable || backupBusyRef.current) return;
+        backupBusyRef.current = true; setBackupBusy(true); setBackupProg(null);
+        try {
+            const key = getBackupKey();
+            const assetSink = [];
+            const data = await buildData(true, assetSink); // frames and audio go out as separate assets, keeping the JSON small
+            if (assetSink.length) await uploadAssetsDeduped(key, assetSink);
+            await apiFetch(`/api/backups/${key}`, {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: serverNameRef.current || localNameRef.current || tr('자동 백업'), data }),
+            });
+            setBackupAt(Date.now());
+            if (!silent) setToast(tr('서버에 백업했습니다.'));
+        } catch (e) {
+            if (!silent) setAppError(tr('서버 백업 실패: ') + e.message);
+        } finally { backupBusyRef.current = false; setBackupBusy(false); setBackupProg(null); }
+    };
+
+    const openBackupList = async () => {
+        try { setBackupList(await apiFetch(`/api/backups/${getBackupKey()}`)); }
+        catch (e) { alert(tr('백업 목록을 불러오지 못했습니다: ') + e.message); }
+    };
+
+    const doBackupRestore = async (stamp) => {
+        if (!window.confirm(tr('이 백업으로 되돌릴까요? 현재 작업 내용은 사라집니다.'))) return;
+        try {
+            const key = getBackupKey();
+            const data = await apiFetch(`/api/backups/${key}/${stamp}`);
+            if (!await restore(data, `/api/projects/${key}`)) return; // assets come from the same key
+            setBackupList(null);
+        } catch (e) { alert(tr('백업 복구 실패: ') + e.message); }
+    };
+
+    const doBackupDelete = async (stamp) => {
+        if (!window.confirm(tr('이 백업을 삭제할까요?'))) return;
+        try { await apiFetch(`/api/backups/${getBackupKey()}/${stamp}`, { method: 'DELETE' }); openBackupList(); }
+        catch (e) { alert(tr('삭제 실패: ') + e.message); }
+    };
+
+    // Periodic backup. Reads the newest state through a ref: putting `cuts` in the deps would
+    // restart the timer on every stroke, so it would never actually fire while you draw.
+    const backupFnRef = useRef(/** @type {typeof doServerBackup|null} */(null));
+    backupFnRef.current = doServerBackup;
+    useEffect(() => {
+        if (!serverAvailable) return;
+        const id = setInterval(() => {
+            const cs = liveRef.current?.cuts || [];
+            const sig = cs.length + ':' + cs.map(c => safeArray(c.layers).reduce((n, l) => n + safeArray(l.strokes).length, 0)).join(',');
+            if (sig === lastBackupSigRef.current) return; // nothing changed, so skip
+            lastBackupSigRef.current = sig;
+            backupFnRef.current?.(true);
+        }, BACKUP_EVERY_MS);
+        return () => clearInterval(id);
+    }, [serverAvailable, liveRef]);
+
+    return {
+        serverProjects, setServerProjects,
+        backupAt, backupBusy, backupList, setBackupList, backupProg,
+        serverIdRef, serverNameRef, forgetProject,
+        doServerSave, openServerList, doServerOpen, doServerDelete,
+        doServerBackup, openBackupList, doBackupRestore, doBackupDelete,
+    };
+}

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { apiFetch, fetchAsset, putAsset } from '../src/core/api.js';
+
+// A real server rather than a stubbed fetch, because the thing being tested is what fetch does
+// with a status code - and a stub would be me asserting my own assumption about that.
+
+let server, base, lastPut;
+
+const start = () => new Promise((res) => {
+    server = http.createServer((req, url) => { });
+    server.close();
+    server = http.createServer((req, reply) => {
+        const [path, query] = req.url.split('?');
+        if (path === '/ok') { reply.writeHead(200, { 'Content-Type': 'application/json' }); reply.end('{"id":"p_1","name":"Round Trip"}'); return; }
+        if (path === '/missing') { reply.writeHead(404, { 'Content-Type': 'application/json' }); reply.end('{"error":"not found"}'); return; }
+        if (path === '/broken') { reply.writeHead(500, { 'Content-Type': 'text/html' }); reply.end('<html>oops</html>'); return; }
+        if (path === '/blob') { reply.writeHead(200, { 'Content-Type': 'image/webp' }); reply.end(Buffer.from([1, 2, 3, 4])); return; }
+        if (path.includes('/asset/')) {
+            const chunks = [];
+            req.on('data', c => chunks.push(c));
+            req.on('end', () => {
+                lastPut = { path, query, type: req.headers['content-type'], bytes: Buffer.concat(chunks) };
+                if (path.includes('refuse')) { reply.writeHead(507); reply.end('{}'); return; }
+                reply.writeHead(200, { 'Content-Type': 'application/json' }); reply.end('{"ok":true}');
+            });
+            return;
+        }
+        reply.writeHead(404); reply.end('{}');
+    });
+    server.listen(0, () => { base = `http://127.0.0.1:${server.address().port}`; res(); });
+});
+
+test('apiFetch: a good response is parsed', async (t) => {
+    await start();
+    t.after(() => server.close());
+    assert.deepEqual(await apiFetch(`${base}/ok`), { id: 'p_1', name: 'Round Trip' });
+});
+
+// fetch resolves on a 404. Without the status check the caller parses the error body as its
+// answer - which is exactly how {"error":"not found"} once became a frame's image data.
+test('apiFetch: a 404 throws instead of returning the error body', async (t) => {
+    await start();
+    t.after(() => server.close());
+    await assert.rejects(() => apiFetch(`${base}/missing`), /HTTP 404/);
+    await assert.rejects(() => apiFetch(`${base}/broken`), /HTTP 500/);
+});
+
+test('fetchAsset: bytes come back as a Blob with their type', async (t) => {
+    await start();
+    t.after(() => server.close());
+    const blob = await fetchAsset(`${base}/blob`);
+    assert.equal(blob.type, 'image/webp');
+    assert.equal(blob.size, 4);
+    assert.deepEqual([...new Uint8Array(await blob.arrayBuffer())], [1, 2, 3, 4]);
+});
+
+test('fetchAsset: a missing asset throws rather than handing back the error page', async (t) => {
+    await start();
+    t.after(() => server.close());
+    await assert.rejects(() => fetchAsset(`${base}/missing`), /HTTP 404/);
+});
+
+test('putAsset: sends the blob itself, with its type and extension', async (t) => {
+    await start();
+    t.after(() => server.close());
+    const blob = new Blob([new Uint8Array([9, 9, 9])], { type: 'image/webp' });
+    await putAsset(`${base}/api/projects/p_1`, { id: 'frame7', ext: 'webp', blob }, 'nope');
+    assert.equal(lastPut.path, '/api/projects/p_1/asset/frame7');
+    assert.equal(lastPut.query, 'ext=webp');
+    assert.equal(lastPut.type, 'image/webp');
+    assert.deepEqual([...lastPut.bytes], [9, 9, 9]);
+});
+
+test('putAsset: a legacy dataURL is fetched back into a Blob first', async (t) => {
+    await start();
+    t.after(() => server.close());
+    const url = 'data:image/png;base64,' + Buffer.from([7, 7]).toString('base64');
+    await putAsset(`${base}/api/projects/p_1`, { id: 'old', ext: 'png', url }, 'nope');
+    assert.equal(lastPut.type, 'image/png');
+    assert.deepEqual([...lastPut.bytes], [7, 7]);
+});
+
+test('putAsset: a refused upload throws the message it was given, not a status code', async (t) => {
+    await start();
+    t.after(() => server.close());
+    const blob = new Blob([new Uint8Array([1])], { type: 'image/webp' });
+    await assert.rejects(
+        () => putAsset(`${base}/api/projects/refuse`, { id: 'f', ext: 'webp', blob }, '프레임 업로드 실패 (3/9)'),
+        /프레임 업로드 실패 \(3\/9\)/,
+        'the caller localises and numbers it, so the message has to survive',
+    );
+});
+
+test('putAsset: an extension is escaped rather than trusted into the query', async (t) => {
+    await start();
+    t.after(() => server.close());
+    const blob = new Blob([new Uint8Array([1])], { type: 'image/webp' });
+    await putAsset(`${base}/api/projects/p_1`, { id: 'f', ext: 'we bp&x=1', blob }, 'nope');
+    assert.equal(lastPut.query, 'ext=we%20bp%26x%3D1');
+});


### PR DESCRIPTION
## First, the question: is App separable, or is it a knot?

Measured rather than guessed:

```
App() logic:  3860 lines
99 useState/useStored/useReducer, 86 useRef, 33 effects
166 top-level function definitions
nine distinct concerns
```

**It is not spaghetti** — the pure logic is already extracted, the modules are tested, and the comments are alive. It is a God Component: one function doing nine jobs. Which is exactly the thing that makes it tiring to maintain, so the complaint is right.

So the question is not *"can a concern leave"* but *"which cut is narrowest"*. I measured the seam of four candidates — how many App names each reads, and how many of its own the rest of App reads back:

| candidate | names | reads from App |
|---|---|---|
| **server + backup** | 22 | **15** |
| panel docking + splitters | 21 | 22 |
| video import + scene detect | 16 | 29 |

Server storage won. Two hundred lines that never touch cuts, layers, strokes, the canvas or the timeline — **not the biggest concern in App, the one with the narrowest cut.**

## What stayed, and why

`buildData` and `restore` stay in App and arrive as two functions. Building a document reads most of App's state; restoring one writes most of it. Threading either in would have made the seam wider than the thing it separates.

`apiFetch` and `fetchAsset` went to `core/api.js` first — App's `restore` needs them too, and neither owns them: no state, only `fetch` and a status code. `putAsset` joined them, collapsing two upload loops that differed only in their error message.

## The numbers

| | before | after |
|---|---|---|
| App.jsx lines | 4324 | 4158 |
| useState / useStored / useReducer | 99 | 94 |
| useRef | 86 | 80 |
| top-level functions | 166 | 153 |

## Verification — this must change nothing

**Diffed the moved code against the original.** Five differences, every one intended: the two fetch wrappers leaving, the two upload loops becoming `putAsset`, the two-line ref reset becoming `forgetProject()`, a type annotation, and `5 * 60 * 1000` becoming a named constant. Everything else is byte-identical.

**Eight tests for `core/api.js` against a real `http.createServer`** — including the 404 that must throw rather than come back as a Blob, the upload message surviving so the caller can number it, and the extension being escaped into the query.

**The built bundle boots** with no console errors and the API probe still answers.

`npm run check` green — 744 tests.

## Next cuts, if this shape is right

Panel docking (seam 22) and video import (seam 29) are the next two, in that order. Each is a bigger chunk than this one and a wider seam, so they are worth doing one at a time with the same before/after diff.