### PR TITLE
feat: a ZIP that can be written one piece at a time

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -601,6 +601,16 @@ Which addresses the importer will hand to yt-dlp.
 | `isYouTubeUrl` | Parses rather than pattern-matches, because both obvious string checks are wrong in opposite directions. |
 | `YOUTUBE_HOSTS` | Hosts yt-dlp is allowed to be pointed at. |
 
+## `src/export/byteWriter.js`
+
+A growable byte buffer, little-endian. Both export formats want one for the same reason: a JS array
+holds each byte as a number - eight bytes of heap per byte of output - so a handful of full-size
+frames becomes hundreds of megabytes before anything is written.
+
+| | |
+|---|---|
+| `ByteWriter` | Doubles a Uint8Array instead of collecting bytes in an array. `u32` uses `>>>` so a CRC or an offset with its top bit set does not come out negative and write the wrong bytes. |
+
 ## `src/export/download.js`
 
 Handing a finished file to the browser. Written three times over - the project save's fallback,
@@ -631,6 +641,7 @@ A store-only ZIP writer, for the PNG frame sequence a transparent project export
 
 | | |
 |---|---|
+| `ZipWriter` | A ZIP being written one entry at a time. `makeZip` is this with every entry handed over at once. The whole-archive version had to know all of them first, to allocate one exact buffer - fine for one project, wrong for a queue of them (#123), which works by never holding more than one piece. Entry bytes are copied in, so a caller may reuse one buffer per frame. |
 | `makeZip` | Builds the archive in memory. Store-only because PNGs are already deflated, which keeps this pure arithmetic that unit tests can check without a browser. Refuses zip64-sized input rather than writing a wrong header. |
 | `crc32` | The checksum ZIP entries carry. Table built on first use. |
 | `dosDateTime` | Packs a `Date` into the two 16-bit fields the format stores. Clamps below 1980 instead of writing a negative year. |

--- a/scripts/helper-index.mjs
+++ b/scripts/helper-index.mjs
@@ -35,6 +35,10 @@ function exportsOf(source) {
     const names = new Set();
     for (const m of source.matchAll(/^export\s+(?:async\s+)?function\s+(\w+)/gm)) names.add(m[1]);
     for (const m of source.matchAll(/^export\s+const\s+(\w+)\s*=/gm)) names.add(m[1]);
+    // Classes were invisible here until ByteWriter and ZipWriter arrived, which is the one
+    // kind of gap this check cannot afford: a shared export the index cannot see is exactly
+    // the export someone writes a second time.
+    for (const m of source.matchAll(/^export\s+class\s+(\w+)/gm)) names.add(m[1]);
     return [...names];
 }
 

--- a/src/export/byteWriter.js
+++ b/src/export/byteWriter.js
@@ -1,0 +1,47 @@
+/**
+ * A growable byte buffer.
+ *
+ * The obvious thing is to collect bytes in a plain array and convert at the end, and for a small
+ * picture it is fine. A full-size frame is two million pixels, and a JS array holds each byte as
+ * a number - eight bytes of heap for one byte of output - so a handful of frames turns into
+ * hundreds of megabytes before anything is written. This doubles a Uint8Array instead.
+ *
+ * Both export formats want one, and they want it for the same reason, so it lives here rather
+ * than inside whichever of them was written first. Everything is little-endian, which is what
+ * both GIF and ZIP use.
+ */
+export class ByteWriter {
+    constructor(capacity = 1 << 16) {
+        this.buf = new Uint8Array(capacity);
+        this.len = 0;
+    }
+    _room(n) {
+        if (this.len + n <= this.buf.length) return;
+        let size = this.buf.length;
+        while (size < this.len + n) size *= 2;
+        const next = new Uint8Array(size);
+        next.set(this.buf.subarray(0, this.len));
+        this.buf = next;
+    }
+    u8(v) { this._room(1); this.buf[this.len++] = v & 255; }
+    u16(v) { this._room(2); this.buf[this.len++] = v & 255; this.buf[this.len++] = (v >> 8) & 255; }
+    u32(v) {
+        this._room(4);
+        // >>> rather than >>, so a value with the top bit set - a CRC, or an offset past 2GB -
+        // does not come out as a negative number and write the wrong bytes.
+        this.buf[this.len++] = v & 255;
+        this.buf[this.len++] = (v >>> 8) & 255;
+        this.buf[this.len++] = (v >>> 16) & 255;
+        this.buf[this.len++] = (v >>> 24) & 255;
+    }
+    str(text) { this._room(text.length); for (let i = 0; i < text.length; i++) this.buf[this.len++] = text.charCodeAt(i); }
+    bytes(arr) { this._room(arr.length); this.buf.set(arr, this.len); this.len += arr.length; }
+    /** How many bytes have been written, which is also the offset the next one lands at. */
+    get position() { return this.len; }
+    /** @returns {Uint8Array<ArrayBuffer>} backed by a plain ArrayBuffer, ready for a Blob. */
+    done() {
+        const out = new Uint8Array(new ArrayBuffer(this.len));
+        out.set(this.buf.subarray(0, this.len));
+        return out;
+    }
+}

--- a/src/export/gif.js
+++ b/src/export/gif.js
@@ -14,38 +14,7 @@
 //     drawing. Line art and flat colour are comfortable inside that; a photographic frame is not.
 //   - delays are in hundredths of a second, so the frame rate is quantised.
 
-/**
- * A growable byte buffer.
- *
- * The obvious thing is to collect bytes in a plain array and convert at the end, and for a small
- * picture it is fine. A full-size frame is two million pixels, and a JS array holds each byte as
- * a number - eight bytes of heap for one byte of output - so a handful of frames turns into
- * hundreds of megabytes before anything is written. This doubles a Uint8Array instead.
- */
-class ByteWriter {
-    constructor(capacity = 1 << 16) {
-        this.buf = new Uint8Array(capacity);
-        this.len = 0;
-    }
-    _room(n) {
-        if (this.len + n <= this.buf.length) return;
-        let size = this.buf.length;
-        while (size < this.len + n) size *= 2;
-        const next = new Uint8Array(size);
-        next.set(this.buf.subarray(0, this.len));
-        this.buf = next;
-    }
-    u8(v) { this._room(1); this.buf[this.len++] = v & 255; }
-    u16(v) { this._room(2); this.buf[this.len++] = v & 255; this.buf[this.len++] = (v >> 8) & 255; }
-    str(text) { this._room(text.length); for (let i = 0; i < text.length; i++) this.buf[this.len++] = text.charCodeAt(i); }
-    bytes(arr) { this._room(arr.length); this.buf.set(arr, this.len); this.len += arr.length; }
-    /** @returns {Uint8Array<ArrayBuffer>} backed by a plain ArrayBuffer, ready for a Blob. */
-    done() {
-        const out = new Uint8Array(new ArrayBuffer(this.len));
-        out.set(this.buf.subarray(0, this.len));
-        return out;
-    }
-}
+import { ByteWriter } from './byteWriter.js';
 
 const TRANSPARENT = 0;   // palette slot 0 is reserved for it, so every frame agrees where it is.
 

--- a/src/export/zip.js
+++ b/src/export/zip.js
@@ -9,6 +9,8 @@
 // at that listing. Zip64 is not written, so this tops out at 4GB or 65535 files - far past any
 // frame sequence this app produces, but the limits are checked rather than silently exceeded.
 
+import { ByteWriter } from './byteWriter.js';
+
 const LOCAL_SIG = 0x04034b50;
 const CENTRAL_SIG = 0x02014b50;
 const END_SIG = 0x06054b50;
@@ -58,7 +60,108 @@ export function dosDateTime(d) {
 }
 
 /**
+ * A ZIP being written, one entry at a time.
+ *
+ * The whole-archive version had to know every entry before it could start, because it measured
+ * everything to allocate one exact buffer. That is fine for a single project's frames and wrong
+ * for a queue of them: exporting several pieces as one file (#123) works precisely by never
+ * holding more than one piece, and an archive builder that wants them all at once takes that back.
+ *
+ * Streaming costs one thing - the archive is written into a growing buffer rather than an exact
+ * one - and saves a bigger one: the caller can drop each piece's frames as soon as they are in,
+ * so peak memory is the archive plus one frame rather than the archive plus every frame.
+ *
+ * Store-only, like the whole-archive version, because PNGs are already deflated.
+ */
+export class ZipWriter {
+    /** @param {{ date?: Date }} [opts] */
+    constructor({ date = new Date() } = {}) {
+        const { time, date: dosDate } = dosDateTime(date);
+        this.time = time;
+        this.dosDate = dosDate;
+        this.w = new ByteWriter();
+        this.enc = new TextEncoder();
+        /** @type {{name: Uint8Array, crc: number, size: number, offset: number}[]} */
+        this.files = [];
+        this.finished = false;
+    }
+
+    /**
+     * Add one file. Its bytes are written immediately, so the caller may release them after.
+     *
+     * @param {string} name
+     * @param {Uint8Array} data
+     */
+    add(name, data) {
+        if (this.finished) throw new Error('zip already finished');
+        if (this.files.length >= 0xffff) throw new Error('too many files for a non-zip64 archive');
+        const encoded = this.enc.encode(name);
+        if (encoded.length > 0xffff) throw new Error('file name too long: ' + name);
+        const offset = this.w.position;
+        // An entry that starts past 4GB cannot be pointed at by a 32-bit central directory offset,
+        // and refusing here says which file it was rather than writing a header that lies.
+        if (offset > 0xffffffff) throw new Error('archive too large for a non-zip64 archive');
+        const crc = crc32(data);
+        const w = this.w;
+        w.u32(LOCAL_SIG);
+        w.u16(20);              // version needed
+        w.u16(0);               // flags
+        w.u16(0);               // method: stored
+        w.u16(this.time); w.u16(this.dosDate);
+        w.u32(crc);
+        w.u32(data.length);     // compressed
+        w.u32(data.length);     // uncompressed
+        w.u16(encoded.length);
+        w.u16(0);               // extra field length
+        w.bytes(encoded);
+        w.bytes(data);
+        this.files.push({ name: encoded, crc, size: data.length, offset });
+    }
+
+    /**
+     * Write the central directory and hand back the archive.
+     *
+     * @returns {Uint8Array<ArrayBuffer>}
+     */
+    finish() {
+        if (this.finished) throw new Error('zip already finished');
+        this.finished = true;
+        const w = this.w;
+        const centralStart = w.position;
+        for (const f of this.files) {
+            w.u32(CENTRAL_SIG);
+            w.u16(20);          // version made by
+            w.u16(20);          // version needed
+            w.u16(0); w.u16(0); // flags, method
+            w.u16(this.time); w.u16(this.dosDate);
+            w.u32(f.crc);
+            w.u32(f.size); w.u32(f.size);
+            w.u16(f.name.length);
+            w.u16(0); w.u16(0); // extra, comment
+            w.u16(0);           // disk number
+            w.u16(0);           // internal attrs
+            w.u32(0);           // external attrs
+            w.u32(f.offset);
+            w.bytes(f.name);
+        }
+        // Taken before the end record is written: position is a cursor, and by the time the size
+        // field is reached it has already moved past the directory it is meant to measure.
+        const centralEnd = w.position;
+        w.u32(END_SIG);
+        w.u16(0); w.u16(0);     // this disk, disk with central directory
+        w.u16(this.files.length); w.u16(this.files.length);
+        w.u32(centralEnd - centralStart);
+        w.u32(centralStart);
+        w.u16(0);               // comment length
+        return w.done();
+    }
+}
+
+/**
  * Build a ZIP archive from entries already in memory.
+ *
+ * Kept as the name every existing caller uses; it is the streaming writer with all the entries
+ * handed over at once.
  *
  * @param {ZipEntry[]} entries
  * @param {{ date?: Date }} [opts]
@@ -66,73 +169,9 @@ export function dosDateTime(d) {
  */
 export function makeZip(entries, { date = new Date() } = {}) {
     if (entries.length > 0xffff) throw new Error('too many files for a non-zip64 archive');
-    const enc = new TextEncoder();
-    const { time, date: dosDate } = dosDateTime(date);
-
-    const files = entries.map(e => {
-        const name = enc.encode(e.name);
-        if (name.length > 0xffff) throw new Error('file name too long: ' + e.name);
-        return { name, data: e.data, crc: crc32(e.data) };
-    });
-
-    const localSize = files.reduce((n, f) => n + 30 + f.name.length + f.data.length, 0);
-    const centralSize = files.reduce((n, f) => n + 46 + f.name.length, 0);
-    const total = localSize + centralSize + 22;
-    if (total > 0xffffffff) throw new Error('archive too large for a non-zip64 archive');
-
-    // Backed by a plain ArrayBuffer rather than an inferred ArrayBufferLike, so the result
-    // can be handed straight to a Blob.
-    const out = new Uint8Array(new ArrayBuffer(total));
-    const view = new DataView(out.buffer);
-    let p = 0;
-    const u32 = (v) => { view.setUint32(p, v, true); p += 4; };
-    const u16 = (v) => { view.setUint16(p, v, true); p += 2; };
-
-    const offsets = [];
-    for (const f of files) {
-        offsets.push(p);
-        u32(LOCAL_SIG);
-        u16(20);            // version needed
-        u16(0);             // flags
-        u16(0);             // method: stored
-        u16(time); u16(dosDate);
-        u32(f.crc);
-        u32(f.data.length); // compressed
-        u32(f.data.length); // uncompressed
-        u16(f.name.length);
-        u16(0);             // extra field length
-        out.set(f.name, p); p += f.name.length;
-        out.set(f.data, p); p += f.data.length;
-    }
-
-    const centralStart = p;
-    files.forEach((f, i) => {
-        u32(CENTRAL_SIG);
-        u16(20);            // version made by
-        u16(20);            // version needed
-        u16(0); u16(0);     // flags, method
-        u16(time); u16(dosDate);
-        u32(f.crc);
-        u32(f.data.length); u32(f.data.length);
-        u16(f.name.length);
-        u16(0); u16(0);     // extra, comment
-        u16(0);             // disk number
-        u16(0);             // internal attrs
-        u32(0);             // external attrs
-        u32(offsets[i]);
-        out.set(f.name, p); p += f.name.length;
-    });
-
-    // Taken before the end record is written: `p` is a cursor, and by the time the size field
-    // is reached it has already moved past the directory it is meant to measure.
-    const centralEnd = p;
-    u32(END_SIG);
-    u16(0); u16(0);         // this disk, disk with central directory
-    u16(files.length); u16(files.length);
-    u32(centralEnd - centralStart);
-    u32(centralStart);
-    u16(0);                 // comment length
-    return out;
+    const zip = new ZipWriter({ date });
+    for (const e of entries) zip.add(e.name, e.data);
+    return zip.finish();
 }
 
 /**

--- a/test/zip.test.js
+++ b/test/zip.test.js
@@ -4,7 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { crc32, dosDateTime, makeZip, frameName } from '../src/export/zip.js';
+import { crc32, dosDateTime, makeZip, frameName, ZipWriter } from '../src/export/zip.js';
 
 const bytes = (s) => new TextEncoder().encode(s);
 
@@ -124,3 +124,68 @@ test('a system unzip can list and extract the archive', { skip: !hasUnzip() }, (
 function hasUnzip() {
     try { execFileSync('unzip', ['-v'], { stdio: 'ignore' }); return true; } catch { return false; }
 }
+
+// --- the streaming writer ------------------------------------------------------------------
+// makeZip is this class with everything handed over at once, so the tests above already cover the
+// bytes it produces. What is left is the thing only streaming can get wrong: state carried across
+// calls, and the promise that a caller may release each entry's data once it has been added.
+
+test('ZipWriter: adding one at a time gives the same archive as all at once', () => {
+    const entries = [
+        { name: 'frame_0001.png', data: new Uint8Array([1, 2, 3]) },
+        { name: 'frame_0002.png', data: new Uint8Array([4, 5]) },
+        { name: 'frame_0003.png', data: new Uint8Array([6, 7, 8, 9]) },
+    ];
+    const date = new Date('2026-02-03T04:05:06Z');
+    const atOnce = makeZip(entries, { date });
+    const zip = new ZipWriter({ date });
+    for (const e of entries) zip.add(e.name, e.data);
+    assert.deepEqual([...zip.finish()], [...atOnce], 'a queue must not produce a different file');
+});
+
+// The whole point: a caller writes a piece's frames, drops them, and moves on. If the writer kept
+// a reference instead of copying, the archive would come out full of whatever the buffer held next.
+test('ZipWriter: the caller may reuse or clear the buffer it handed over', () => {
+    const zip = new ZipWriter({ date: new Date('2026-02-03T04:05:06Z') });
+    const scratch = new Uint8Array([1, 2, 3, 4]);
+    zip.add('a.bin', scratch);
+    scratch.fill(0xff);                    // as a caller reusing one buffer per frame would
+    zip.add('b.bin', scratch);
+    const out = zip.finish();
+    const first = out.subarray(30 + 'a.bin'.length, 30 + 'a.bin'.length + 4);
+    assert.deepEqual([...first], [1, 2, 3, 4], 'the bytes were copied in, not pointed at');
+});
+
+test('ZipWriter: an empty archive is still a valid one', () => {
+    const out = new ZipWriter().finish();
+    assert.equal(out.length, 22);
+    assert.equal(new DataView(out.buffer).getUint32(0, true), 0x06054b50);
+});
+
+test('ZipWriter: finishing twice, or adding after finishing, is refused', () => {
+    const zip = new ZipWriter();
+    zip.add('a.bin', new Uint8Array([1]));
+    zip.finish();
+    assert.throws(() => zip.add('b.bin', new Uint8Array([2])), /already finished/);
+    assert.throws(() => zip.finish(), /already finished/);
+});
+
+test('ZipWriter: offsets keep counting across many entries', async () => {
+    const zip = new ZipWriter({ date: new Date('2026-02-03T04:05:06Z') });
+    const n = 200;
+    for (let i = 0; i < n; i++) zip.add(frameName(i, n), new Uint8Array(64).fill(i & 255));
+    const out = zip.finish();
+    const view = new DataView(out.buffer);
+    // Read the end record, walk the central directory, and check every offset points at a local
+    // header - which is what a reader does, and what a wrong cursor would break.
+    const centralStart = view.getUint32(out.length - 6, true);
+    let p = centralStart;
+    for (let i = 0; i < n; i++) {
+        assert.equal(view.getUint32(p, true), 0x02014b50, `central entry ${i}`);
+        const nameLen = view.getUint16(p + 28, true);
+        const offset = view.getUint32(p + 42, true);
+        assert.equal(view.getUint32(offset, true), 0x04034b50, `entry ${i} points at a local header`);
+        p += 46 + nameLen;
+    }
+    assert.equal(view.getUint16(out.length - 12, true), n, 'and the count agrees');
+});


### PR DESCRIPTION
Step 3 of #123 — the format that needed the least. PNG frames are already deflated, so the archive is store-only arithmetic. The only thing in the way: **`makeZip` had to know every entry before it could start**, because it measured them all to allocate one exact buffer.

Fine for one project's frames. Wrong for a queue of them — combining several pieces works precisely by never holding more than one, and a builder that wants them all at once takes that back.

| | peak memory |
|---|---|
| before | the archive **plus every frame** |
| now | the archive **plus one frame** |

## `makeZip` stays, and that is a verification choice

It is the streaming writer with everything handed over at once. Not only for the callers — it means the **fourteen existing tests, including the one that shells out to a real `unzip` and extracts the archive**, are testing the new writer.

## Five more, for what only streaming can get wrong

- one at a time produces a **byte-identical** archive to all at once
- **the caller may reuse or clear the buffer it handed over** — exactly what a queue does per frame. Written because a writer that kept a reference instead of copying would produce an archive full of whatever the buffer held next, and nothing else would notice
- an empty archive is still valid
- adding after finishing is refused rather than writing a header nobody will read
- across **two hundred** entries, every central-directory offset still points at a real local header — read the way a reader reads it, since a cursor that drifts is the failure

## `ByteWriter` moved out of `gif.js`

Both formats want a growable little-endian buffer for the same reason — a JS array holds one byte as eight — so it lives beside them rather than inside whichever was written first. GIF's 22 tests pass unchanged.

It gained `u32`, which uses `>>>` so a CRC or an offset with its top bit set does not come out negative and write the wrong bytes.

## The helper index could not see either class

It scanned `export function` and `export const` only, so **`export class` was invisible**. That is the one gap that check cannot afford — a shared export it cannot see is exactly the one someone writes a second time. Fixed, and it immediately named the two it had been missing.

`npm run check` green — 791 tests, 251 helpers indexed.

## Left on #123

- GIF: a streaming `encodeGif`, and a shared palette so colours do not shift at seams
- the picker: choose files, show progress, cancel