### PR TITLE
refactor: a text object's fields, in one place instead of three

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -397,6 +397,22 @@ halves exist, and until this the pieces had to be made by hand.
 | `splitProject` | One piece per part, each carrying only the pixels its own cuts reference - which is the whole point, since a piece that dragged every frame along would be the size of the project it came from. Times are left alone, so a split and a recombine come back to the same film. **No cut may be lost:** cuts belonging to no part become a piece rather than being dropped. |
 | `pieceFileName` | `01_Chorus.emv` - padded so a directory listing is the running order, and stripped of the characters a file name cannot hold. |
 
+## `src/core/textEdit.js`
+
+A text object's twenty-odd fields, in one place instead of three. The app moved them across by
+hand twice - opening a text into the editor, writing the editor back out - with a third, shorter
+list for a new one. Adding a property meant editing all three, and forgetting one is silent: the
+property simply does not survive being edited, which reads as the editor losing it.
+
+| | |
+|---|---|
+| `textFromEdit` | The text to store, from what the editor holds. Rounds the position, and clamps the size on the way out because Ctrl+Enter commits without the size field ever losing focus. |
+| `editFromText` | What the editor should hold, from a stored text. A text missing a colour opens in the colour being drawn with, which is what someone editing it expects. |
+| `blankTextEdit` | A text that does not exist yet. Short on purpose - what it leaves out, `textFromEdit` fills in, and listing them here would be the third copy this file exists to stop. |
+
+Having both directions in one place is what lets the round trip be tested: open a text, write it
+straight back, and it must be the text you started with.
+
 ## `src/core/timeCode.js`
 
 Formatting and parsing times.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import { resolveDrawLayer as resolveDrawLayerPure, commitStroke, insertFill, pat
 import { closeLassoPath, lassoBounds, applyResize } from './core/lassoOps.js';
 import { useTimelineGestures } from './hooks/useTimelineGestures.js';
 import { fmt, parseClock } from './core/timeCode.js';
+import { textFromEdit, editFromText, blankTextEdit } from './core/textEdit.js';
 import { useHistory } from './hooks/useHistory.js';
 import { usePlayback } from './hooks/usePlayback.js';
 import { useServerProbe } from './hooks/useServerProbe.js';
@@ -1997,17 +1998,9 @@ export default function App() {
         setTextEdit({
             cutId: currentCutId,
             layerId: currentCut.activeLayerId,
-            textId: null,
-            x: pos.x,
-            y: pos.y,
+            ...blankTextEdit(pos, { color, opacity }),
             cssX: (pos.x * sx / view.zoom),
             cssY: (pos.y * sy / view.zoom),
-            text: '',
-            fontSize: 36,
-            fontFamily: 'sans-serif',
-            color,
-            opacity,
-            visible: true,
         });
     };
 
@@ -2455,40 +2448,9 @@ export default function App() {
     const cancelText = () => setTextEdit(null);
     const commitText = () => {
         if (!textEdit) return;
-        const t = String(textEdit.text ?? '');
-        if (!t.trim()) { setTextEdit(null); return; }
+        if (!String(textEdit.text ?? '').trim()) { setTextEdit(null); return; }
         const id = textEdit.textId ?? nextId();
-        const obj = {
-            id,
-            x: Math.round(textEdit.x),
-            y: Math.round(textEdit.y),
-            text: t,
-            // Ctrl+Enter commits without the size field ever losing focus, so the range that the
-            // field would have applied on blur is applied here too.
-            fontSize: clampNum(Number(textEdit.fontSize) || 36, 6, 400),
-            fontFamily: textEdit.fontFamily,
-            color: textEdit.color,
-            opacity: textEdit.opacity,
-            visible: textEdit.visible ?? true,
-            outline: !!textEdit.outline,
-            outlineColor: textEdit.outlineColor || '#ffffff',
-            bold: !!textEdit.bold,
-            italic: !!textEdit.italic,
-            align: textEdit.align || 'left',
-            lineHeight: textEdit.lineHeight ?? 1.25,
-            letterSpacing: textEdit.letterSpacing ?? 0,
-            shadow: !!textEdit.shadow,
-            shadowColor: textEdit.shadowColor || 'rgba(0,0,0,0.5)',
-            shadowBlur: textEdit.shadowBlur ?? 6,
-            gradient: !!textEdit.gradient,
-            color2: textEdit.color2 || '#ffffff',
-            bgColor: textEdit.bgColor || '',
-            rotation: textEdit.rotation ?? 0,
-            curve: textEdit.curve ?? 0,
-            flipX: !!textEdit.flipX,
-            flipY: !!textEdit.flipY,
-            anim: textEdit.anim || null,
-        };
+        const obj = textFromEdit(textEdit, id);
         dispatchCuts(upsertText(textEdit.cutId, obj));
         setSelectedText({ cutId: textEdit.cutId, textId: id });
         setTextEdit(null);
@@ -2506,34 +2468,11 @@ export default function App() {
         setTextEdit({
             cutId,
             textId,
-            x: t.x ?? 0,
-            y: t.y ?? 0,
+            ...editFromText(t, { color, opacity }),
+            // Where the textarea sits on screen, which is the editor's business and not the
+            // document's - so it is added here rather than in the shared shape.
             cssX: ((t.x ?? 0) * sx / view.zoom),
             cssY: ((t.y ?? 0) * sy / view.zoom),
-            text: t.text ?? '',
-            fontSize: t.fontSize ?? 36,
-            fontFamily: t.fontFamily ?? 'sans-serif',
-            color: t.color ?? color,
-            opacity: t.opacity ?? opacity,
-            visible: t.visible !== false,
-            outline: !!t.outline,
-            outlineColor: t.outlineColor || '#ffffff',
-            bold: !!t.bold,
-            italic: !!t.italic,
-            align: t.align || 'left',
-            lineHeight: t.lineHeight ?? 1.25,
-            letterSpacing: t.letterSpacing ?? 0,
-            shadow: !!t.shadow,
-            shadowColor: t.shadowColor || 'rgba(0,0,0,0.5)',
-            shadowBlur: t.shadowBlur ?? 6,
-            gradient: !!t.gradient,
-            color2: t.color2 || '#ffffff',
-            bgColor: t.bgColor || '',
-            rotation: t.rotation ?? 0,
-            curve: t.curve ?? 0,
-            flipX: !!t.flipX,
-            flipY: !!t.flipY,
-            anim: t.anim || null,
         });
     };
 

--- a/src/core/textEdit.js
+++ b/src/core/textEdit.js
@@ -1,0 +1,134 @@
+// A text object's fields, in one place instead of three.
+//
+// A text carries about twenty properties, and the app moved them across twice by hand: once
+// opening an existing text into the editor, once writing the editor back out. A third, shorter
+// list starts a brand-new one. Adding a property meant editing all three, and forgetting one is
+// silent - the property simply does not survive being edited, which looks like the editor losing
+// it rather than like a missing line.
+//
+// The two directions are here so the round trip can be tested: open a text, write it straight
+// back, and it must be the text you started with. That test cannot exist while the lists are
+// inline in a component.
+//
+// Deliberately not one shared list of field names with a loop over it. The two directions are not
+// symmetrical - opening fills in the app's current colour where a text has none, writing out
+// rounds the position and clamps the size - and a loop that had to carry those exceptions would
+// say less than the two explicit lists do.
+
+import { clampNum } from './numInput.js';
+
+/** Font sizes the renderer will accept. Matches clampFontSize in textRender. */
+const FONT_MIN = 6;
+const FONT_MAX = 400;
+
+/**
+ * The text object to store, from what the editor holds.
+ *
+ * @param {any} edit the editor state
+ * @param {any} id the id to store it under - the existing one, or a fresh one for a new text
+ * @returns {any}
+ */
+export function textFromEdit(edit, id) {
+    return {
+        id,
+        // Rounded because a text's position is a pixel on the canvas, and a fractional one only
+        // ever came from a pointer.
+        x: Math.round(edit.x),
+        y: Math.round(edit.y),
+        text: String(edit.text ?? ''),
+        // Ctrl+Enter commits without the size field ever losing focus, so the range that field
+        // would have applied on blur is applied here too.
+        fontSize: clampNum(Number(edit.fontSize) || 36, FONT_MIN, FONT_MAX),
+        fontFamily: edit.fontFamily,
+        color: edit.color,
+        opacity: edit.opacity,
+        visible: edit.visible ?? true,
+        outline: !!edit.outline,
+        outlineColor: edit.outlineColor || '#ffffff',
+        bold: !!edit.bold,
+        italic: !!edit.italic,
+        align: edit.align || 'left',
+        lineHeight: edit.lineHeight ?? 1.25,
+        letterSpacing: edit.letterSpacing ?? 0,
+        shadow: !!edit.shadow,
+        shadowColor: edit.shadowColor || 'rgba(0,0,0,0.5)',
+        shadowBlur: edit.shadowBlur ?? 6,
+        gradient: !!edit.gradient,
+        color2: edit.color2 || '#ffffff',
+        bgColor: edit.bgColor || '',
+        rotation: edit.rotation ?? 0,
+        curve: edit.curve ?? 0,
+        flipX: !!edit.flipX,
+        flipY: !!edit.flipY,
+        anim: edit.anim || null,
+    };
+}
+
+/**
+ * What the editor should hold, from a stored text.
+ *
+ * A text written by an older version, or by hand, may be missing anything. Where a property has
+ * no sensible fixed default the app's current one is used instead - a text with no colour opens
+ * in the colour you are drawing with, which is what someone editing it expects.
+ *
+ * @param {any} t the stored text
+ * @param {{color: string, opacity: number}} now what the app is currently set to
+ * @returns {any}
+ */
+export function editFromText(t, now) {
+    return {
+        x: t.x ?? 0,
+        y: t.y ?? 0,
+        text: t.text ?? '',
+        fontSize: t.fontSize ?? 36,
+        fontFamily: t.fontFamily ?? 'sans-serif',
+        color: t.color ?? now.color,
+        opacity: t.opacity ?? now.opacity,
+        // `!== false` rather than `?? true`: both mean "unless it says otherwise", and this one
+        // also treats a stored null as visible, which is what an older file can hold.
+        visible: t.visible !== false,
+        outline: !!t.outline,
+        outlineColor: t.outlineColor || '#ffffff',
+        bold: !!t.bold,
+        italic: !!t.italic,
+        align: t.align || 'left',
+        lineHeight: t.lineHeight ?? 1.25,
+        letterSpacing: t.letterSpacing ?? 0,
+        shadow: !!t.shadow,
+        shadowColor: t.shadowColor || 'rgba(0,0,0,0.5)',
+        shadowBlur: t.shadowBlur ?? 6,
+        gradient: !!t.gradient,
+        color2: t.color2 || '#ffffff',
+        bgColor: t.bgColor || '',
+        rotation: t.rotation ?? 0,
+        curve: t.curve ?? 0,
+        flipX: !!t.flipX,
+        flipY: !!t.flipY,
+        anim: t.anim || null,
+    };
+}
+
+/**
+ * The editor state for a text that does not exist yet.
+ *
+ * Short on purpose: everything it leaves out, `textFromEdit` fills in when it is written. Listing
+ * them here as well would be a third copy of the defaults, which is the thing this file exists to
+ * stop.
+ *
+ * @param {{x: number, y: number}} at where on the canvas it was placed
+ * @param {{color: string, opacity: number}} now
+ * @returns {any}
+ */
+export function blankTextEdit(at, now) {
+    return {
+        textId: null,
+        x: at.x,
+        y: at.y,
+        text: '',
+        fontSize: 36,
+        fontFamily: 'sans-serif',
+        color: now.color,
+        opacity: now.opacity,
+        visible: true,
+    };
+}

--- a/test/textEdit.test.js
+++ b/test/textEdit.test.js
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { textFromEdit, editFromText, blankTextEdit } from '../src/core/textEdit.js';
+
+const now = { color: '#123456', opacity: 0.7 };
+
+const full = () => ({
+    id: 9, x: 100, y: 200, text: 'hello',
+    fontSize: 48, fontFamily: 'Nanum', color: '#ff0000', opacity: 0.5, visible: true,
+    outline: true, outlineColor: '#00ff00', bold: true, italic: true, align: 'center',
+    lineHeight: 1.5, letterSpacing: 3, shadow: true, shadowColor: '#000', shadowBlur: 12,
+    gradient: true, color2: '#0000ff', bgColor: '#eeeeee', rotation: 15, curve: 30,
+    flipX: true, flipY: true, anim: { inType: 'fade' },
+});
+
+// The test the inline version could not have. Opening a text and writing it straight back must
+// give the text you started with - anything else means the editor quietly changes what it touches.
+test('a text survives being opened and written straight back', () => {
+    const t = full();
+    assert.deepEqual(textFromEdit(editFromText(t, now), t.id), t);
+});
+
+test('and survives it again, so the second save does not differ from the first', () => {
+    const t = full();
+    const once = textFromEdit(editFromText(t, now), t.id);
+    const twice = textFromEdit(editFromText(once, now), t.id);
+    assert.deepEqual(twice, once);
+});
+
+// A text written by an older version, or by hand, may be missing anything at all.
+test('a text with nothing but a position and words comes back complete', () => {
+    const t = { id: 1, x: 10, y: 20, text: 'hi' };
+    const out = textFromEdit(editFromText(t, now), 1);
+    assert.equal(out.fontSize, 36);
+    assert.equal(out.fontFamily, 'sans-serif');
+    assert.equal(out.align, 'left');
+    assert.equal(out.lineHeight, 1.25);
+    assert.equal(out.shadowBlur, 6);
+    assert.equal(out.outlineColor, '#ffffff');
+    assert.equal(out.visible, true);
+    assert.equal(out.anim, null);
+});
+
+test('a text with no colour of its own opens in the colour being drawn with', () => {
+    const e = editFromText({ id: 1, x: 0, y: 0, text: 'x' }, now);
+    assert.equal(e.color, '#123456');
+    assert.equal(e.opacity, 0.7);
+});
+
+test('a hidden text stays hidden, and a null visible is not hidden', () => {
+    assert.equal(editFromText({ visible: false }, now).visible, false);
+    assert.equal(editFromText({ visible: null }, now).visible, true, 'an older file can hold null');
+    assert.equal(editFromText({}, now).visible, true);
+});
+
+test('the position is whole pixels, because a fractional one only came from a pointer', () => {
+    const out = textFromEdit({ ...editFromText(full(), now), x: 10.4, y: 20.6 }, 1);
+    assert.equal(out.x, 10);
+    assert.equal(out.y, 21);
+});
+
+// Ctrl+Enter commits without the size field losing focus, so the range that field would have
+// applied on blur has to be applied on the way out too.
+test('a font size out of range is brought back in on the way out', () => {
+    assert.equal(textFromEdit({ ...editFromText(full(), now), fontSize: 9999 }, 1).fontSize, 400);
+    assert.equal(textFromEdit({ ...editFromText(full(), now), fontSize: 1 }, 1).fontSize, 6);
+    assert.equal(textFromEdit({ ...editFromText(full(), now), fontSize: 'abc' }, 1).fontSize, 36,
+        'unreadable falls back rather than becoming NaN');
+});
+
+test('the id it is written under is the one it is given', () => {
+    assert.equal(textFromEdit(editFromText(full(), now), 77).id, 77);
+});
+
+test('editor-only fields do not reach the stored text', () => {
+    const out = textFromEdit({ ...editFromText(full(), now), cssX: 5, cssY: 6, cutId: 3, layerId: 2 }, 1);
+    for (const k of ['cssX', 'cssY', 'cutId', 'layerId']) {
+        assert.ok(!(k in out), `${k} is the editor's, not the document's`);
+    }
+});
+
+// Short on purpose: what it leaves out, textFromEdit fills in. A third copy of the defaults here
+// is the thing this file exists to stop.
+test('a new text starts with what a new text needs and nothing else', () => {
+    const e = blankTextEdit({ x: 40, y: 50 }, now);
+    assert.equal(e.textId, null);
+    assert.deepEqual([e.x, e.y, e.text], [40, 50, '']);
+    assert.equal(e.color, '#123456');
+    const out = textFromEdit(e, 5);
+    assert.equal(out.align, 'left', 'and the rest is filled in when it is written');
+    assert.equal(out.lineHeight, 1.25);
+});
+
+test('the two directions agree on every field they both name', () => {
+    const written = Object.keys(textFromEdit(editFromText(full(), now), 1)).filter(k => k !== 'id');
+    const opened = Object.keys(editFromText(full(), now));
+    assert.deepEqual(written.sort(), opened.sort(),
+        'a field on one side only is a field that does not survive editing');
+});


### PR DESCRIPTION
A text carries about twenty properties, and the app moved them across **by hand twice** — once opening an existing text into the editor, once writing the editor back out. A third, shorter list starts a new one.

Adding a property meant editing all three, and forgetting one is **silent**: the property simply does not survive being edited, which reads as the editor losing it rather than as a missing line.

## I checked for drift before touching it

Compared the default each side falls back to, field by field. **They had not drifted.** Every difference is explainable:

| | |
|---|---|
| `color`, `opacity`, `fontFamily`, `fontSize` | opening fills in the app's current value where a text has none |
| `x`, `y` | writing out rounds the position |
| `fontSize` | writing out clamps it |
| `visible` | `!== false` and `?? true` mean the same thing |

So this is not a bug fix. It is removing the chance of one.

## What it buys beyond the line count

**The round trip can be tested.** Open a text, write it straight back, and it must be the text you started with; do it twice and the second save must match the first. Neither test could exist while the lists were inline in a component.

Eleven tests, including one that asserts the two directions **name the same set of fields** — a field on one side only is a field that does not survive editing.

`commitText` goes from forty lines to eight.

## One thing deliberately not done

Not one list of field names with a loop over it. The two directions are not symmetrical, and a loop carrying the exceptions would say less than two explicit lists do.

`npm run check` green — 821 tests.