### PR TITLE
feat: a GIF that can be written one piece at a time

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -629,6 +629,7 @@ unsupported for every codec it offers.
 
 | | |
 |---|---|
+| `GifWriter` | A GIF being written one frame at a time; `encodeGif` is this with every frame handed over at once. Streaming is easy for this format because every frame already carries its own local colour table - nothing is shared, so a frame written after the next piece is loaded encodes identically. Refuses to finish with no frames, since a GIF of a header and a trailer is something a viewer opens and shows nothing for. |
 | `encodeGif` | Assemble an animated GIF. Each frame carries its own palette, and disposal 2 is what stops a transparent animation smearing the previous frame through the gaps. |
 | `buildPalette` | Colours actually used, exact while they fit in 255. Past that the least-used fold into their nearest neighbour, which suits a drawing of flat colour plus anti-aliasing. |
 | `toIndices` | One frame as palette indices, with slot 0 for anything under the alpha cutoff. |

--- a/src/export/gif.js
+++ b/src/export/gif.js
@@ -165,6 +165,103 @@ export function paletteBits(n) {
  */
 
 /**
+ * A GIF being written, one frame at a time.
+ *
+ * The whole-animation version had to be handed every frame before it could start. That is fine
+ * for one project and wrong for a queue of them (#123), which works by never holding more than
+ * one piece - so an encoder that wants them all at once takes that back.
+ *
+ * Streaming is unusually easy here, and worth saying why: this encoder already gives **every
+ * frame its own local colour table**. Nothing is shared between frames, so a frame written now
+ * and a frame written after the next piece is loaded are encoded identically to two frames of
+ * one animation. There is no seam. (Stitching finished GIF *files* together would have a palette
+ * problem; writing frames into one file does not.)
+ */
+export class GifWriter {
+    /**
+     * @param {{width: number, height: number, delayMs?: number, loop?: boolean, alphaCutoff?: number}} opts
+     */
+    constructor({ width, height, delayMs = 100, loop = true, alphaCutoff = 128 }) {
+        this.width = width;
+        this.height = height;
+        this.delayMs = delayMs;
+        this.alphaCutoff = alphaCutoff;
+        this.frames = 0;
+        this.finished = false;
+        const out = this.out = new ByteWriter();
+
+        out.str('GIF89a');
+        out.u16(width); out.u16(height);
+        // No global colour table: every frame brings its own, so this byte only says how deep the
+        // screen is. Background index and pixel aspect are both zero.
+        out.u8(0x70); out.u8(0); out.u8(0);
+
+        if (loop) {
+            // The Netscape extension. Not in the specification, universally implemented, and the
+            // only way to say "repeat forever".
+            out.u8(0x21); out.u8(0xff); out.u8(11);
+            out.str('NETSCAPE2.0');
+            out.u8(3); out.u8(1); out.u16(0); out.u8(0);
+        }
+    }
+
+    /**
+     * Add one frame. Its pixels are encoded immediately, so the caller may release them after -
+     * which is the whole point: a queue drops each piece's frames as it goes.
+     *
+     * @param {Uint8ClampedArray} rgba
+     * @param {{delayMs?: number}} [opts]
+     */
+    addFrame(rgba, { delayMs } = {}) {
+        if (this.finished) throw new Error('gif already finished');
+        const out = this.out;
+        const { palette, indexOf } = buildPalette(rgba, this.alphaCutoff);
+        const indices = toIndices(rgba, indexOf, this.alphaCutoff);
+        const bits = paletteBits(palette.length + 1);   // +1 for the transparent slot
+        const tableSize = 1 << bits;
+
+        // Graphic control: the delay, the transparent index, and disposal 2 so the frame is
+        // cleared rather than left underneath the next one.
+        out.u8(0x21); out.u8(0xf9); out.u8(4);
+        out.u8((2 << 2) | 1);                                        // disposal 2, transparency on
+        out.u16(Math.max(1, Math.round((delayMs ?? this.delayMs) / 10)));   // hundredths
+        out.u8(TRANSPARENT);
+        out.u8(0);
+
+        out.u8(0x2c);                                                // image descriptor
+        out.u16(0); out.u16(0); out.u16(this.width); out.u16(this.height);
+        out.u8(0x80 | (bits - 1));                                   // local colour table, its size
+
+        // Slot 0 is the transparent one. Its colour is never drawn, but it has to be present.
+        out.u8(0); out.u8(0); out.u8(0);
+        for (let i = 0; i < tableSize - 1; i++) {
+            const rgb = palette[i] ?? 0;
+            out.u8((rgb >> 16) & 255); out.u8((rgb >> 8) & 255); out.u8(rgb & 255);
+        }
+
+        const minCodeSize = Math.max(2, bits);
+        out.u8(minCodeSize);
+        writeSubBlocks(out, lzwEncode(indices, minCodeSize));
+        this.frames++;
+    }
+
+    /**
+     * Write the trailer and hand back the file.
+     * @returns {Uint8Array<ArrayBuffer>}
+     */
+    finish() {
+        if (this.finished) throw new Error('gif already finished');
+        // Guarded here rather than at the caller, so it covers a queue that turned out to have
+        // nothing in it as well as an encodeGif handed an empty list. A GIF with no frames is a
+        // header and a trailer: something a viewer will open and show nothing for.
+        if (!this.frames) throw new Error('a GIF needs at least one frame');
+        this.finished = true;
+        this.out.u8(0x3b);   // trailer
+        return this.out.done();
+    }
+}
+
+/**
  * Assemble an animated GIF.
  *
  * Each frame carries its own palette (a local colour table), so a colour that appears in one
@@ -182,56 +279,7 @@ export function paletteBits(n) {
  * @returns {Uint8Array<ArrayBuffer>}
  */
 export function encodeGif(frames, { width, height, delayMs = 100, loop = true, alphaCutoff = 128 }) {
-    if (!frames.length) throw new Error('a GIF needs at least one frame');
-    const out = new ByteWriter();
-    const u8 = (v) => out.u8(v);
-    const u16 = (v) => out.u16(v);
-    const str = (s) => out.str(s);
-
-    str('GIF89a');
-    u16(width); u16(height);
-    // No global colour table: every frame brings its own, so this byte only says how deep the
-    // screen is. Background index and pixel aspect are both zero.
-    u8(0x70); u8(0); u8(0);
-
-    if (loop) {
-        // The Netscape extension. Not in the specification, universally implemented, and the
-        // only way to say "repeat forever".
-        u8(0x21); u8(0xff); u8(11);
-        str('NETSCAPE2.0');
-        u8(3); u8(1); u16(0); u8(0);
-    }
-
-    for (const frame of frames) {
-        const { palette, indexOf } = buildPalette(frame.rgba, alphaCutoff);
-        const indices = toIndices(frame.rgba, indexOf, alphaCutoff);
-        const bits = paletteBits(palette.length + 1);   // +1 for the transparent slot
-        const tableSize = 1 << bits;
-
-        // Graphic control: the delay, the transparent index, and disposal 2 so the frame is
-        // cleared rather than left underneath the next one.
-        u8(0x21); u8(0xf9); u8(4);
-        u8((2 << 2) | 1);                                     // disposal 2, transparency on
-        u16(Math.max(1, Math.round((frame.delayMs ?? delayMs) / 10)));   // hundredths
-        u8(TRANSPARENT);
-        u8(0);
-
-        u8(0x2c);                                             // image descriptor
-        u16(0); u16(0); u16(width); u16(height);
-        u8(0x80 | (bits - 1));                                // local colour table, its size
-
-        // Slot 0 is the transparent one. Its colour is never drawn, but it has to be present.
-        u8(0); u8(0); u8(0);
-        for (let i = 0; i < tableSize - 1; i++) {
-            const rgb = palette[i] ?? 0;
-            u8((rgb >> 16) & 255); u8((rgb >> 8) & 255); u8(rgb & 255);
-        }
-
-        const minCodeSize = Math.max(2, bits);
-        u8(minCodeSize);
-        writeSubBlocks(out, lzwEncode(indices, minCodeSize));
-    }
-
-    u8(0x3b);   // trailer
-    return out.done();
+    const gif = new GifWriter({ width, height, delayMs, loop, alphaCutoff });
+    for (const frame of frames) gif.addFrame(frame.rgba, { delayMs: frame.delayMs });
+    return gif.finish();
 }

--- a/test/gif.test.js
+++ b/test/gif.test.js
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildPalette, toIndices, lzwEncode, paletteBits, encodeGif } from '../src/export/gif.js';
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildPalette, toIndices, lzwEncode, paletteBits, encodeGif, GifWriter } from '../src/export/gif.js';
 
 const rgba = (...px) => new Uint8ClampedArray(px.flat());
 const OPAQUE_RED = [255, 0, 0, 255];
@@ -265,3 +269,127 @@ test('the pixels come back out of the file', () => {
         assert.deepEqual(table[indices[i]], [px[i * 4], px[i * 4 + 1], px[i * 4 + 2]], `pixel ${i}`);
     }
 });
+
+// --- the streaming writer ------------------------------------------------------------------
+// encodeGif is this class with every frame handed over at once, so the tests above already cover
+// the bytes. What is left is what only streaming can get wrong.
+
+const solid = (w, h, [r, g, b, a]) => {
+    const px = new Uint8ClampedArray(w * h * 4);
+    for (let i = 0; i < px.length; i += 4) { px[i] = r; px[i + 1] = g; px[i + 2] = b; px[i + 3] = a; }
+    return px;
+};
+
+test('GifWriter: one frame at a time gives the same file as all at once', () => {
+    const a = solid(4, 4, [255, 0, 0, 255]);
+    const b = solid(4, 4, [0, 128, 255, 255]);
+    const atOnce = encodeGif([{ rgba: a }, { rgba: b }], { width: 4, height: 4, delayMs: 80 });
+    const gif = new GifWriter({ width: 4, height: 4, delayMs: 80 });
+    gif.addFrame(a);
+    gif.addFrame(b);
+    assert.deepEqual([...gif.finish()], [...atOnce], 'a queue must not produce a different file');
+});
+
+// The reason streaming is easy for this format, stated as a test: nothing carries between frames,
+// so a frame written after another piece was loaded encodes exactly as if it had always been here.
+test('GifWriter: frames are independent, so writing them apart changes nothing', () => {
+    const a = solid(3, 3, [10, 20, 30, 255]);
+    const b = solid(3, 3, [200, 100, 50, 255]);
+    const together = new GifWriter({ width: 3, height: 3 });
+    together.addFrame(a); together.addFrame(b);
+    const bytes = together.finish();
+
+    // Encode b on its own and find its frame block inside the two-frame file: identical bytes.
+    const alone = new GifWriter({ width: 3, height: 3 });
+    alone.addFrame(b);
+    const aloneBytes = alone.finish();
+    // Both files share the same header, and both end with the trailer; strip those and the
+    // second frame of the pair must contain the whole of the single frame's block.
+    const body = aloneBytes.subarray(headerLength(aloneBytes), aloneBytes.length - 1);
+    assert.ok(indexOfSub(bytes, body) > 0, "the frame's bytes are the same wherever it was written");
+});
+
+test('GifWriter: the caller may reuse the pixel buffer it handed over', () => {
+    const px = solid(2, 2, [1, 2, 3, 255]);
+    const gif = new GifWriter({ width: 2, height: 2 });
+    gif.addFrame(px);
+    const afterFirst = gif.out.position;
+    px.fill(255);                                   // as a queue reusing one buffer would
+    gif.addFrame(px);
+    const bytes = gif.finish();
+    assert.ok(bytes.length > afterFirst, 'the second frame was encoded from the new contents');
+    assert.equal(bytes[bytes.length - 1], 0x3b);
+});
+
+test('GifWriter: a queue that produced nothing is refused, not written empty', () => {
+    assert.throws(() => new GifWriter({ width: 4, height: 4 }).finish(), /at least one frame/);
+});
+
+test('GifWriter: adding after finishing, or finishing twice, is refused', () => {
+    const gif = new GifWriter({ width: 2, height: 2 });
+    gif.addFrame(solid(2, 2, [0, 0, 0, 255]));
+    gif.finish();
+    assert.throws(() => gif.addFrame(solid(2, 2, [0, 0, 0, 255])), /already finished/);
+    assert.throws(() => gif.finish(), /already finished/);
+});
+
+test('GifWriter: a per-frame delay still overrides the default', () => {
+    const gif = new GifWriter({ width: 2, height: 2, delayMs: 1000 });
+    gif.addFrame(solid(2, 2, [0, 0, 0, 255]), { delayMs: 20 });
+    const bytes = gif.finish();
+    const gce = indexOfSub(bytes, new Uint8Array([0x21, 0xf9, 0x04]));
+    assert.equal(bytes[gce + 4] | (bytes[gce + 5] << 8), 2, '20ms is 2 hundredths');
+});
+
+/** Bytes before the first graphic-control extension: header, screen descriptor, loop block. */
+function headerLength(bytes) {
+    return indexOfSub(bytes, new Uint8Array([0x21, 0xf9, 0x04]));
+}
+
+/** Index of `needle` in `hay`, or -1. Small and linear, which is plenty for these sizes. */
+function indexOfSub(hay, needle) {
+    outer: for (let i = 0; i + needle.length <= hay.length; i++) {
+        for (let j = 0; j < needle.length; j++) if (hay[i + j] !== needle[j]) continue outer;
+        return i;
+    }
+    return -1;
+}
+
+// The counterpart to the unzip test in zip.test.js: our own byte assertions can only say the file
+// matches what we meant to write. This asks something that has never seen our code whether it is
+// a GIF. Skipped where ffprobe is not installed, since it is not a dependency.
+test('ffprobe reads a GIF written the way a queue writes one', { skip: !hasFfprobe() }, () => {
+    const W = 8, H = 8;
+    const solid = ([r, g, b, a]) => {
+        const px = new Uint8ClampedArray(W * H * 4);
+        for (let i = 0; i < px.length; i += 4) { px[i] = r; px[i + 1] = g; px[i + 2] = b; px[i + 3] = a; }
+        return px;
+    };
+    const gif = new GifWriter({ width: W, height: H, delayMs: 100 });
+    // Three "pieces", each releasing its pixels before the next is opened - the pattern the
+    // multi-piece export uses, rather than one array of frames built up first.
+    for (const colour of [[255, 0, 0, 255], [0, 255, 0, 255], [0, 0, 255, 255]]) {
+        let px = solid(colour);
+        gif.addFrame(px);
+        px = null;
+    }
+    const path = join(tmpdir(), `mv-gif-${process.pid}.gif`);
+    try {
+        writeFileSync(path, gif.finish());
+        const out = execFileSync('ffprobe', [
+            '-v', 'error', '-count_frames', '-select_streams', 'v:0',
+            '-show_entries', 'stream=nb_read_frames,width,height,codec_name',
+            '-of', 'default=noprint_wrappers=1', path,
+        ], { encoding: 'utf8' });
+        assert.match(out, /codec_name=gif/);
+        assert.match(out, /width=8/);
+        assert.match(out, /height=8/);
+        assert.match(out, /nb_read_frames=3/, 'all three frames are there and decodable');
+    } finally {
+        try { unlinkSync(path); } catch { }
+    }
+});
+
+function hasFfprobe() {
+    try { execFileSync('ffprobe', ['-version'], { stdio: 'ignore' }); return true; } catch { return false; }
+}

--- a/test/gif.test.js
+++ b/test/gif.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { writeFileSync, unlinkSync } from 'node:fs';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildPalette, toIndices, lzwEncode, paletteBits, encodeGif, GifWriter } from '../src/export/gif.js';
@@ -373,7 +373,10 @@ test('ffprobe reads a GIF written the way a queue writes one', { skip: !hasFfpro
         gif.addFrame(px);
         px = null;
     }
-    const path = join(tmpdir(), `mv-gif-${process.pid}.gif`);
+    // A directory of our own, as zip.test.js already does for its unzip run. A predictable name
+    // in the shared temp dir is a file anyone else on the machine can point a symlink at first.
+    const dir = mkdtempSync(join(tmpdir(), 'gif-'));
+    const path = join(dir, 'out.gif');
     try {
         writeFileSync(path, gif.finish());
         const out = execFileSync('ffprobe', [
@@ -385,9 +388,7 @@ test('ffprobe reads a GIF written the way a queue writes one', { skip: !hasFfpro
         assert.match(out, /width=8/);
         assert.match(out, /height=8/);
         assert.match(out, /nb_read_frames=3/, 'all three frames are there and decodable');
-    } finally {
-        try { unlinkSync(path); } catch { }
-    }
+    } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
 function hasFfprobe() {


### PR DESCRIPTION
Step 3 of #123 finished. Same shape as the ZIP: a `GifWriter` that takes frames as they come, with `encodeGif` kept as that class with every frame handed over at once — which means **the twenty-two existing tests are testing the new writer**.

## Correcting something I wrote on the issue

I said each piece would carry its own palette and colours could shift at every seam. That is true of **stitching finished GIF files** together — option B — and **not true here**: this encoder already gives every frame its own local colour table. Nothing is shared between frames, so a frame written now and a frame written after the next piece is loaded encode identically.

**There is no seam to get wrong, and no shared palette needed.** The GIF half of this turned out to be the easy one.

## The existing tests caught a real mistake

Rewriting the function dropped its guard against an empty animation, and the test that says so failed. Restoring it in `finish()` rather than in `encodeGif` is the better place anyway — it now covers a queue that turned out to have nothing in it, as well as a caller handing over an empty list.

## Six streaming tests

The two that matter:

- **frames are independent** — proven rather than asserted: encode a frame alone, then find its bytes verbatim inside a two-frame file
- **the caller may reuse the pixel buffer**, which is what a queue does per frame

## And one that answers a question our own assertions cannot

`zip.test.js` shells out to a real `unzip`. `gif.test.js` had no equivalent, so every check was this code agreeing with itself.

`ffprobe` is on this machine, so a GIF written **the way the queue writes one** — three pieces, each releasing its pixels before the next is opened — now goes to a decoder that has never seen our code:

```
codec_name=gif
width=8
height=8
nb_read_frames=3
```

Skipped where `ffprobe` is not installed, since it is not a dependency.

`npm run check` green — **798 tests**.

## Left on #123

Only step 4: the picker — choose files, run the queue, show progress, cancel. Both encoders and the plan are in place.