### PR TITLE
test: replace two tests that could not fail

### DIFF
--- a/test/gif.test.js
+++ b/test/gif.test.js
@@ -280,14 +280,22 @@ const solid = (w, h, [r, g, b, a]) => {
     return px;
 };
 
-test('GifWriter: one frame at a time gives the same file as all at once', () => {
-    const a = solid(4, 4, [255, 0, 0, 255]);
-    const b = solid(4, 4, [0, 128, 255, 255]);
-    const atOnce = encodeGif([{ rgba: a }, { rgba: b }], { width: 4, height: 4, delayMs: 80 });
-    const gif = new GifWriter({ width: 4, height: 4, delayMs: 80 });
-    gif.addFrame(a);
-    gif.addFrame(b);
-    assert.deepEqual([...gif.finish()], [...atOnce], 'a queue must not produce a different file');
+// This slot used to hold "one frame at a time gives the same file as all at once", comparing
+// GifWriter against encodeGif. That test could not fail: encodeGif *is* a GifWriter with every
+// frame handed over, so it compared a function with its own inlining. It read as reassurance and
+// was worth nothing, which is worse than having no test there.
+//
+// What it was reaching for - "a change to the writer must not silently change the bytes" - is a
+// real thing to want, and this is it. The file below was produced by the writer and read back by
+// ffprobe, so it is a record of output known to decode rather than of output that merely exists.
+const GOLDEN_GIF = [71,73,70,56,57,97,2,0,2,0,112,0,0,33,255,11,78,69,84,83,67,65,80,69,50,46,48,3,1,0,0,0,33,249,4,9,10,0,0,0,44,0,0,0,0,2,0,2,0,129,0,0,0,255,0,0,0,0,0,0,0,0,2,2,140,83,0,33,249,4,9,10,0,0,0,44,0,0,0,0,2,0,2,0,129,0,0,0,0,0,255,0,0,0,0,0,0,2,2,140,83,0,59];
+
+test('GifWriter: the bytes are exactly what they were, frame by frame', () => {
+    const gif = new GifWriter({ width: 2, height: 2, delayMs: 100 });
+    gif.addFrame(solid(2, 2, [255, 0, 0, 255]));
+    gif.addFrame(solid(2, 2, [0, 0, 255, 255]));
+    assert.deepEqual([...gif.finish()], GOLDEN_GIF,
+        'a change here is a change to every GIF the app writes - deliberate or not');
 });
 
 // The reason streaming is easy for this format, stated as a test: nothing carries between frames,

--- a/test/zip.test.js
+++ b/test/zip.test.js
@@ -130,17 +130,23 @@ function hasUnzip() {
 // bytes it produces. What is left is the thing only streaming can get wrong: state carried across
 // calls, and the promise that a caller may release each entry's data once it has been added.
 
-test('ZipWriter: adding one at a time gives the same archive as all at once', () => {
-    const entries = [
-        { name: 'frame_0001.png', data: new Uint8Array([1, 2, 3]) },
-        { name: 'frame_0002.png', data: new Uint8Array([4, 5]) },
-        { name: 'frame_0003.png', data: new Uint8Array([6, 7, 8, 9]) },
-    ];
-    const date = new Date('2026-02-03T04:05:06Z');
-    const atOnce = makeZip(entries, { date });
-    const zip = new ZipWriter({ date });
-    for (const e of entries) zip.add(e.name, e.data);
-    assert.deepEqual([...zip.finish()], [...atOnce], 'a queue must not produce a different file');
+// This slot used to hold "adding one at a time gives the same archive as all at once", comparing
+// ZipWriter against makeZip. That test could not fail: makeZip *is* a ZipWriter with every entry
+// handed over, so it compared a function with its own inlining. It read as reassurance and was
+// worth nothing, which is worse than having no test there.
+//
+// What it was reaching for - "a change to the writer must not silently change the bytes" - is a
+// real thing to want, and this is it. The archive below was produced by the writer and checked by
+// a system unzip, so it is a record of output that is known to work rather than of output that
+// merely exists.
+const GOLDEN_ZIP = [80,75,3,4,20,0,0,0,0,0,163,104,67,92,29,128,188,85,3,0,0,0,3,0,0,0,5,0,0,0,97,46,98,105,110,1,2,3,80,75,3,4,20,0,0,0,0,0,163,104,67,92,116,35,223,85,2,0,0,0,2,0,0,0,5,0,0,0,98,46,98,105,110,4,5,80,75,1,2,20,0,20,0,0,0,0,0,163,104,67,92,29,128,188,85,3,0,0,0,3,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,97,46,98,105,110,80,75,1,2,20,0,20,0,0,0,0,0,163,104,67,92,116,35,223,85,2,0,0,0,2,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,0,38,0,0,0,98,46,98,105,110,80,75,5,6,0,0,0,0,2,0,2,0,102,0,0,0,75,0,0,0,0,0];
+
+test('ZipWriter: the bytes are exactly what they were, entry by entry', () => {
+    const zip = new ZipWriter({ date: new Date('2026-02-03T04:05:06Z') });
+    zip.add('a.bin', new Uint8Array([1, 2, 3]));
+    zip.add('b.bin', new Uint8Array([4, 5]));
+    assert.deepEqual([...zip.finish()], GOLDEN_ZIP,
+        'a change here is a change to every archive the app writes - deliberate or not');
 });
 
 // The whole point: a caller writes a piece's frames, drops them, and moves on. If the writer kept

--- a/test/zip.test.js
+++ b/test/zip.test.js
@@ -139,10 +139,14 @@ function hasUnzip() {
 // real thing to want, and this is it. The archive below was produced by the writer and checked by
 // a system unzip, so it is a record of output that is known to work rather than of output that
 // merely exists.
-const GOLDEN_ZIP = [80,75,3,4,20,0,0,0,0,0,163,104,67,92,29,128,188,85,3,0,0,0,3,0,0,0,5,0,0,0,97,46,98,105,110,1,2,3,80,75,3,4,20,0,0,0,0,0,163,104,67,92,116,35,223,85,2,0,0,0,2,0,0,0,5,0,0,0,98,46,98,105,110,4,5,80,75,1,2,20,0,20,0,0,0,0,0,163,104,67,92,29,128,188,85,3,0,0,0,3,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,97,46,98,105,110,80,75,1,2,20,0,20,0,0,0,0,0,163,104,67,92,116,35,223,85,2,0,0,0,2,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,0,38,0,0,0,98,46,98,105,110,80,75,5,6,0,0,0,0,2,0,2,0,102,0,0,0,75,0,0,0,0,0];
+const GOLDEN_ZIP = [80,75,3,4,20,0,0,0,0,0,163,32,67,92,29,128,188,85,3,0,0,0,3,0,0,0,5,0,0,0,97,46,98,105,110,1,2,3,80,75,3,4,20,0,0,0,0,0,163,32,67,92,116,35,223,85,2,0,0,0,2,0,0,0,5,0,0,0,98,46,98,105,110,4,5,80,75,1,2,20,0,20,0,0,0,0,0,163,32,67,92,29,128,188,85,3,0,0,0,3,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,97,46,98,105,110,80,75,1,2,20,0,20,0,0,0,0,0,163,32,67,92,116,35,223,85,2,0,0,0,2,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,0,38,0,0,0,98,46,98,105,110,80,75,5,6,0,0,0,0,2,0,2,0,102,0,0,0,75,0,0,0,0,0];
 
+// The date is built from local components rather than parsed from a Z-suffixed string, because
+// ZIP stores wall-clock time in whatever zone wrote the file - dosDateTime uses getHours and
+// getMonth, correctly. A UTC string put the timezone of whoever ran the test into the fixture,
+// which passed here and failed on CI, where the clock is UTC and mine is not.
 test('ZipWriter: the bytes are exactly what they were, entry by entry', () => {
-    const zip = new ZipWriter({ date: new Date('2026-02-03T04:05:06Z') });
+    const zip = new ZipWriter({ date: new Date(2026, 1, 3, 4, 5, 6) });
     zip.add('a.bin', new Uint8Array([1, 2, 3]));
     zip.add('b.bin', new Uint8Array([4, 5]));
     assert.deepEqual([...zip.finish()], GOLDEN_ZIP,


### PR DESCRIPTION
Found by asking which exports nothing outside their own file uses. `makeZip` and `encodeGif` came back as **"tests only"** — true, and the thread worth pulling: after #128 moved the app onto the writers, the wrappers have no production callers, and the tests leaning on them turned out to be leaning on nothing.

## The two tests

> `ZipWriter: adding one at a time gives the same archive as all at once`

compared `ZipWriter` with `makeZip`. But **`makeZip` *is* a `ZipWriter` with every entry handed over** — three lines, no other behaviour:

```js
export function makeZip(entries, { date = new Date() } = {}) {
    if (entries.length > 0xffff) throw new Error('too many files for a non-zip64 archive');
    const zip = new ZipWriter({ date });
    for (const e of entries) zip.add(e.name, e.data);
    return zip.finish();
}
```

The test compared a function with its own inlining. **It could not fail.** The GIF one was the same shape.

I wrote both, in #126 and #127, and described them as verification. They were not.

## What replaces them

Golden-byte tests — which is what those two were reaching for: *a change to the writer must not silently change the bytes.*

The fixtures are not arbitrary. The zip one is output a **system `unzip` has extracted**; the gif one is output **`ffprobe` has decoded**. So they pin bytes already known to work rather than bytes that merely exist.

**Confirmed they fail on purpose**, which the old ones never could — changing the ZIP local header's `version needed` from 20 to 45:

```
not ok 15 - ZipWriter: the bytes are exactly what they were, entry by entry
# pass 18
# fail 1
```

Under the old test that change would have passed, because `makeZip` would have changed with it.

## What stays

`makeZip` and `encodeGif` remain. They are a reasonable way to hand over a whole list, the tests read better through them, and the 14 and 22 byte-level tests that go through them **do** exercise the writers underneath — that part of what I claimed was true.

The other "used nowhere" hits are the scan's own blind spot rather than dead code: `STORE_ASSET`, `STORE_BLOB`, `STORE_DATAURL`, `YOUTUBE_HOSTS` and `openVideoFile` are all used inside the file that exports them, which the scan excludes by design. Checked each.

`npm run check` green — 798 tests.