### PR TITLE
refactor: the music track leaves App as a hook

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -235,6 +235,14 @@ Layers: moving, merging, resolving which one a stroke lands on.
 | `offsetLayers` | Shift whole layers, and optionally the cut's texts, by a pixel offset. This is what a move-everything drag commits. |
 | `resolveDrawLayer` | Which layer a stroke should actually go into. The active layer is not always usable: it can be a folder, or point at something that no longer exists. |
 
+## `src/core/mediaEl.js`
+
+The DOM side of the media tracks: `mediaReducer` says what the audio and video are, this says what to do to the elements playing them.
+
+| | |
+|---|---|
+| `detachMedia` | Let go of an `<audio>`/`<video>` element's source. Pause, remove the attribute, then `load()` — without the last one the bytes stay held, and a revoked blob: URL never gives its memory back. |
+
 ## `src/core/mediaReducer.js`
 
 The audio and video tracks, as named actions.
@@ -548,6 +556,14 @@ thumbnails and onion skin should all describe a frame the same way.
 | `visibleCutsAt` | What to draw, which is not the same question: while paused it also includes the cut being edited, or clicking a cut and finding a blank canvas becomes normal. |
 | `onionNeighbours` | The cuts either side on the **same** track. `next` starts at `endTime`, because cuts abut and a strict comparison would find nothing in the common case. |
 | `topCutAt` | The cut the playhead selects: topmost of those it is over, since the upper tracks are what a click would land on. |
+
+## `src/hooks/useAudioTrack.js`
+
+The music track: the element that plays it, the copies of it a save needs, and the four ways one gets loaded or dropped.
+
+| | |
+|---|---|
+| `useAudioTrack` | Owns `audioRef` and the AudioContext the export recorder taps, plus the two extra shapes of the same sound — a base64 dataURL so an `.emv` is self-contained, and a Blob (cached by the dataURL it came from) because IndexedDB can hold one and autosave cannot afford base64. |
 
 ## `src/hooks/useAutosave.js`
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,7 +28,9 @@ import { useServerStorage } from './hooks/useServerStorage.js';
 import { usePanelLayout } from './hooks/usePanelLayout.js';
 import { useLocalDocuments } from './hooks/useLocalDocuments.js';
 import { fetchAsset } from './core/api.js';
+import { detachMedia } from './core/mediaEl.js';
 import { useAutosave } from './hooks/useAutosave.js';
+import { useAudioTrack } from './hooks/useAudioTrack.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
 import { playbackStartFrom } from './core/playbackStart.js';
 import {
@@ -77,29 +79,6 @@ import {
     targetCanvasFor, imageDataCanvas, cutProgress, seekTarget,
 } from './canvas/canvasUtils';
 
-/**
- * Let go of a media element's source.
- *
- * Three steps, and the order is the point: pause first or the browser keeps decoding a source
- * that is being taken away; remove the attribute rather than setting src to '' or the element
- * reloads the page URL as media and logs a failure; then load(), which is what actually drops
- * the buffered data - without it the bytes stay held and a project with a big import never
- * gives them back.
- *
- * Written out six times, three for audio and three for video, and they had drifted: the audio
- * copies left pause() outside the try, so a detached element would throw where the video
- * copies would not.
- *
- * @param {HTMLMediaElement | null | undefined} el
- */
-const detachMedia = (el) => {
-    if (!el) return;
-    try {
-        el.pause();
-        el.removeAttribute('src');
-        el.load();
-    } catch { }
-};
 
 
 const PEN_TYPES = [
@@ -284,29 +263,6 @@ export default function App() {
     // only the writes go through an action. See core/mediaReducer.
     const [media, dispatchMedia] = React.useReducer(mediaReducer, EMPTY_MEDIA);
     const { audioFile, audioUrl, audioDuration, audioData } = media;
-    const audioRef = useRef(null);
-    const audioB64Ref = useRef(null); // audio as base64 data URL, embedded into saves
-    // The same audio as a Blob, for the saves that can hold one.
-    //
-    // The video overlay has had three shapes for a while - a server asset, a Blob, or a base64
-    // dataURL - and the audio only ever had two, no Blob. That gap is why autosave was built with
-    // includeAudio false: writing a whole song into IndexedDB as a base64 string on every
-    // debounce is not something to do. The cost of the workaround was that crash recovery brought
-    // the video overlay back and left the music behind.
-    //
-    // Keyed by the dataURL it came from, so switching tracks or clearing the audio invalidates it
-    // on its own rather than needing every site that touches audioB64Ref to remember to.
-    const audioBlobRef = useRef(/** @type {{src: string|null, blob: Blob|null}} */({ src: null, blob: null }));
-    const audioAsBlob = async () => {
-        const src = audioB64Ref.current;
-        if (!src) return null;
-        if (audioBlobRef.current.src === src) return audioBlobRef.current.blob;
-        try {
-            const blob = await (await fetch(src)).blob();
-            audioBlobRef.current = { src, blob };
-            return blob;
-        } catch { return null; }
-    };
     // Video overlay track: play the original video underneath the drawing layers (no per-frame
     // cuts) - for drawing over a video. Like audio, but painted onto the canvas each frame.
     const { videoOverlay } = media; // { name, startTime, endTime, offset, duration, w, h, cuts? }
@@ -331,6 +287,11 @@ export default function App() {
     const [videoBusyBg, setVideoBusyBg] = useState(false); // extraction moved to a background chip
     // YouTube link input. A native prompt fails silently once blocked, so this asks in-app.
     const [linkPrompt, setLinkPrompt] = useState(null); // {kind:'video'|'audio'}
+
+    const {
+        audioRef, audioB64Ref, audioCtxRef, audioSourceRef, audioDestRef,
+        audioAsBlob, loadAudioUrl, handleAudioUpload, handleDeleteAudio, loadYoutubeAudio,
+    } = useAudioTrack({ audioUrl, dispatchMedia, setLinkPrompt });
     // Make failures visible. Once the browser blocks dialogs, alert is swallowed and the app
     // looks like it simply did nothing - which is exactly why one bug here took so long to find.
     const [appError, setAppError] = useState(null);
@@ -339,9 +300,6 @@ export default function App() {
     const videoStopRef = useRef(false);
     const isExporting = useRef(false);
     const mediaRecorderRef = useRef(null);
-    const audioCtxRef = useRef(null);
-    const audioSourceRef = useRef(null);
-    const audioDestRef = useRef(null);
     const exportEndRef = useRef(0);
     const [tool, setTool] = useState('pen');
     const [rulerMode, setRulerMode] = useState('line'); // the Ruler tool's two options: line and curve
@@ -905,7 +863,9 @@ export default function App() {
     useEffect(() => {
         if (!isPlaying && audioRef.current && audioUrl && Math.abs(audioRef.current.currentTime - currentTime) > 0.1)
             audioRef.current.currentTime = currentTime;
-    }, [currentTime, isPlaying, audioUrl]);
+        // audioRef is listed because the linter can no longer see it is a ref: it comes from
+        // useAudioTrack now, and a ref object's identity never changes, so this costs nothing.
+    }, [currentTime, isPlaying, audioUrl, audioRef]);
     // Paused: seek the overlay video to the scrubbed time so the canvas shows that frame (onseeked repaints).
     useEffect(() => {
         if (isPlaying) return;
@@ -3111,26 +3071,6 @@ export default function App() {
         videoOverlay,
     });
 
-    const loadAudioUrl = (url, name, startAt = 0, offset = 0, clipDur = null) => {
-        dispatchMedia(loadAudio(name, url));
-        const audio = new Audio(url);
-        // startAt aligns the track to a given timeline position (e.g. the first imported video frame);
-        // offset/clipDur select a sub-range of the source audio (used when only a video segment is
-        // imported), so audio + frames extracted together stay mechanically in sync.
-        audio.onloadedmetadata = () => {
-            dispatchMedia(setAudioDuration(audio.duration));
-            const dur = clipDur != null ? Math.min(clipDur, Math.max(0, audio.duration - offset)) : Math.max(0, audio.duration - offset);
-            dispatchMedia(setAudioClip({ startTime: startAt, endTime: startAt + dur, offset }));
-            if (audioRef.current) audioRef.current.src = url;
-        };
-        // Capture base64 once so the project can be saved "with the music".
-        if (url.startsWith('data:')) { audioB64Ref.current = url; }
-        else { fetch(url).then(r => r.blob()).then(b => { const fr = new FileReader(); fr.onload = () => { audioB64Ref.current = fr.result; }; fr.readAsDataURL(b); }).catch(() => { }); }
-    };
-    const handleAudioUpload = (e) => {
-        const file = e.target.files[0]; if (!file) return;
-        loadAudioUrl(URL.createObjectURL(file), file.name);
-    };
     // Lay a whole video under the drawing layers (overlay/rotoscope use). No frame cuts.
     const loadVideoOverlay = (blob, name, startAt = 0, offset = 0, clipDur = null) => {
         videoBlobRef.current = blob;
@@ -3349,22 +3289,6 @@ export default function App() {
             setVideoBusy(null);
             setVideoBusyBg(false);
         }
-    };
-    const handleDeleteAudio = () => {
-        detachMedia(audioRef.current);
-        if (audioUrl && audioUrl.startsWith('blob:')) { try { URL.revokeObjectURL(audioUrl); } catch { } }
-        audioB64Ref.current = null;
-        dispatchMedia(clearAudio());
-    };
-    const loadYoutubeAudio = async (presetUrl) => {
-        const url = typeof presetUrl === 'string' ? presetUrl : null;
-        if (!url) { setLinkPrompt({ kind: 'audio' }); return; }
-        try {
-            const res = await fetch('/api/youtube-audio?url=' + encodeURIComponent(url));
-            if (!res.ok) { const j = await res.json().catch(() => ({})); throw new Error(j.error || ('HTTP ' + res.status)); }
-            const blob = await res.blob();
-            loadAudioUrl(URL.createObjectURL(blob), tr('유튜브 음원'));
-        } catch (e) { alert(tr('음원 추출 실패: ') + e.message); }
     };
     // Transparency cannot survive the recorder. Chrome hands VP9 to the hardware encoder above
     // roughly 480p, and that encoder has no alpha channel - measured here, the background came back

--- a/src/core/mediaEl.js
+++ b/src/core/mediaEl.js
@@ -1,0 +1,26 @@
+// The DOM side of the media tracks. `mediaReducer` holds what the audio and video *are*; this
+// holds the one thing that has to be done to the elements playing them.
+
+/**
+ * Let go of a media element's source.
+ *
+ * Three steps, and the order is the point: pause first or the browser keeps decoding a source
+ * that is being taken away; remove the attribute rather than setting src to '' or the element
+ * reloads the page URL as media and logs a failure; then load(), which is what actually drops
+ * the buffered data - without it the bytes stay held and a project with a big import never
+ * gives them back.
+ *
+ * Written out six times, three for audio and three for video, and they had drifted: the audio
+ * copies left pause() outside the try, so a detached element would throw where the video
+ * copies would not.
+ *
+ * @param {HTMLMediaElement | null | undefined} el
+ */
+export function detachMedia(el) {
+    if (!el) return;
+    try {
+        el.pause();
+        el.removeAttribute('src');
+        el.load();
+    } catch { }
+}

--- a/src/hooks/useAudioTrack.js
+++ b/src/hooks/useAudioTrack.js
@@ -1,0 +1,103 @@
+import { useRef } from 'react';
+import { loadAudio, setAudioDuration, setAudioClip, clearAudio } from '../core/mediaReducer.js';
+import { detachMedia } from '../core/mediaEl.js';
+import { tr } from '../i18n';
+
+/**
+ * The music track: the element that plays it, the copies of it a save needs, and the four ways
+ * one gets loaded or dropped.
+ *
+ * This could leave App whole because of what it does *not* touch. The audio knows nothing about
+ * cuts, layers, the canvas or the timeline - it is a source, a position on the timeline, and a
+ * clip range, all of which live in `mediaReducer` already. What was left in App was the browser
+ * side: an <audio> element, the AudioContext the export recorder taps, and the base64 and Blob
+ * copies that exist so a project can be saved with the music in it.
+ *
+ * The three shapes of the same sound, and why each exists:
+ * - `audioRef` — the element. What plays, and what the recorder taps for the exported video.
+ * - `audioB64Ref` — a base64 dataURL. Self-contained, so an `.emv` file carries the music.
+ * - `audioBlobRef` — the same bytes as a Blob, cached by the dataURL they came from, so
+ *   switching tracks invalidates it without anyone having to remember to. IndexedDB can hold a
+ *   Blob; writing a whole song into it as base64 on every autosave debounce cannot be done.
+ *
+ * @param {object} deps
+ * @param {string | null} deps.audioUrl the current source, from `media`
+ * @param {(action: any) => void} deps.dispatchMedia
+ * @param {(p: any) => void} deps.setLinkPrompt asks for a YouTube URL when none was given
+ */
+export function useAudioTrack({ audioUrl, dispatchMedia, setLinkPrompt }) {
+    const audioRef = useRef(/** @type {HTMLAudioElement | null} */(null));
+    const audioB64Ref = useRef(/** @type {string | null} */(null));
+    const audioBlobRef = useRef(/** @type {{src: string|null, blob: Blob|null}} */({ src: null, blob: null }));
+    // The export recorder mixes the audio into the captured stream through these. Created once,
+    // on the first export, because createMediaElementSource can only be called once per element.
+    const audioCtxRef = useRef(/** @type {AudioContext | null} */(null));
+    const audioSourceRef = useRef(/** @type {MediaElementAudioSourceNode | null} */(null));
+    const audioDestRef = useRef(/** @type {MediaStreamAudioDestinationNode | null} */(null));
+
+    /** The current audio as a Blob, or null. Cached against the dataURL it was made from. */
+    const audioAsBlob = async () => {
+        const src = audioB64Ref.current;
+        if (!src) return null;
+        if (audioBlobRef.current.src === src) return audioBlobRef.current.blob;
+        try {
+            const blob = await (await fetch(src)).blob();
+            audioBlobRef.current = { src, blob };
+            return blob;
+        } catch { return null; }
+    };
+
+    /**
+     * @param {string} url
+     * @param {string} name
+     * @param {number} [startAt] where on the timeline the track begins
+     * @param {number} [offset] where in the source the track begins
+     * @param {number | null} [clipDur] how much of the source to use
+     */
+    const loadAudioUrl = (url, name, startAt = 0, offset = 0, clipDur = null) => {
+        dispatchMedia(loadAudio(name, url));
+        const audio = new Audio(url);
+        // startAt aligns the track to a given timeline position (e.g. the first imported video frame);
+        // offset/clipDur select a sub-range of the source audio (used when only a video segment is
+        // imported), so audio + frames extracted together stay mechanically in sync.
+        audio.onloadedmetadata = () => {
+            dispatchMedia(setAudioDuration(audio.duration));
+            const dur = clipDur != null ? Math.min(clipDur, Math.max(0, audio.duration - offset)) : Math.max(0, audio.duration - offset);
+            dispatchMedia(setAudioClip({ startTime: startAt, endTime: startAt + dur, offset }));
+            if (audioRef.current) audioRef.current.src = url;
+        };
+        // Capture base64 once so the project can be saved "with the music".
+        if (url.startsWith('data:')) { audioB64Ref.current = url; }
+        else { fetch(url).then(r => r.blob()).then(b => { const fr = new FileReader(); fr.onload = () => { audioB64Ref.current = /** @type {string} */(fr.result); }; fr.readAsDataURL(b); }).catch(() => { }); }
+    };
+
+    const handleAudioUpload = (e) => {
+        const file = e.target.files[0]; if (!file) return;
+        loadAudioUrl(URL.createObjectURL(file), file.name);
+    };
+
+    const handleDeleteAudio = () => {
+        detachMedia(audioRef.current);
+        if (audioUrl && audioUrl.startsWith('blob:')) { try { URL.revokeObjectURL(audioUrl); } catch { } }
+        audioB64Ref.current = null;
+        dispatchMedia(clearAudio());
+    };
+
+    // Its own fetch rather than `apiFetch`: this endpoint answers a failure with a JSON body
+    // explaining what yt-dlp said, and that sentence is the whole value of the error here.
+    const loadYoutubeAudio = async (presetUrl) => {
+        const url = typeof presetUrl === 'string' ? presetUrl : null;
+        if (!url) { setLinkPrompt({ kind: 'audio' }); return; }
+        try {
+            const res = await fetch('/api/youtube-audio?url=' + encodeURIComponent(url));
+            if (!res.ok) { const j = await res.json().catch(() => ({})); throw new Error(j.error || ('HTTP ' + res.status)); }
+            const blob = await res.blob();
+            loadAudioUrl(URL.createObjectURL(blob), tr('유튜브 음원'));
+        } catch (e) { alert(tr('음원 추출 실패: ') + e.message); }
+    };
+
+    return {
+        audioRef, audioB64Ref, audioBlobRef, audioCtxRef, audioSourceRef, audioDestRef,
+        audioAsBlob, loadAudioUrl, handleAudioUpload, handleDeleteAudio, loadYoutubeAudio,
+    };
+}


### PR DESCRIPTION
## Why this one

I measured seam cost across what is left in App — for each candidate group, how many App names it reads that it does not own. The audio cluster was the clearest by a distance:

| group | names | lines | reads from outside |
|---|---|---|---|
| **audio** | 11 | 86 | **4** |
| video import/overlay | 19 | 163 | 19 |
| text objects | 23 | 278 | 21 |
| drawing/strokes | 14 | 430 | 67 |

Audio knows nothing about cuts, layers, the canvas or the timeline. Where the track sits and which part of it plays already live in `mediaReducer`; what was still in App was the browser side.

## What moved

**`src/hooks/useAudioTrack.js`** — `audioRef`, the three AudioContext refs the export recorder taps, `audioB64Ref`/`audioBlobRef`, and `audioAsBlob`, `loadAudioUrl`, `handleAudioUpload`, `handleDeleteAudio`, `loadYoutubeAudio`. Its doc comment finally writes down why the same sound is kept in three shapes, which was spread across three separate comments before.

**`src/core/mediaEl.js`** — `detachMedia`. App and the hook both need it and neither owns it; same reason `core/api.js` exists.

## Behaviour

None intended. Everything is moved verbatim — including `loadYoutubeAudio` keeping its own `fetch` rather than `apiFetch`, because that endpoint answers failure with a JSON body explaining what yt-dlp said and that sentence is the whole value of the error.

One dependency array gains `audioRef`: the linter could see it was a ref while it was declared in App and cannot now. A ref object's identity never changes, so listing it costs nothing — and it keeps the warning count at 8 rather than 9.

## Numbers

App.jsx **3945 → 3868**. `npm run check`: 810 tests, 8 hook warnings (unchanged), 257 helpers indexed, reachability 385/385, i18n 548 strings, build clean.

## Worth a manual look

Audio is one of the paths a test cannot reach, so: load an audio file, load one from a YouTube link, delete the track, save and reopen a project with music in it (both `.emv` and the server), and start a video export with audio so the recorder taps the AudioContext.