### PR TITLE
refactor: the arithmetic inside a video import becomes testable

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -85,6 +85,20 @@ Clipping: a layer that only shows where the layer beneath it has paint.
 | `canClip` | Whether the clip toggle would do anything. False only for the bottom layer, which has nothing to clip to. |
 | `clipGroups` | Which layers clip to which base. A run of clipped layers all attach to the same base, and a clipped layer with nothing below it draws normally rather than vanishing. |
 
+## `src/core/videoCuts.js`
+
+Turning extracted video frames into cuts: the arithmetic in the middle of the import, with the
+file reading and the bitmap storing taken off either end. It was inline in a function that also
+picks a canvas size, decodes a video, stores blobs, loads the audio and moves the playhead - so
+the part with the actual rules in it was the part nobody could test.
+
+| | |
+|---|---|
+| `importPlacement` | Which track an import goes on and where it starts: after whatever is already on that track, so a second video does not land on the first. Cuts from the same source are ignored, since a re-import replaces them. |
+| `frameDurations` | How long each frame lasts. One frame's worth, except where the extractor collapsed a run of identical frames - a held frame spans its whole run, so a still shot stays still. Never zero: a cut of no length cannot be selected. |
+| `partAssigner` | Which part each frame belongs to. Split by count, so the last part is the short one; with a single part there are no part suffixes at all. |
+| `buildImportedCuts` | The cuts themselves, laid end to end, each holding one paste stroke of its frame - which is what makes an imported frame drawable over rather than a background. |
+
 ## `src/core/viewZoom.js`
 
 How far the canvas view may be zoomed. It was in three places and they disagreed: pinch and the

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ import {
 import { cloneCutContents as cloneCutContentsPure } from './core/cutClone.js';
 import { DEFAULT_KEYS, KEY_LABELS, keyOf, matchShortcut, keymapFrom, toolFromAction, findConflicts } from './core/shortcuts.js';
 import { derivePartsFrom, deriveVideoBatches } from './core/partOps.js';
+import { importPlacement, buildImportedCuts } from './core/videoCuts.js';
 import { playRange } from './core/playRange.js';
 import { clampBrush, brushUp, brushDown } from './core/brushSize.js';
 import {
@@ -3495,10 +3496,7 @@ export default function App() {
             }
             // Re-importing the same source replaces its old frames instead of piling up duplicates.
             const srcKey = cfg.srcKey;
-            const kept = cuts.filter(c => c.videoSrc !== srcKey);
-            const track = kept.find(c => c.id === currentCutId)?.track ?? 0;
-            const startAt = kept.filter(c => c.track === track).reduce((m, c) => Math.max(m, c.endTime), 0);
-            const dur = 1 / Math.max(0.1, fps);
+            const { track, startAt } = importPlacement(cuts, srcKey, currentCutId);
             // The batch key comes from an id rather than the clock so that importing twice in
             // quick succession cannot produce two batches with the same name.
             const batch = 'vb_' + nextId().toString(36);
@@ -3506,26 +3504,15 @@ export default function App() {
             // Native-res frames keep the source aspect, so letterbox-fit them into the canvas;
             // compressed frames are already pre-letterboxed to the canvas (full-canvas paste).
             const fit = (isNative && fW && fH) ? fitRect(fW, fH, TW, TH) : { x: 0, y: 0, w: TW, h: TH };
-            const px = Math.round(fit.x), py = Math.round(fit.y), pw = Math.round(fit.w), ph = Math.round(fit.h);
-            // Split the import into N sequential parts (part1~n) so a long video comes in already
-            // organized. videoBatch stays one value (the frame manager deletes the whole import).
-            const nParts = Math.max(1, Math.min(frames.length, Math.floor(cfg.parts) || 1));
-            const perPart = Math.ceil(frames.length / nParts);
-            const made = [];
-            let t = startAt;
-            for (let i = 0; i < frames.length; i++) {
-                const bitmapId = await storeBitmapBlob(frames[i], fW, fH);
-                const s = t, e = t + dur * (holds[i] || 1); // held frames span their whole duplicate run
-                t = e;
-                const pIdx = nParts > 1 ? Math.floor(i / perPart) : 0;
-                const partId = nParts > 1 ? `${batch}_p${pIdx}` : batch;
-                const partName = nParts > 1 ? `${label} ${pIdx + 1}` : label;
-                made.push({
-                    id: nextId(), name: `${label} ${i + 1}`, startTime: s, endTime: e, track,
-                    activeLayerId: 1, texts: [], videoBatch: batch, videoLabel: label, videoSrc: srcKey, partId, partName,
-                    layers: [{ id: 1, name: 'L1', type: 'layer', parentId: null, visible: true, redoStrokes: [], strokes: [{ id: nextId(), tool: 'paste', bitmapId, x: px, y: py, w: pw, h: ph }] }],
-                });
-            }
+            const rect = { x: Math.round(fit.x), y: Math.round(fit.y), w: Math.round(fit.w), h: Math.round(fit.h) };
+            // Storing the blobs is the only part of this that has to happen here: everything after
+            // it - where the cuts go, how long each lasts, which part it belongs to - is arithmetic,
+            // and lives in core/videoCuts.js where it can be tested.
+            const bitmapIds = [];
+            for (let i = 0; i < frames.length; i++) bitmapIds.push(await storeBitmapBlob(frames[i], fW, fH));
+            const made = buildImportedCuts({
+                bitmapIds, holds, fps, track, startAt, batch, label, srcKey, parts: cfg.parts, rect, nextId,
+            });
             dispatchCuts(replaceBatchCuts(srcKey, made));
             setCurrentCutId(made[0].id);
             setCurrentTime(made[0].startTime);

--- a/src/core/videoCuts.js
+++ b/src/core/videoCuts.js
@@ -1,0 +1,127 @@
+// Turning extracted video frames into cuts.
+//
+// This is the arithmetic in the middle of the import, with the file reading and the bitmap storing
+// taken off either end. It was inline in a function that also picks a canvas size, decodes a
+// video, stores blobs, loads the audio and moves the playhead - so the part with the actual rules
+// in it was the part nobody could test.
+//
+// The rules, all of which have a reason someone hit:
+//
+//   held frames     the extractor collapses runs of identical frames and reports how many each
+//                   one stood for. A held frame spans its whole run, so a still shot stays still
+//                   for as long as it was still, rather than being one frame followed by a gap.
+//   where they go   after whatever is already on the chosen track, not at zero, so importing a
+//                   second video does not land on top of the first.
+//   which track     the one the current cut sits on, so an import goes where the user is looking.
+//   re-import       cuts from the same source are replaced rather than added to, so importing the
+//                   same file twice does not double it. That is why every cut carries videoSrc.
+//   parts           a long video arrives already grouped. The split is by count, so the last part
+//                   is the short one.
+
+/**
+ * Where a run of imported cuts should start, and on which track.
+ *
+ * @param {Array<{id: any, track: number, startTime: number, endTime: number, videoSrc?: string}>} cuts
+ *   the cuts already in the project
+ * @param {string} srcKey the source being imported; its existing cuts are ignored, since they are
+ *   about to be replaced
+ * @param {any} currentCutId which cut is selected, deciding the track
+ * @returns {{track: number, startAt: number}}
+ */
+export function importPlacement(cuts, srcKey, currentCutId) {
+    const kept = (Array.isArray(cuts) ? cuts : []).filter(c => c && c.videoSrc !== srcKey);
+    const track = kept.find(c => c.id === currentCutId)?.track ?? 0;
+    const startAt = kept.filter(c => c.track === track)
+        .reduce((m, c) => Math.max(m, Number(c.endTime) || 0), 0);
+    return { track, startAt };
+}
+
+/**
+ * How long each imported frame lasts, in order.
+ *
+ * One frame's worth each, except where the extractor collapsed duplicates - those last for as
+ * many frames as they stood in for. A missing or nonsense hold counts as one, because a frame
+ * that lasts zero seconds is a cut that cannot be selected.
+ *
+ * @param {number[]} holds how many source frames each extracted frame represents
+ * @param {number} count how many frames there are
+ * @param {number} fps
+ * @returns {number[]}
+ */
+export function frameDurations(holds, count, fps) {
+    const dur = 1 / Math.max(0.1, Number(fps) || 0);
+    const out = new Array(count);
+    for (let i = 0; i < count; i++) {
+        const held = Math.max(1, Math.floor(Number(holds?.[i]) || 1));
+        out[i] = dur * held;
+    }
+    return out;
+}
+
+/**
+ * Which part each frame belongs to, and what that part is called.
+ *
+ * Split by count rather than by duration: the parts are meant to be even handfuls of cuts, and
+ * held frames would otherwise make one part much longer than another. With one part there are no
+ * part suffixes at all, so an import that was not split reads the way it always did.
+ *
+ * @param {number} count how many frames
+ * @param {number} parts how many groups to make
+ * @param {string} batch the batch id every cut carries
+ * @param {string} label the name the user gave the import
+ * @returns {(i: number) => {partId: string, partName: string}}
+ */
+export function partAssigner(count, parts, batch, label) {
+    const n = Math.max(1, Math.min(count || 1, Math.floor(Number(parts)) || 1));
+    if (n <= 1) return () => ({ partId: batch, partName: label });
+    const perPart = Math.ceil(count / n);
+    return (i) => {
+        const p = Math.floor(i / perPart);
+        return { partId: `${batch}_p${p}`, partName: `${label} ${p + 1}` };
+    };
+}
+
+/**
+ * The cuts an import produces, one per extracted frame.
+ *
+ * Every frame becomes a cut holding a single paste stroke of its bitmap - which is what makes an
+ * imported frame drawable over rather than a background layer.
+ *
+ * @param {object} opts
+ * @param {string[]} opts.bitmapIds one per frame, already stored
+ * @param {number[]} opts.holds
+ * @param {number} opts.fps
+ * @param {number} opts.track
+ * @param {number} opts.startAt
+ * @param {string} opts.batch
+ * @param {string} opts.label
+ * @param {string} opts.srcKey
+ * @param {number} opts.parts
+ * @param {{x: number, y: number, w: number, h: number}} opts.rect where each frame is pasted
+ * @param {() => any} opts.nextId
+ * @returns {any[]}
+ */
+export function buildImportedCuts({ bitmapIds, holds, fps, track, startAt, batch, label, srcKey, parts, rect, nextId }) {
+    const durations = frameDurations(holds, bitmapIds.length, fps);
+    const partOf = partAssigner(bitmapIds.length, parts, batch, label);
+    const made = [];
+    let t = startAt;
+    for (let i = 0; i < bitmapIds.length; i++) {
+        const start = t;
+        t = start + durations[i];
+        const { partId, partName } = partOf(i);
+        made.push({
+            id: nextId(),
+            name: `${label} ${i + 1}`,
+            startTime: start, endTime: t, track,
+            activeLayerId: 1, texts: [],
+            videoBatch: batch, videoLabel: label, videoSrc: srcKey,
+            partId, partName,
+            layers: [{
+                id: 1, name: 'L1', type: 'layer', parentId: null, visible: true, redoStrokes: [],
+                strokes: [{ id: nextId(), tool: 'paste', bitmapId: bitmapIds[i], x: rect.x, y: rect.y, w: rect.w, h: rect.h }],
+            }],
+        });
+    }
+    return made;
+}

--- a/test/videoCuts.test.js
+++ b/test/videoCuts.test.js
@@ -1,0 +1,155 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { importPlacement, frameDurations, partAssigner, buildImportedCuts } from '../src/core/videoCuts.js';
+
+const rect = { x: 0, y: 0, w: 1920, h: 1080 };
+const ids = (n) => { let i = 0; return () => ++i; };
+
+test('placement: an import lands after what is already on the track', () => {
+    const cuts = [
+        { id: 1, track: 0, startTime: 0, endTime: 3 },
+        { id: 2, track: 0, startTime: 3, endTime: 7 },
+        { id: 3, track: 1, startTime: 0, endTime: 40 },
+    ];
+    assert.deepEqual(importPlacement(cuts, 'newsrc', 1), { track: 0, startAt: 7 },
+        'starting at zero would drop the import on top of what is there');
+});
+
+test('placement: the track is the one the selected cut is on', () => {
+    const cuts = [
+        { id: 1, track: 0, startTime: 0, endTime: 3 },
+        { id: 2, track: 2, startTime: 0, endTime: 9 },
+    ];
+    assert.deepEqual(importPlacement(cuts, 'newsrc', 2), { track: 2, startAt: 9 });
+});
+
+// Re-importing the same file replaces its cuts, so those cuts must not push the new ones along -
+// otherwise every re-import would start later than the last.
+test('placement: cuts from the same source are ignored, since they are about to be replaced', () => {
+    const cuts = [
+        { id: 1, track: 0, startTime: 0, endTime: 3 },
+        { id: 2, track: 0, startTime: 3, endTime: 90, videoSrc: 'same' },
+    ];
+    assert.deepEqual(importPlacement(cuts, 'same', 1), { track: 0, startAt: 3 });
+});
+
+test('placement: an empty project starts at zero on track zero', () => {
+    assert.deepEqual(importPlacement([], 'x', null), { track: 0, startAt: 0 });
+    assert.deepEqual(importPlacement(null, 'x', null), { track: 0, startAt: 0 });
+});
+
+test('placement: a selected cut that is gone falls back to track zero', () => {
+    const cuts = [{ id: 1, track: 3, startTime: 0, endTime: 5 }];
+    assert.deepEqual(importPlacement(cuts, 'x', 999), { track: 0, startAt: 0 });
+});
+
+test('durations: one frame each at the import fps', () => {
+    assert.deepEqual(frameDurations([], 3, 10), [0.1, 0.1, 0.1]);
+});
+
+// A still shot is collapsed to one frame that stood for many; it has to last as long as the run
+// it replaced, or the still would flash past and leave a gap.
+test('durations: a held frame lasts for the whole run it stands in for', () => {
+    assert.deepEqual(frameDurations([1, 5, 2], 3, 10), [0.1, 0.5, 0.2]);
+});
+
+test('durations: a missing or nonsense hold is one frame, never zero', () => {
+    assert.deepEqual(frameDurations([0, -4, NaN, undefined, 'x'], 5, 10), [0.1, 0.1, 0.1, 0.1, 0.1],
+        'a cut of zero length cannot be selected');
+});
+
+test('durations: an impossible fps does not divide by zero', () => {
+    assert.ok(frameDurations([], 1, 0)[0] > 0 && Number.isFinite(frameDurations([], 1, 0)[0]));
+    assert.ok(Number.isFinite(frameDurations([], 1, NaN)[0]));
+});
+
+test('parts: one part means no part suffixes at all', () => {
+    const of = partAssigner(10, 1, 'vb_1', 'Clip');
+    assert.deepEqual(of(0), { partId: 'vb_1', partName: 'Clip' });
+    assert.deepEqual(of(9), { partId: 'vb_1', partName: 'Clip' });
+});
+
+test('parts: split by count, so the last part is the short one', () => {
+    const of = partAssigner(10, 3, 'vb_1', 'Clip');           // ceil(10/3) = 4 per part
+    assert.deepEqual(of(0).partName, 'Clip 1');
+    assert.deepEqual(of(3).partName, 'Clip 1');
+    assert.deepEqual(of(4).partName, 'Clip 2');
+    assert.deepEqual(of(8).partName, 'Clip 3');
+    assert.deepEqual(of(9).partName, 'Clip 3');
+});
+
+test('parts: asking for more parts than frames does not make empty ones', () => {
+    const of = partAssigner(3, 99, 'vb_1', 'Clip');
+    const names = [0, 1, 2].map(i => of(i).partName);
+    assert.deepEqual(names, ['Clip 1', 'Clip 2', 'Clip 3']);
+});
+
+test('parts: nonsense falls back to one part', () => {
+    assert.deepEqual(partAssigner(5, NaN, 'vb_1', 'Clip')(0), { partId: 'vb_1', partName: 'Clip' });
+    assert.deepEqual(partAssigner(5, 0, 'vb_1', 'Clip')(0), { partId: 'vb_1', partName: 'Clip' });
+});
+
+// Times accumulate rather than being computed from the index, which is what the import has always
+// done - 2.1 + 0.3 lands on 2.4000000000000004. The drift is a thousandth of a nanosecond per
+// frame, so it is compared with a tolerance rather than pretended away or "fixed" into a change
+// of behaviour. What must hold exactly is that each cut starts where the previous one ended.
+const near = (a, b, why) => assert.ok(Math.abs(a - b) < 1e-9, `${why}: ${a} vs ${b}`);
+
+test('cuts: laid end to end with no gaps, holds included', () => {
+    const made = buildImportedCuts({
+        bitmapIds: ['b0', 'b1', 'b2'], holds: [1, 3, 1], fps: 10,
+        track: 1, startAt: 2, batch: 'vb_1', label: 'Clip', srcKey: 'src', parts: 1, rect, nextId: ids(),
+    });
+    const want = [[2, 2.1], [2.1, 2.4], [2.4, 2.5]];
+    made.forEach((c, i) => {
+        near(c.startTime, want[i][0], `cut ${i} start`);
+        near(c.endTime, want[i][1], `cut ${i} end`);
+        assert.equal(c.track, 1);
+    });
+    for (let i = 1; i < made.length; i++) {
+        assert.equal(made[i].startTime, made[i - 1].endTime, 'a gap here would be a frame of nothing');
+    }
+});
+
+test('cuts: each frame becomes one paste stroke of its own bitmap', () => {
+    const made = buildImportedCuts({
+        bitmapIds: ['b0', 'b1'], holds: [], fps: 10,
+        track: 0, startAt: 0, batch: 'vb_1', label: 'Clip', srcKey: 'src', parts: 1,
+        rect: { x: 0, y: 140, w: 1920, h: 800 }, nextId: ids(),
+    });
+    assert.equal(made.length, 2);
+    const s = made[1].layers[0].strokes[0];
+    assert.equal(s.tool, 'paste');
+    assert.equal(s.bitmapId, 'b1');
+    assert.deepEqual([s.x, s.y, s.w, s.h], [0, 140, 1920, 800], 'the letterbox rect is where it is pasted');
+    assert.equal(made[0].layers[0].id, 1);
+    assert.equal(made[0].activeLayerId, 1);
+});
+
+test('cuts: every id is distinct, which is what stops a batch selecting the wrong cut', () => {
+    const made = buildImportedCuts({
+        bitmapIds: ['a', 'b', 'c', 'd'], holds: [], fps: 12,
+        track: 0, startAt: 0, batch: 'vb_1', label: 'Clip', srcKey: 'src', parts: 2, rect, nextId: ids(),
+    });
+    const seen = new Set(made.map(c => c.id));
+    assert.equal(seen.size, made.length);
+});
+
+test('cuts: every cut carries the source, so a re-import can find and replace them', () => {
+    const made = buildImportedCuts({
+        bitmapIds: ['a', 'b'], holds: [], fps: 12,
+        track: 0, startAt: 0, batch: 'vb_9', label: 'Clip', srcKey: 'file:abc', parts: 1, rect, nextId: ids(),
+    });
+    for (const c of made) {
+        assert.equal(c.videoSrc, 'file:abc');
+        assert.equal(c.videoBatch, 'vb_9');
+        assert.equal(c.videoLabel, 'Clip');
+    }
+});
+
+test('cuts: no frames is no cuts, not one empty one', () => {
+    assert.deepEqual(buildImportedCuts({
+        bitmapIds: [], holds: [], fps: 12, track: 0, startAt: 0,
+        batch: 'vb_1', label: 'Clip', srcKey: 'src', parts: 3, rect, nextId: ids(),
+    }), []);
+});


### PR DESCRIPTION
## The third candidate does not come out whole, and here is why

`runVideoImport` reads **twenty-four** things — because it is the point where a video *becomes a document*. It picks a canvas size, decodes the file, stores blobs, makes cuts, loads the audio and moves the playhead. Wrapping that in a hook would thread twenty-four names through a parameter list and call it separation.

What *can* leave is the part in the middle with the rules in it, which is arithmetic:

| | |
|---|---|
| `importPlacement` | which track, and where on it |
| `frameDurations` | how long each frame lasts, holds included |
| `partAssigner` | which part a frame belongs to |
| `buildImportedCuts` | the cuts themselves |

**Every one of those has a reason someone hit:**

- An import lands *after* what is already on the track, or a second video sits on top of the first.
- It goes on the track the **selected cut** is on, so it arrives where you are looking.
- Cuts from the same source are **ignored when placing**, because a re-import replaces them — if they were counted, every re-import would start later than the last.
- A **held frame** spans the whole run of duplicates it stood in for, so a still shot stays still instead of flashing past and leaving a gap.
- Parts split **by count**, so the last one is the short one.

None of it was reachable from a test before, being inside a function that needs a video file and a browser. **Eighteen tests now.**

## Two things worth being explicit about

**Times accumulate** rather than being computed from an index — `2.1 + 0.3` lands on `2.4000000000000004` — which is what the import has always done. The test compares with a tolerance rather than me "fixing" it into a change of behaviour, and asserts the thing that *must* be exact: each cut starts where the previous one ended.

**`frameDurations` floors a hold**, where the old code used it as given. In practice that changes nothing — the extractor only ever writes `1` and increments it, which I checked rather than assumed — but it is a difference, and the tests cover what it does with junk.

## Numbers

App.jsx 4103 → 4089. `npm run check` green — 762 tests.

## Needs a real check

This one touches the import path, which no automated check here can drive. Asking for a manual pass — details in the conversation.