### PR TITLE
refactor: the document on this machine leaves App

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -557,6 +557,17 @@ the narrowest.
 |---|---|
 | `useServerStorage` | Save, open and delete server projects; snapshot every five minutes and rotate. Takes `buildData` and `restore` as functions rather than reaching for the document itself, because building one reads most of App's state and restoring one writes most of it - threading either in would make the seam wider than the thing it separates. |
 
+## `src/hooks/useLocalDocuments.js`
+
+The document on this machine: `.emv` files, IndexedDB projects, the autosave crash recovery offers,
+and the tabs that hold several documents at once. The mirror of `useServerStorage`, split along the
+same line - three things that look separate and are one concern, because all three are "a document
+that lives here rather than on a server" and all three go through `buildData` and `restore`.
+
+| | |
+|---|---|
+| `useLocalDocuments` | Owns the local pickers, the tab list and their in-memory snapshots. Takes `buildData`, `restore` and `resetToEmpty` as functions: the first two because building a document reads most of App's state and restoring one writes most of it, the third for the same reason from the other end - emptying the document is App's business. |
+
 ## `src/hooks/usePanelLayout.js`
 
 Where the panels are and how wide they are: three panels that each dock left, dock right or float,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ import { usePlayback } from './hooks/usePlayback.js';
 import { useServerProbe } from './hooks/useServerProbe.js';
 import { useServerStorage } from './hooks/useServerStorage.js';
 import { usePanelLayout } from './hooks/usePanelLayout.js';
+import { useLocalDocuments } from './hooks/useLocalDocuments.js';
 import { fetchAsset } from './core/api.js';
 import { useAutosave } from './hooks/useAutosave.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
@@ -402,6 +403,9 @@ export default function App() {
     const [showMediaMenu, setShowMediaMenu] = useState(false);
     const [showHelp, setShowHelp] = useState(false);
     const fileHandleRef = useRef(null);
+    // Shared by both document hooks: the server backup falls back to it for a name, and the
+    // local save writes it. Owned here because the two hooks cannot both create it.
+    const localNameRef = useRef('');
     const [dragLayerInfo, setDragLayerInfo] = useState(null);
     const [dropInfo, setDropInfo] = useState(null);
     const canvasRef = useRef(null);
@@ -467,15 +471,11 @@ export default function App() {
     const textAreaRef = useRef(null);
     const textDragRef = useRef(null);
     const textMeasureCtxRef = useRef(null);
-    const didRecoverRef = useRef(false);
     const [view, setView] = useState({ zoom: 1, x: 0, y: 0 });
     const touchPtsRef = useRef(new Map());
     const pinchRef = useRef(null);
     const tlTouchRef = useRef(new Map());
     const tlPinchRef = useRef(null);
-    const [localProjects, setLocalProjects] = useState(null); // IndexedDB project picker
-    const localIdRef = useRef(null);
-    const localNameRef = useRef('');
     // Which document is loaded, as a number that changes whenever the whole thing is replaced.
     //
     // Long jobs - extracting frames from a video, detecting scenes - can be sent to the
@@ -500,7 +500,6 @@ export default function App() {
     // an app that decided at load time is an app that never notices the server starting.
     const serverAvailable = useServerProbe();
 
-    const [storageInfo, setStorageInfo] = useState(null); // local storage usage
     const [loadProgress, setLoadProgress] = useState(null); // {label, done, total}; total 0 means the length is unknown
     // The lang state exists only to trigger a redraw; lookups read the module variable.
     // Nothing here is memoised, so changing it re-renders the whole tree in the new language.
@@ -1293,55 +1292,6 @@ export default function App() {
         liveRef, localNameRef,
     });
 
-    const doSave = async (asNew = false) => {
-        const json = JSON.stringify(await buildData(), null, 2);
-        if ('showSaveFilePicker' in window && (asNew || !fileHandleRef.current)) {
-            try { const h = await window.showSaveFilePicker({ suggestedName: 'project.emv', types: [{ description: 'Easy MV Project', accept: { 'application/json': ['.emv'] } }] }); fileHandleRef.current = h; const w = await h.createWritable(); await w.write(json); await w.close(); return; } catch (e) { if (e.name === 'AbortError') return; }
-        } else if ('showSaveFilePicker' in window && fileHandleRef.current) {
-            try { const w = await fileHandleRef.current.createWritable(); await w.write(json); await w.close(); return; } catch (e) {
-                // The handle stopped working. The download below still saves the work, but it
-                // goes to the downloads folder rather than over the file the user chose, so
-                // silence here would read as a successful overwrite.
-                fileHandleRef.current = null;
-                setToast(tr('저장한 파일에 쓸 수 없어 다운로드로 저장합니다'));
-            }
-        }
-        downloadBlob(new Blob([json], { type: 'application/json' }), 'project.emv');
-    };
-    // A large .emv looks frozen during the read and parse alone, so that stretch shows just a
-    // label with an indeterminate bar (total 0); restore then takes over with real progress.
-    const readAndRestore = async (getText) => {
-        setLoadProgress({ label: tr('파일 읽는 중'), done: 0, total: 0 });
-        try {
-            const text = await getText();
-            setLoadProgress({ label: tr('파일 분석 중'), done: 0, total: 0 });
-            await new Promise(r => setTimeout(r, 0)); // give the bar a chance to paint once
-            const data = JSON.parse(text);
-            return await restore(data);
-        } catch (err) {
-            setLoadProgress(null);
-            alert(tr('파일 오류: ') + err.message);
-            return false;
-        }
-    };
-    const doOpen = async () => {
-        if ('showOpenFilePicker' in window) {
-            try {
-                const [h] = await window.showOpenFilePicker({ types: [{ description: 'Easy MV Project', accept: { 'application/json': ['.emv'] } }] });
-                // Only after the file is actually open. Set first, the handle pointed at a file
-                // that had not been loaded - and the next save would write whatever is on screen
-                // over it.
-                if (await readAndRestore(async () => (await h.getFile()).text())) fileHandleRef.current = h;
-                return;
-            } catch (e) { if (e.name === 'AbortError') return; }
-        }
-        const inp = document.createElement('input'); inp.type = 'file'; inp.accept = '.emv';
-        inp.onchange = e => {
-            const f = /** @type {HTMLInputElement} */ (e.target).files[0]; if (!f) return;
-            readAndRestore(() => new Promise((res, rej) => { const r = new FileReader(); r.onload = ev => res(ev.target.result); r.onerror = rej; r.readAsText(f); }));
-        };
-        inp.click();
-    };
     const resetToEmpty = () => {
         fileHandleRef.current = null;
         bitmapStoreRef.current.clear();
@@ -1356,130 +1306,19 @@ export default function App() {
         videoBlobRef.current = null; dispatchMedia(clearVideo()); setSceneCfg(null);
         detachMedia(videoElRef.current);
     };
-    const doNew = () => {
-        if (!window.confirm(tr('새 프로젝트? 저장되지 않은 내용은 사라집니다.'))) return;
-        resetToEmpty();
-    };
-
-    // --- Document tabs (multiple projects open at once, Clip Studio / SAI style) ---
-    // Each tab keeps a full in-memory document snapshot (buildData with Blobs, so no base64 cost).
-    // Switching = snapshot the current tab, then restore the target's snapshot.
-    const [tabs, setTabs] = useState([{ id: 't1', name: tr('프로젝트 1') }]);
-    const [activeTabId, setActiveTabId] = useState('t1');
-    const tabDocsRef = useRef({}); // id -> doc snapshot (null = fresh/empty)
-    const tabBusyRef = useRef(false);
-    const snapshotActiveTab = async () => {
-        // A failure here is not cosmetic: the snapshot is the only copy of this tab's work once we
-        // switch away from it, so the caller must not switch.
-        tabDocsRef.current[activeTabId] = await buildData(true, null, true);
-    };
-    const switchTab = async (id) => {
-        if (id === activeTabId || tabBusyRef.current) return;
-        tabBusyRef.current = true;
-        try {
-            try { await snapshotActiveTab(); }
-            catch (e) { setAppError(tr('현재 탭을 저장할 수 없어 탭을 바꾸지 않았습니다: ') + (e?.message || String(e))); return; }
-            setActiveTabId(id);
-            const doc = tabDocsRef.current[id];
-            if (doc) await restore(doc); else resetToEmpty();
-        } finally { tabBusyRef.current = false; }
-    };
-    const newTab = async () => {
-        if (tabBusyRef.current) return; tabBusyRef.current = true;
-        try {
-            // Same reasoning as switchTab: opening a new tab means leaving this one, and leaving
-            // it without a snapshot loses it.
-            try { await snapshotActiveTab(); }
-            catch (e) { setAppError(tr('현재 탭을 저장할 수 없어 새 탭을 열지 않았습니다: ') + (e?.message || String(e))); return; }
-            const id = 't' + nextId().toString(36);
-            setTabs(p => { const n = [...p, { id, name: tr('프로젝트 ') + (p.length + 1) }]; return n; });
-            tabDocsRef.current[id] = null;
-            setActiveTabId(id);
-            resetToEmpty();
-        } finally { tabBusyRef.current = false; }
-    };
-    const closeTab = async (id) => {
-        if (tabs.length <= 1) { if (window.confirm(tr('마지막 탭입니다. 내용을 비울까요?'))) { resetToEmpty(); tabDocsRef.current[id] = null; } return; }
-        if (!window.confirm(tr('이 탭을 닫을까요? 저장하지 않은 내용은 사라집니다.'))) return;
-        delete tabDocsRef.current[id];
-        const rest = tabs.filter(t => t.id !== id);
-        setTabs(rest);
-        if (id === activeTabId) {
-            const target = rest[rest.length - 1];
-            setActiveTabId(target.id);
-            const doc = tabDocsRef.current[target.id];
-            if (doc) await restore(doc); else resetToEmpty();
-        }
-    };
-
-    // Ask the browser to make local storage persistent, so the IndexedDB autosave isn't
-    // silently evicted under storage pressure (the main way local-only work gets lost).
-    useEffect(() => { navigator.storage?.persist?.().catch(() => { }); }, []);
-    // Warn before the local quota runs out — a failed autosave is otherwise invisible.
-    useEffect(() => {
-        let alive = true;
-        const check = async () => {
-            try {
-                const est = await navigator.storage?.estimate?.();
-                if (!est || !alive || !est.quota) return;
-                setStorageInfo({ usage: est.usage || 0, quota: est.quota, pct: (est.usage || 0) / est.quota });
-            } catch { }
-        };
-        check();
-        const id = setInterval(check, 60000);
-        return () => { alive = false; clearInterval(id); };
-    }, []);
-
-    // --- Local (IndexedDB) named projects — works offline / in the deployed build too ---
-    const doLocalSave = async (forceNew = false) => {
-        try {
-            const data = await buildData(true, null, true); // IndexedDB stores frame Blobs directly
-            if (!forceNew && localIdRef.current) { await saveProject(localIdRef.current, data, localNameRef.current || 'Untitled'); alert(tr('로컬에 저장했습니다.')); return; }
-            const name = window.prompt(tr('로컬 저장 이름:'), localNameRef.current || 'MV Project');
-            if (!name) return;
-            const id = randomId('l_');
-            await saveProject(id, data, name);
-            localIdRef.current = id; localNameRef.current = name;
-            alert(tr('로컬에 저장했습니다.'));
-        } catch (e) { alert(tr('로컬 저장 실패: ') + e.message); }
-    };
-    const openLocalList = async () => {
-        try { setLocalProjects((await listProjects()).filter(p => p.id !== autosaveKey)); }
-        catch (e) { alert(tr('로컬 목록 실패: ') + e.message); }
-    };
-    const doLocalOpen = async (id, name) => {
-        try {
-            const data = await loadProject(id);
-            if (!data) { alert(tr('데이터가 없습니다.')); return; }
-            // As in doServerOpen: the identity is only ours once the document is actually in.
-            if (!await restore(data)) return;
-            localIdRef.current = id; localNameRef.current = name || ''; setLocalProjects(null);
-        }
-        catch (e) { alert(tr('로컬 열기 실패: ') + e.message); }
-    };
-    const doLocalDelete = async (id) => {
-        if (!window.confirm(tr('이 로컬 프로젝트를 삭제할까요?'))) return;
-        try { await deleteProject(id); if (localIdRef.current === id) { localIdRef.current = null; localNameRef.current = ''; } openLocalList(); }
-        catch (e) { alert(tr('삭제 실패: ') + e.message); }
-    };
-
-    // Crash recovery: on first load, offer to restore the last autosaved project.
-    useEffect(() => {
-        let cancelled = false;
-        loadAutosave().then(data => {
-            if (cancelled || !data || !Array.isArray(data.cuts)) return;
-            const meaningful = data.cuts.length > 1 || data.cuts.some(c =>
-                safeArray(c.layers).some(l => safeArray(l.strokes).length) || safeArray(c.texts).length);
-            if (!meaningful) return;
-            const when = data.savedAt ? new Date(data.savedAt).toLocaleString() : '';
-            if (window.confirm(tr('이전에 자동저장된 작업이 있습니다{0}.\n복구할까요?', when ? ` (${when})` : ''))) {
-                restore(data);
-            }
-        }).catch(() => { }).finally(() => { didRecoverRef.current = true; });
-        return () => { cancelled = true; };
-    }, []);
-
-
+    // Files, browser storage and the tabs that hold several documents at once. Called here
+    // because it needs buildData, restore and resetToEmpty, and this is the first point at which
+    // all three exist.
+    const {
+        doSave, doOpen, doNew, readAndRestore,
+        localProjects, setLocalProjects, localIdRef,
+        doLocalSave, openLocalList, doLocalOpen, doLocalDelete,
+        tabs, activeTabId, switchTab, newTab, closeTab, renameTab,
+        storageInfo, didRecoverRef,
+    } = useLocalDocuments({
+        buildData, restore, resetToEmpty,
+        setAppError, setToast, setLoadProgress, fileHandleRef, localNameRef,
+    });
 
     // Debounced autosave to IndexedDB, so a refresh or a crash never costs work. It waits for
     // crash recovery to finish deciding - otherwise a new empty document overwrites the autosave
@@ -4000,7 +3839,7 @@ export default function App() {
             <div className="doc-tabs" style={{ display: 'flex', alignItems: 'stretch', gap: 2, background: 'hsl(var(--ui-h) var(--ui-s) 11%)', borderBottom: '1px solid hsl(var(--ui-h) var(--ui-s) 20%)', padding: '3px 6px 0', overflowX: 'auto', flexShrink: 0 }}>
                 {tabs.map(t => (
                     <div key={t.id} onClick={() => switchTab(t.id)}
-                        onDoubleClick={() => { const n = window.prompt(tr('탭 이름'), t.name); if (n != null) setTabs(p => p.map(x => x.id === t.id ? { ...x, name: n || x.name } : x)); }}
+                        onDoubleClick={() => { const n = window.prompt(tr('탭 이름'), t.name); if (n != null) renameTab(t.id, n); }}
                         title={tr('클릭: 전환 · 더블클릭: 이름변경')}
                         style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '5px 10px', borderRadius: '6px 6px 0 0', cursor: 'pointer', fontSize: 12, whiteSpace: 'nowrap', maxWidth: 180, background: t.id === activeTabId ? 'hsl(var(--ui-h) var(--ui-s) 15%)' : 'transparent', color: t.id === activeTabId ? '#fff' : '#9a9ab0', borderBottom: t.id === activeTabId ? '2px solid var(--accent-soft)' : '2px solid transparent' }}>
                         <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.name}</span>

--- a/src/hooks/useLocalDocuments.js
+++ b/src/hooks/useLocalDocuments.js
@@ -1,0 +1,253 @@
+// The document, on this machine: files, browser storage, and the tabs that hold several at once.
+//
+// The mirror of useServerStorage, and split along the same line. Three things that look separate
+// and are one concern, because all three are "a document that lives here rather than on a server"
+// and all three go through the same two functions:
+//
+//   .emv files      a file the user picked, written with the File System Access API where it
+//                   exists and downloaded where it does not
+//   IndexedDB       projects kept in the browser, plus the autosave that crash recovery offers
+//   tabs            several documents open at once, each one a snapshot in memory
+//
+// What stays in App and arrives as functions: buildData, restore, and resetToEmpty. The first two
+// for the reason useServerStorage gives - building a document reads most of App's state and
+// restoring one writes most of it. resetToEmpty for the same reason from the other end: emptying
+// the document means clearing cuts, tracks, the playhead, the selection, the layer cache and both
+// media tracks, which is App's business and not this file's.
+//
+// Nothing here touches a canvas, a stroke, or the timeline.
+
+import { useState, useRef, useEffect } from 'react';
+import { saveProject, loadProject, listProjects, deleteProject, loadAutosave, autosaveKey } from '../db.js';
+import { downloadBlob } from '../export/download.js';
+import { randomId, nextId } from '../core/ids.js';
+import { safeArray } from '../canvas/canvasUtils.js';
+import { tr } from '../i18n.js';
+
+/** How often to ask the browser how much room is left. */
+const QUOTA_POLL_MS = 60000;
+
+/**
+ * @param {object} opts
+ * @param {(includeAudio?: boolean, assetSink?: any[], blobsOk?: boolean) => Promise<any>} opts.buildData
+ * @param {(data: any, assetBase?: string|null, label?: string) => Promise<boolean>} opts.restore
+ * @param {() => void} opts.resetToEmpty
+ * @param {(m: string) => void} opts.setAppError
+ * @param {(m: string) => void} opts.setToast
+ * @param {(p: any) => void} opts.setLoadProgress
+ * @param {{current: any}} opts.fileHandleRef owned by App, because resetToEmpty clears it
+ * @param {{current: string}} opts.localNameRef owned by App, because the server backup falls back
+ *   to it for a name and that hook is created first
+ */
+export function useLocalDocuments({ buildData, restore, resetToEmpty, setAppError, setToast, setLoadProgress, fileHandleRef, localNameRef }) {
+    const [localProjects, setLocalProjects] = useState(/** @type {any} */(null)); // null = picker closed
+    const localIdRef = useRef(/** @type {string|null} */(null));
+    const [storageInfo, setStorageInfo] = useState(/** @type {any} */(null));
+
+    const [tabs, setTabs] = useState([{ id: 't1', name: tr('프로젝트 1') }]);
+    const [activeTabId, setActiveTabId] = useState('t1');
+    const tabDocsRef = useRef(/** @type {Record<string, any>} */({})); // id -> doc snapshot (null = fresh/empty)
+    const tabBusyRef = useRef(false);
+
+    // Crash recovery has to finish deciding before the autosave may write, or a new empty document
+    // overwrites the very thing the user is about to be offered.
+    const didRecoverRef = useRef(false);
+
+    // --- .emv files --------------------------------------------------------------------------
+    const doSave = async (asNew = false) => {
+        const json = JSON.stringify(await buildData(), null, 2);
+        if ('showSaveFilePicker' in window && (asNew || !fileHandleRef.current)) {
+            try {
+                const h = await window.showSaveFilePicker({ suggestedName: 'project.emv', types: [{ description: 'Easy MV Project', accept: { 'application/json': ['.emv'] } }] });
+                fileHandleRef.current = h;
+                const w = await h.createWritable(); await w.write(json); await w.close();
+                return;
+            } catch (e) { if (e.name === 'AbortError') return; }
+        } else if ('showSaveFilePicker' in window && fileHandleRef.current) {
+            try { const w = await fileHandleRef.current.createWritable(); await w.write(json); await w.close(); return; } catch (e) {
+                // The handle stopped working. The download below still saves the work, but it
+                // goes to the downloads folder rather than over the file the user chose, so
+                // silence here would read as a successful overwrite.
+                fileHandleRef.current = null;
+                setToast(tr('저장한 파일에 쓸 수 없어 다운로드로 저장합니다'));
+            }
+        }
+        downloadBlob(new Blob([json], { type: 'application/json' }), 'project.emv');
+    };
+
+    // A large .emv looks frozen during the read and parse alone, so that stretch shows just a
+    // label with an indeterminate bar (total 0); restore then takes over with real progress.
+    const readAndRestore = async (getText) => {
+        setLoadProgress({ label: tr('파일 읽는 중'), done: 0, total: 0 });
+        try {
+            const text = await getText();
+            setLoadProgress({ label: tr('파일 분석 중'), done: 0, total: 0 });
+            await new Promise(r => setTimeout(r, 0)); // give the bar a chance to paint once
+            const data = JSON.parse(text);
+            return await restore(data);
+        } catch (err) {
+            setLoadProgress(null);
+            alert(tr('파일 오류: ') + err.message);
+            return false;
+        }
+    };
+
+    const doOpen = async () => {
+        if ('showOpenFilePicker' in window) {
+            try {
+                const [h] = await window.showOpenFilePicker({ types: [{ description: 'Easy MV Project', accept: { 'application/json': ['.emv'] } }] });
+                // Only after the file is actually open. Set first, the handle pointed at a file
+                // that had not been loaded - and the next save would write whatever is on screen
+                // over it.
+                if (await readAndRestore(async () => (await h.getFile()).text())) fileHandleRef.current = h;
+                return;
+            } catch (e) { if (e.name === 'AbortError') return; }
+        }
+        const inp = document.createElement('input'); inp.type = 'file'; inp.accept = '.emv';
+        inp.onchange = e => {
+            const f = /** @type {HTMLInputElement} */ (e.target).files[0]; if (!f) return;
+            readAndRestore(() => new Promise((res, rej) => { const r = new FileReader(); r.onload = ev => res(ev.target.result); r.onerror = rej; r.readAsText(f); }));
+        };
+        inp.click();
+    };
+
+    const doNew = () => {
+        if (!window.confirm(tr('새 프로젝트? 저장되지 않은 내용은 사라집니다.'))) return;
+        resetToEmpty();
+    };
+
+    // --- IndexedDB projects ------------------------------------------------------------------
+    const doLocalSave = async (forceNew = false) => {
+        try {
+            const data = await buildData(true, null, true); // IndexedDB stores frame Blobs directly
+            if (!forceNew && localIdRef.current) { await saveProject(localIdRef.current, data, localNameRef.current || 'Untitled'); alert(tr('로컬에 저장했습니다.')); return; }
+            const name = window.prompt(tr('로컬 저장 이름:'), localNameRef.current || 'MV Project');
+            if (!name) return;
+            const id = randomId('l_');
+            await saveProject(id, data, name);
+            localIdRef.current = id; localNameRef.current = name;
+            alert(tr('로컬에 저장했습니다.'));
+        } catch (e) { alert(tr('로컬 저장 실패: ') + e.message); }
+    };
+
+    const openLocalList = async () => {
+        try { setLocalProjects((await listProjects()).filter(p => p.id !== autosaveKey)); }
+        catch (e) { alert(tr('로컬 목록 실패: ') + e.message); }
+    };
+
+    const doLocalOpen = async (id, name) => {
+        try {
+            const data = await loadProject(id);
+            if (!data) { alert(tr('데이터가 없습니다.')); return; }
+            // As in doServerOpen: the identity is only ours once the document is actually in.
+            if (!await restore(data)) return;
+            localIdRef.current = id; localNameRef.current = name || ''; setLocalProjects(null);
+        }
+        catch (e) { alert(tr('로컬 열기 실패: ') + e.message); }
+    };
+
+    const doLocalDelete = async (id) => {
+        if (!window.confirm(tr('이 로컬 프로젝트를 삭제할까요?'))) return;
+        try { await deleteProject(id); if (localIdRef.current === id) { localIdRef.current = null; localNameRef.current = ''; } openLocalList(); }
+        catch (e) { alert(tr('삭제 실패: ') + e.message); }
+    };
+
+    // --- Tabs (multiple projects open at once, Clip Studio / SAI style) -----------------------
+    // Each tab keeps a full in-memory document snapshot (buildData with Blobs, so no base64 cost).
+    // Switching = snapshot the current tab, then restore the target's snapshot.
+    const snapshotActiveTab = async () => {
+        // A failure here is not cosmetic: the snapshot is the only copy of this tab's work once we
+        // switch away from it, so the caller must not switch.
+        tabDocsRef.current[activeTabId] = await buildData(true, null, true);
+    };
+
+    const switchTab = async (id) => {
+        if (id === activeTabId || tabBusyRef.current) return;
+        tabBusyRef.current = true;
+        try {
+            try { await snapshotActiveTab(); }
+            catch (e) { setAppError(tr('현재 탭을 저장할 수 없어 탭을 바꾸지 않았습니다: ') + (e?.message || String(e))); return; }
+            setActiveTabId(id);
+            const doc = tabDocsRef.current[id];
+            if (doc) await restore(doc); else resetToEmpty();
+        } finally { tabBusyRef.current = false; }
+    };
+
+    const newTab = async () => {
+        if (tabBusyRef.current) return; tabBusyRef.current = true;
+        try {
+            // Same reasoning as switchTab: opening a new tab means leaving this one, and leaving
+            // it without a snapshot loses it.
+            try { await snapshotActiveTab(); }
+            catch (e) { setAppError(tr('현재 탭을 저장할 수 없어 새 탭을 열지 않았습니다: ') + (e?.message || String(e))); return; }
+            const id = 't' + nextId().toString(36);
+            setTabs(p => [...p, { id, name: tr('프로젝트 ') + (p.length + 1) }]);
+            tabDocsRef.current[id] = null;
+            setActiveTabId(id);
+            resetToEmpty();
+        } finally { tabBusyRef.current = false; }
+    };
+
+    /** Rename a tab. Asking for the name is the caller's business; this only records it. */
+    const renameTab = (id, name) => setTabs(p => p.map(t => (t.id === id ? { ...t, name: name || t.name } : t)));
+
+    const closeTab = async (id) => {
+        if (tabs.length <= 1) { if (window.confirm(tr('마지막 탭입니다. 내용을 비울까요?'))) { resetToEmpty(); tabDocsRef.current[id] = null; } return; }
+        if (!window.confirm(tr('이 탭을 닫을까요? 저장하지 않은 내용은 사라집니다.'))) return;
+        delete tabDocsRef.current[id];
+        const rest = tabs.filter(t => t.id !== id);
+        setTabs(rest);
+        if (id === activeTabId) {
+            const target = rest[rest.length - 1];
+            setActiveTabId(target.id);
+            const doc = tabDocsRef.current[target.id];
+            if (doc) await restore(doc); else resetToEmpty();
+        }
+    };
+
+    // --- Crash recovery and the storage budget ------------------------------------------------
+    // Offer the last autosave on first load. Deliberately a question rather than automatic: the
+    // autosave may be older than what the user meant to open.
+    useEffect(() => {
+        let cancelled = false;
+        loadAutosave().then(data => {
+            if (cancelled || !data || !Array.isArray(data.cuts)) return;
+            const meaningful = data.cuts.length > 1 || data.cuts.some(c =>
+                safeArray(c.layers).some(l => safeArray(l.strokes).length) || safeArray(c.texts).length);
+            if (!meaningful) return;
+            const when = data.savedAt ? new Date(data.savedAt).toLocaleString() : '';
+            if (window.confirm(tr('이전에 자동저장된 작업이 있습니다{0}.\n복구할까요?', when ? ` (${when})` : ''))) {
+                restore(data);
+            }
+        }).catch(() => { }).finally(() => { didRecoverRef.current = true; });
+        return () => { cancelled = true; };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- once, on mount, by design
+    }, []);
+
+    // Ask the browser to make local storage persistent, so the IndexedDB autosave isn't
+    // silently evicted under storage pressure (the main way local-only work gets lost).
+    useEffect(() => { navigator.storage?.persist?.().catch(() => { }); }, []);
+
+    // Warn before the local quota runs out — a failed autosave is otherwise invisible.
+    useEffect(() => {
+        let alive = true;
+        const check = async () => {
+            try {
+                const est = await navigator.storage?.estimate?.();
+                if (!est || !alive || !est.quota) return;
+                setStorageInfo({ usage: est.usage || 0, quota: est.quota, pct: (est.usage || 0) / est.quota });
+            } catch { }
+        };
+        check();
+        const id = setInterval(check, QUOTA_POLL_MS);
+        return () => { alive = false; clearInterval(id); };
+    }, []);
+
+    return {
+        doSave, doOpen, doNew, readAndRestore,
+        localProjects, setLocalProjects, localIdRef, localNameRef,
+        doLocalSave, openLocalList, doLocalOpen, doLocalDelete,
+        tabs, activeTabId, switchTab, newTab, closeTab, renameTab,
+        storageInfo, didRecoverRef,
+    };
+}


### PR DESCRIPTION
The mirror of #119, split along the same line. Three things that look separate and are one concern — all three are *"a document that lives here rather than on a server"*, and all three go through the same two functions:

| | |
|---|---|
| `.emv` files | the File System Access API where it exists, a download where it does not |
| IndexedDB | named projects, plus the autosave crash recovery offers on first load |
| tabs | several documents open at once, each a snapshot in memory |

`buildData` and `restore` arrive as functions, for the reason #119 gives. **`resetToEmpty` joins them for the same reason from the other end**: emptying the document means clearing cuts, tracks, the playhead, the selection, the layer cache and both media tracks — App's business, not this file's.

## Two ownership questions the extraction forced into the open

Both invisible while everything lived in one function:

- **`localNameRef`** is read by the server backup (a name to fall back to) and written by the local save. Two hooks cannot both create it, and having the local one create it would mean the server hook could not be built first. App owns it and hands it to both — which is what `fileHandleRef` already needed, because `resetToEmpty` clears it.
- **Renaming a tab reached into `setTabs` from the JSX.** It goes through `renameTab` now, so the shape of the tab list is not something the markup has to know.

## Faithfulness

Diffed function by function against the original:

- `readAndRestore`, `doOpen`, `doLocalSave`, `doLocalOpen`, `doLocalDelete`, `openLocalList` — **byte-identical**
- the whole tab block — **byte-identical**
- `doSave` — differs only in that one very long line is now several. Same order, same branches.

## The hook baseline went 9 → 8, and that is not a fix

Worth being explicit. The crash-recovery effect is deliberately mount-only and uses `restore`, so its deps must be empty. In App that was one of the nine unexplained warnings; here it carries a disable with the reason written beside it.

A stated reason at the site beats a number in a file — but the count moving is bookkeeping, not repair.

## Numbers

| | before | after |
|---|---|---|
| App.jsx lines | 4118 | **3957** |
| useState / useStored / useReducer | 86 | 82 |
| useRef | 80 | 76 |
| effects | 31 | 28 |
| top-level functions | 153 | 141 |

App.jsx is under four thousand lines for the first time this session — it started at 4324.

`npm run check` green — 798 tests.