### PR TITLE
refactor: panel geometry leaves App

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -526,6 +526,16 @@ the narrowest.
 |---|---|
 | `useServerStorage` | Save, open and delete server projects; snapshot every five minutes and rotate. Takes `buildData` and `restore` as functions rather than reaching for the document itself, because building one reads most of App's state and restoring one writes most of it - threading either in would make the seam wider than the thing it separates. |
 
+## `src/hooks/usePanelLayout.js`
+
+Where the panels are and how wide they are: three panels that each dock left, dock right or float,
+the drags that move and resize them, and the timeline's height. Pure geometry - it reads nothing
+about the document, which is what made it separable whole.
+
+| | |
+|---|---|
+| `usePanelLayout` | Owns the widths, the dock assignments, the floating positions and both drags. Returns the numbers to lay out with and three gesture starters. The panels themselves stay in App: a hook that returned them would need every prop each one takes, which is most of App. |
+
 ## `src/hooks/useServerProbe.js`
 
 Whether the project-storage API is reachable, re-checked with a backoff.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import { useHistory } from './hooks/useHistory.js';
 import { usePlayback } from './hooks/usePlayback.js';
 import { useServerProbe } from './hooks/useServerProbe.js';
 import { useServerStorage } from './hooks/useServerStorage.js';
+import { usePanelLayout } from './hooks/usePanelLayout.js';
 import { fetchAsset } from './core/api.js';
 import { useAutosave } from './hooks/useAutosave.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
@@ -252,17 +253,21 @@ export default function App() {
     const currentCut = cuts.find(c => c.id === currentCutId);
     const [loopPlay, setLoopPlay] = useState(false);
     const [playbackRate, setPlaybackRate] = useState(1);
-    const [rightW, setRightW] = useState(270);
     // Which tab the cut panel is showing. It follows the editor rather than being chosen: a text
     // you have just opened is the thing you want to see.
     const [rightTab, setRightTab] = useState('cut');
-    const [leftW, setLeftW] = useState(96);
-    const [colorW, setColorW] = useState(200);
-    const [timelineH, setTimelineH] = useState(240);
+    // Panel geometry: where each panel is docked, how wide it is, and the drags that change
+    // either. It reads nothing about the document, which is why it could leave whole.
+    const {
+        leftW, rightW, colorW, toolW, timelineH,
+        setLeftW, setRightW, setColorW, setTimelineH,
+        panelWidth, docks, floatPos, panelDrag,
+        onDockPointerDown, startPanelResize, startBottomResize,
+    } = usePanelLayout({ panelIds: PANEL_IDS, widthRange: PANEL_W });
+
     const [showLeft, setShowLeft] = useState(true);
     const [showRight, setShowRight] = useState(true);
     const [showBottom, setShowBottom] = useState(true);
-    const [splitter, setSplitter] = useState(null);
     // True while the playhead is being dragged. Rendering treats it as playback (see paintFrame).
     const [scrubbing, setScrubbing] = useState(false);
 
@@ -270,19 +275,6 @@ export default function App() {
 
     // Where each panel lives: 'left', 'right' or 'float'. Panels are drawn from these rather than
     // from fixed positions in the layout, so dragging one only has to change this value.
-    const [docks, setDocks] = useStored('mv_docks', { tools: 'left', color: 'left', cut: 'right' }, {
-        // A layout stored by a version that docked differently is treated as absent rather than
-        // restored into a shape this one cannot lay out.
-        decode: (raw) => { const v = JSON.parse(raw); return v && ['left', 'right', 'float'].includes(v.tools) ? v : undefined; },
-        encode: JSON.stringify,
-    });
-    const [floatPos, setFloatPos] = useStored('mv_floats',
-        { tools: { x: 120, y: 120 }, color: { x: 160, y: 160 }, cut: { x: 200, y: 200 } }, {
-        decode: (raw) => { const v = JSON.parse(raw); return v && typeof v === 'object' ? v : undefined; },
-        encode: JSON.stringify,
-    });
-    // The panel being dragged by its header, plus where it would land if dropped now.
-    const [panelDrag, setPanelDrag] = useState(null);
 
     const [snapLinePos, setSnapLinePos] = useState(null);
     // The audio and video tracks move together - loading audio sets four of these at once - so
@@ -937,24 +929,6 @@ export default function App() {
         }
     }, [currentTime, isPlaying, videoOverlay]);
 
-    useEffect(() => {
-        if (!splitter) return;
-        const mv = (e) => {
-            // Relative to grab point so the panel doesn't jump on first move (precise drag).
-            if (splitter.type === 'panel') {
-                // A left-docked panel grows as the pointer moves right; a right-docked one is the
-                // mirror image, so the sign follows the side it is docked to.
-                const delta = splitter.side === 'left' ? (e.clientX - splitter.startX) : (splitter.startX - e.clientX);
-                const [lo, hi] = PANEL_W[splitter.id] || PANEL_W.cut;
-                const w = Math.max(lo, Math.min(hi, splitter.startW + delta));
-                if (splitter.id === 'color') setColorW(w);
-                else if (splitter.id === 'tools') setLeftW(w);
-                else setRightW(w);
-            }
-            else if (splitter.type === 'bottom') setTimelineH(Math.max(100, Math.min(600, splitter.startH + (splitter.startY - e.clientY))));
-        };
-        return dragOnWindow(mv, () => setSplitter(null));
-    }, [splitter]);
 
     // Zoom the timeline about a screen x (cursor), keeping the time under it fixed. The scroll
     // adjustment is deferred to a layout effect so it runs after the new width is laid out.
@@ -3790,7 +3764,6 @@ export default function App() {
     };
 
     // Tool panel: the buttons keep a comfortable size and the column count follows the width.
-    const toolW = Math.max(56, leftW || 96);
     // Named rather than inlined as [!!textEdit]: a dependency the linter cannot read is a
     // dependency nobody can check. This way it runs when the editor opens or closes and not
     // on every keystroke, which would drag the user back from the cut list mid-edit.
@@ -3800,35 +3773,7 @@ export default function App() {
     const isSelectionTool = tool === 'lasso' || !!selection;
     liveRef.current = { cuts, copiedCut, selection, audioData, numTracks }; // current GC + history sources
 
-    const PANEL_ROOTS = { color: '.color-panel', tools: '.toolbar', cut: '.right-panel' };
-    const panelWidth = { color: colorW, tools: toolW, cut: rightW };
     const panelOpen = { color: leftDock === 'color', tools: showLeft, cut: showRight };
-
-    // Which dock a pointer position means. The edge bands are wide enough to hit on a tablet;
-    // anywhere else means the panel is being pulled out into its own window.
-    const dropZoneAt = (x) => (x < 140 ? 'left' : x > window.innerWidth - 140 ? 'right' : 'float');
-
-    // Header drag is delegated from main-content rather than wired into each panel, so ColorPanel
-    // and CutLayerPanel keep their own markup and know nothing about docking.
-    const onDockPointerDown = (e) => {
-        if (e.button !== undefined && e.button !== 0) return;
-        const head = e.target.closest?.('.panel-head');
-        if (!head) return;
-        if (e.target.closest('button, input, select, textarea')) return;   // ✕ and controls still work
-        const id = PANEL_IDS.find(p => head.closest(PANEL_ROOTS[p]));
-        if (!id) return;
-        e.preventDefault();
-        const host = head.closest(PANEL_ROOTS[id]).getBoundingClientRect();
-        const grab = { dx: e.clientX - host.left, dy: e.clientY - host.top };
-        setPanelDrag({ id, x: e.clientX, y: e.clientY, zone: dropZoneAt(e.clientX), ...grab });
-        const mv = (ev) => setPanelDrag(d => d && ({ ...d, x: ev.clientX, y: ev.clientY, zone: dropZoneAt(ev.clientX) }));
-        dragOnWindow(mv, (ev) => {
-            const zone = dropZoneAt(ev.clientX);
-            setPanelDrag(null);
-            setDocks(d => ({ ...d, [id]: zone }));
-            if (zone === 'float') setFloatPos(p => ({ ...p, [id]: { x: Math.max(0, ev.clientX - grab.dx), y: Math.max(0, ev.clientY - grab.dy) } }));
-        });
-    };
 
     // A docked panel keeps a splitter on the side that faces the canvas.
     const panelSplitter = (id, side) => (
@@ -3836,7 +3781,7 @@ export default function App() {
             title={tr('드래그로 패널 너비 조절')}
             onPointerDown={e => {
                 try { e.currentTarget.setPointerCapture(e.pointerId); } catch { }
-                setSplitter({ type: 'panel', id, side, startX: e.clientX, startW: panelWidth[id] });
+                startPanelResize(id, side, e.clientX);
             }} />
     );
 
@@ -4127,7 +4072,7 @@ export default function App() {
                 <div className="dock-hint" style={{ [panelDrag.zone]: 0 }} />
             )}
 
-            {showBottom && <div className="splitter-h" style={{ touchAction: 'none' }} onPointerDown={e => { try { e.currentTarget.setPointerCapture(e.pointerId); } catch { } setSplitter({ type: 'bottom', startY: e.clientY, startH: timelineH }); }} />}
+            {showBottom && <div className="splitter-h" style={{ touchAction: 'none' }} onPointerDown={e => { try { e.currentTarget.setPointerCapture(e.pointerId); } catch { } startBottomResize(e.clientY); }} />}
 
             <Timeline
                 activePartId={activePartId} audioData={audioData} audioFile={audioFile} audioRef={audioRef}

--- a/src/hooks/usePanelLayout.js
+++ b/src/hooks/usePanelLayout.js
@@ -1,0 +1,122 @@
+// Where the panels are and how wide they are.
+//
+// Three panels - tools, colour, cut/layer - each of which can sit in the left dock, the right
+// dock, or its own floating window, each draggable between those by its header and resizable by a
+// splitter. Plus the timeline's height, which is the same kind of thing.
+//
+// This is pure geometry: it reads nothing about the document. Not cuts, not layers, not the
+// canvas, not what is on the timeline. That is what makes it separable at all - the panels
+// themselves are built in App with their own props, and this only says where to put them and how
+// wide they are. A hook that returned the panels would need every prop each one takes, which is
+// most of App, and would have moved the tangle rather than reduced it.
+//
+// What stays in App: `panelOpen`, because which panels are open is decided by the menus and the
+// left dock's tabs, both of which live elsewhere; and the JSX that mounts a panel into a slot.
+
+import { useState, useEffect } from 'react';
+import { useStored } from './useStored.js';
+import { dragOnWindow } from '../core/windowDrag.js';
+
+/** The element each panel's markup is rooted in, for finding which one a header belongs to. */
+const PANEL_ROOTS = { color: '.color-panel', tools: '.toolbar', cut: '.right-panel' };
+
+/** How close to an edge counts as dropping into that dock. Wide enough to hit on a tablet. */
+const DOCK_BAND = 140;
+
+const TIMELINE_H_MIN = 100;
+const TIMELINE_H_MAX = 600;
+
+/**
+ * @param {object} opts
+ * @param {readonly string[]} opts.panelIds every panel that can be docked
+ * @param {Record<string, number[]>} opts.widthRange each panel's [min, max] width
+ */
+export function usePanelLayout({ panelIds, widthRange }) {
+    const [rightW, setRightW] = useState(270);
+    const [leftW, setLeftW] = useState(96);
+    const [colorW, setColorW] = useState(200);
+    const [timelineH, setTimelineH] = useState(240);
+    // The drag in progress: {type:'panel'|'bottom', …} while a splitter is held, else null.
+    const [splitter, setSplitter] = useState(/** @type {any} */(null));
+
+    const [docks, setDocks] = useStored('mv_docks', { tools: 'left', color: 'left', cut: 'right' }, {
+        // A layout stored by a version that docked differently is treated as absent rather than
+        // restored into a shape this one cannot lay out.
+        decode: (raw) => { const v = JSON.parse(raw); return v && ['left', 'right', 'float'].includes(v.tools) ? v : undefined; },
+        encode: JSON.stringify,
+    });
+    const [floatPos, setFloatPos] = useStored('mv_floats',
+        { tools: { x: 120, y: 120 }, color: { x: 160, y: 160 }, cut: { x: 200, y: 200 } }, {
+        decode: (raw) => { const v = JSON.parse(raw); return v && typeof v === 'object' ? v : undefined; },
+        encode: JSON.stringify,
+    });
+    const [panelDrag, setPanelDrag] = useState(/** @type {any} */(null));
+
+    // The tool strip has a floor of its own, below which its icons do not fit. Applied to the
+    // displayed width rather than the stored one, so widening it again returns to what was stored.
+    const toolW = Math.max(widthRange.tools?.[0] ?? 56, leftW || 96);
+    const panelWidth = { color: colorW, tools: toolW, cut: rightW };
+
+    /** Which dock a pointer position means; anywhere in the middle means "pull it out". */
+    const dropZoneAt = (x) => (x < DOCK_BAND ? 'left' : x > window.innerWidth - DOCK_BAND ? 'right' : 'float');
+
+    // Header drag is delegated from main-content rather than wired into each panel, so ColorPanel
+    // and CutLayerPanel keep their own markup and know nothing about docking.
+    const onDockPointerDown = (e) => {
+        if (e.button !== undefined && e.button !== 0) return;
+        const head = e.target.closest?.('.panel-head');
+        if (!head) return;
+        if (e.target.closest('button, input, select, textarea')) return;   // ✕ and controls still work
+        const id = panelIds.find(p => head.closest(PANEL_ROOTS[p]));
+        if (!id) return;
+        e.preventDefault();
+        const host = head.closest(PANEL_ROOTS[id]).getBoundingClientRect();
+        const grab = { dx: e.clientX - host.left, dy: e.clientY - host.top };
+        setPanelDrag({ id, x: e.clientX, y: e.clientY, zone: dropZoneAt(e.clientX), ...grab });
+        const mv = (ev) => setPanelDrag(d => d && ({ ...d, x: ev.clientX, y: ev.clientY, zone: dropZoneAt(ev.clientX) }));
+        dragOnWindow(mv, (ev) => {
+            const zone = dropZoneAt(ev.clientX);
+            setPanelDrag(null);
+            setDocks(d => ({ ...d, [id]: zone }));
+            if (zone === 'float') setFloatPos(p => ({ ...p, [id]: { x: Math.max(0, ev.clientX - grab.dx), y: Math.max(0, ev.clientY - grab.dy) } }));
+        });
+    };
+
+    /** Begin resizing a docked panel. `side` is the edge it is docked to, which decides the sign. */
+    const startPanelResize = (id, side, clientX) =>
+        setSplitter({ type: 'panel', id, side, startX: clientX, startW: panelWidth[id] });
+
+    /** Begin resizing the timeline. It grows upward, so its sign is the opposite of a panel's. */
+    const startBottomResize = (clientY) =>
+        setSplitter({ type: 'bottom', startY: clientY, startH: timelineH });
+
+    // The drag runs on the window rather than on the splitter, so a gesture that leaves the
+    // element keeps working and still ends when the button comes up somewhere else. Movement is
+    // measured from the grab point, so the panel does not jump on the first move.
+    useEffect(() => {
+        if (!splitter) return;
+        const mv = (e) => {
+            if (splitter.type === 'panel') {
+                // A left-docked panel grows as the pointer moves right; a right-docked one is the
+                // mirror image, so the sign follows the side it is docked to.
+                const delta = splitter.side === 'left' ? (e.clientX - splitter.startX) : (splitter.startX - e.clientX);
+                const [lo, hi] = widthRange[splitter.id] || widthRange.cut;
+                const w = Math.max(lo, Math.min(hi, splitter.startW + delta));
+                if (splitter.id === 'color') setColorW(w);
+                else if (splitter.id === 'tools') setLeftW(w);
+                else setRightW(w);
+            }
+            else if (splitter.type === 'bottom') {
+                setTimelineH(Math.max(TIMELINE_H_MIN, Math.min(TIMELINE_H_MAX, splitter.startH + (splitter.startY - e.clientY))));
+            }
+        };
+        return dragOnWindow(mv, () => setSplitter(null));
+    }, [splitter, widthRange]);
+
+    return {
+        leftW, rightW, colorW, toolW, timelineH,
+        setLeftW, setRightW, setColorW, setTimelineH,
+        panelWidth, docks, floatPos, panelDrag,
+        onDockPointerDown, startPanelResize, startBottomResize,
+    };
+}


### PR DESCRIPTION
## The second cut, and a narrower seam than the first

This hook reads **nothing** from App. Where the panels are docked, how wide they are, the header drag that moves one between docks, the splitter drag that resizes it, and the timeline's height — none of it touches cuts, layers, strokes or the canvas.

**What stays, and why:** `panelOpen`, because which panels are open is decided by the menus and the left dock's tabs, both of which live elsewhere; and the JSX that mounts a panel into a slot. A hook that returned the panels *themselves* would need every prop each one takes — which is most of App. That would have moved the tangle rather than reduced it.

## Two things the move improved rather than just relocated

- **The bottom splitter wrote `setSplitter({type:'bottom', …})` inline in the JSX** while panel splitters went through a helper. Both are `startPanelResize` / `startBottomResize` now, and the shape of a splitter object is no longer something the JSX has to know.
- **The drag effect listed `[splitter]`** and reached for `PANEL_W` from module scope. It takes the ranges as an argument now and lists them, so the dependency is real rather than implied — and the hook baseline is **unchanged at 9**, so this added no new warning.

## Faithfulness

This must change nothing, so both moved blocks were diffed against the originals:

| block | every difference |
|---|---|
| dock drag | one line — `PANEL_IDS` became the `panelIds` parameter |
| splitter drag | two magic numbers became named constants, `PANEL_W` became the `widthRange` argument, one statement gained braces |

The validating codecs for `mv_docks` and `mv_floats` moved **verbatim**, including the default float positions — a layout stored by a version that docked differently is still treated as absent rather than restored into a shape this one cannot lay out. I checked those before writing them, having first assumed they were plain `jsonCodec`; they were not.

## The numbers

| | after #119 | now |
|---|---|---|
| App.jsx lines | 4157 | 4103 |
| useState / useStored / useReducer | 94 | 86 |
| effects | 32 | 31 |
| top-level functions | 153 | 151 |

## Verification

`npm run check` green — 744 tests. Built bundle boots with no console errors.

Worth noting how the smoke run went: it **failed first** with *"the API is not reachable"* because I had not restarted the server after the previous extraction. It reports what it finds rather than what I hoped, which is the point of having it. Passed once the API was up.

## Next

Video import + scene detect, seam 29 — the widest of the three candidates, so it will need splitting into more than one hook rather than lifted whole.