### PR TITLE
refactor: the sway slicing leaves paintFrame, with the seam property pinned

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -496,6 +496,16 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `SWING` | The three shapes a return animation can take. `through` passes the resting position and goes out the other side, which is what the layer presets are made of - 둥실둥실 bobs above and below. `there` and `along` go out to the target and back and never past the start. One cycle is one whole trip in all three, so speed means the same thing to each. |
 | `swing` | A return animation's progress for one of those shapes, or 0 once it has run out of repeats. Settling at 0 rather than mid-wave is where a whole trip would have ended anyway. |
 
+## `src/canvas/swayRender.js`
+
+Bending a layer along an axis - hair swinging from its roots, a ribbon trailing from where it is held.
+
+| | |
+|---|---|
+| `drawSwayed` | Draw a layer canvas bent by its profile, in slices, respecting the caller's transform. |
+| `swaySlices` | The shear each slice gets, as `offset(a) = k*a + m`. Separate from the drawing because this is where the correctness lives: a slice that translates rigidly instead of shearing tears the image into visible bands. |
+| `SWAY_SLICES` | How many slices. More only fits the curve better — it is the shear, not the count, that removes the seams. |
+
 ## `src/canvas/textLayout.js`
 
 Where each character of a line goes, for curving and for animating characters separately.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ import { useServerStorage } from './hooks/useServerStorage.js';
 import { usePanelLayout } from './hooks/usePanelLayout.js';
 import { useLocalDocuments } from './hooks/useLocalDocuments.js';
 import { fetchAsset } from './core/api.js';
+import { drawSwayed } from './canvas/swayRender.js';
 import { useAutosave } from './hooks/useAutosave.js';
 import { nextProbeDelay } from './core/probeBackoff.js';
 import { playbackStartFrom } from './core/playbackStart.js';
@@ -73,7 +74,7 @@ import {
     DEFAULT_CUT_DURATION, CANVAS_W as CANVAS_W_DEFAULT, CANVAS_H as CANVAS_H_DEFAULT, FONT_PRESETS, fontGroups,
     pointInPolygon, dist, safeArray, hexToRgb, bucketFillTransparentRegion,
     layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas,
-    flattenForCanvas, flattenLayersInUiOrder, layerSig, applyCutAnim, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, swayWeightAt, morphPrepare,
+    flattenForCanvas, flattenLayersInUiOrder, layerSig, applyCutAnim, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, morphPrepare,
     accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
     targetCanvasFor, imageDataCanvas, cutProgress, seekTarget,
 } from './canvas/canvasUtils';
@@ -116,6 +117,8 @@ const PEN_TYPES = [
     { id: 'fill', label: 'Fill', Icon: PaintBucket },
 ];
 const BOIL_FPS = 10; // how many times a second the boiling-line motion advances
+/** How faint a neighbouring drawing is under the one being worked on. */
+const ONION_ALPHA = 0.35;
 const TIMELINE_MIN_SPAN = 240; // seconds of ruler even with nothing in the project
 const TIMELINE_TAIL_PAD = 60;  // empty room past the end, to drag into
 // How many distinct wobbles the boiling line cycles through. A hand-drawn boiling line is a
@@ -2786,25 +2789,16 @@ export default function App() {
             }
         }
 
-        if (!playing && primary) {
-            if (onionPrev) {
-                const prevCut = onionNeighbours(cuts, primary).prev;
-                if (prevCut) {
-                    const order = flattenLayersInUiOrder(prevCut.layers || []).filter(l => l.type === 'layer' && l.visible !== false);
-                    for (let i = order.length - 1; i >= 0; i--) {
-                        const lc = ensureLayerCanvas(prevCut.id, order[i]);
-                        if (lc) { ctx.globalAlpha = 0.35; ctx.drawImage(lc, 0, 0); ctx.globalAlpha = 1.0; }
-                    }
-                }
-            }
-            if (onionNext) {
-                const nextCut = onionNeighbours(cuts, primary).next;
-                if (nextCut) {
-                    const order = flattenLayersInUiOrder(nextCut.layers || []).filter(l => l.type === 'layer' && l.visible !== false);
-                    for (let i = order.length - 1; i >= 0; i--) {
-                        const lc = ensureLayerCanvas(nextCut.id, order[i]);
-                        if (lc) { ctx.globalAlpha = 0.35; ctx.drawImage(lc, 0, 0); ctx.globalAlpha = 1.0; }
-                    }
+        // Onion skin: the neighbouring drawings, faint, so a new one can be lined up against
+        // them. Paused only - during playback the next frame is about to be shown anyway.
+        if (!playing && primary && (onionPrev || onionNext)) {
+            const { prev, next } = onionNeighbours(cuts, primary);
+            for (const cut of [onionPrev ? prev : null, onionNext ? next : null]) {
+                if (!cut) continue;
+                const order = flattenLayersInUiOrder(cut.layers || []).filter(l => l.type === 'layer' && l.visible !== false);
+                for (let i = order.length - 1; i >= 0; i--) {
+                    const lc = ensureLayerCanvas(cut.id, order[i]);
+                    if (lc) { ctx.globalAlpha = ONION_ALPHA; ctx.drawImage(lc, 0, 0); ctx.globalAlpha = 1.0; }
                 }
             }
         }
@@ -2844,30 +2838,10 @@ export default function App() {
                 if (layerDragRef.current && layerDragRef.current.cutId === ac.id
                     && layerDragRef.current.layerIds.includes(l.id)) { ctx.restore(); continue; }
                 if (la?.swayProfile && (!shouldMask || (!mb && !mi))) {
-                    // Per-point sway: the layer is sliced along the axis and each slice bends by a
-                    // different amount. That is non-affine, so a single shear cannot express it.
-                    // The key is that translating each slice as a rigid block makes the edges
-                    // mismatch and the image tear. Giving each slice a shear instead makes the
-                    // displacement vary continuously within it, and matching the boundary value to
-                    // the neighbour exactly leaves no seam.
-                    const SLICES = 64;
-                    const vertical = la.swayAxis === 'y';
-                    const span = vertical ? CANVAS_H : CANVAS_W;
-                    const dispAt = (pos) => la.swayDisp * swayWeightAt(la.swayProfile, pos / span);
-                    for (let sIdx = 0; sIdx < SLICES; sIdx++) {
-                        const a0 = Math.round(sIdx * span / SLICES);
-                        const a1 = Math.round((sIdx + 1) * span / SLICES);
-                        const len = a1 - a0; if (len <= 0) continue;
-                        const d0 = dispAt(a0), d1 = dispAt(a1);
-                        const k = (d1 - d0) / len;  // gradient within the slice
-                        const m = d0 - k * a0;      // so that it equals d0 exactly at a0
-                        ctx.save();
-                        // The coordinate along the axis is left untouched (diagonal term 1, that
-                        // off-diagonal 0), so the slices butt together without gaps.
-                        if (vertical) { ctx.transform(1, 0, k, 1, m, 0); ctx.drawImage(layerCanvas, 0, a0, CANVAS_W, len, 0, a0, CANVAS_W, len); }
-                        else { ctx.transform(1, k, 0, 1, 0, m); ctx.drawImage(layerCanvas, a0, 0, len, CANVAS_H, a0, 0, len, CANVAS_H); }
-                        ctx.restore();
-                    }
+                    drawSwayed(ctx, layerCanvas, {
+                        profile: la.swayProfile, axis: la.swayAxis, disp: la.swayDisp,
+                        cw: CANVAS_W, ch: CANVAS_H,
+                    });
                 } else if (!shouldMask || (!mb && !mi)) {
                     ctx.drawImage(layerCanvas, 0, 0);
                 } else {

--- a/src/canvas/swayRender.js
+++ b/src/canvas/swayRender.js
@@ -1,0 +1,82 @@
+import { swayWeightAt } from './canvasUtils.js';
+
+/**
+ * Bending a layer along an axis: hair swinging from its roots, a ribbon trailing from where it
+ * is held.
+ *
+ * The displacement varies along the axis - that is the whole point of a profile - so a single
+ * transform cannot express it. An affine matrix moves every pixel by the same rule, and what is
+ * wanted here is a different offset at every height.
+ *
+ * The layer is therefore drawn in slices. The mistake worth writing down is the obvious version:
+ * translate each slice as a rigid block by the displacement at its centre. That leaves a step
+ * between neighbouring slices, and the drawing comes out visibly torn into bands.
+ *
+ * What works is giving each slice a *shear* instead of a translation. Inside a slice the offset
+ * then varies linearly, and the line is chosen to pass through the true displacement at both of
+ * the slice's own boundaries - so where two slices meet, both agree on the offset exactly and
+ * there is no seam, at any slice count. More slices only make the piecewise-linear curve a
+ * closer fit to the profile; they are not what removes the tearing.
+ */
+
+/** Slices across the span. Enough that the straight segments read as a curve. */
+export const SWAY_SLICES = 64;
+
+/**
+ * The shear for each slice: `offset(a) = k * a + m`, in the coordinate along the axis.
+ *
+ * Separate from the drawing because this is where the correctness lives - the boundary values
+ * either match or the image tears - and a canvas is a bad place to check that.
+ *
+ * @param {object} args
+ * @param {Array<number | {p: number, w: number}>} args.profile
+ * @param {number} args.disp full displacement in pixels, at weight 1
+ * @param {number} args.span the canvas edge along the axis
+ * @param {number} [args.slices]
+ * @returns {Array<{a0: number, len: number, k: number, m: number}>}
+ */
+export function swaySlices({ profile, disp, span, slices = SWAY_SLICES }) {
+    const dispAt = (pos) => disp * swayWeightAt(profile, pos / span);
+    const out = [];
+    for (let i = 0; i < slices; i++) {
+        // Rounded to whole pixels so the source rectangles tile the span exactly; the last
+        // slice absorbs the remainder rather than a fractional strip being left over.
+        const a0 = Math.round(i * span / slices);
+        const a1 = Math.round((i + 1) * span / slices);
+        const len = a1 - a0;
+        if (len <= 0) continue;
+        const d0 = dispAt(a0), d1 = dispAt(a1);
+        const k = (d1 - d0) / len;  // gradient within the slice
+        const m = d0 - k * a0;      // so that it equals d0 exactly at a0
+        out.push({ a0, len, k, m });
+    }
+    return out;
+}
+
+/**
+ * Draw `src` onto `ctx`, bent by the profile.
+ *
+ * The caller's transform is respected: each slice saves, applies its own shear on top, draws,
+ * and restores.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {CanvasImageSource} src a canvas the size of the frame
+ * @param {object} args
+ * @param {Array<number | {p: number, w: number}>} args.profile
+ * @param {'x'|'y'} args.axis which way the slices run
+ * @param {number} args.disp
+ * @param {number} args.cw
+ * @param {number} args.ch
+ */
+export function drawSwayed(ctx, src, { profile, axis, disp, cw, ch }) {
+    const vertical = axis === 'y';
+    const span = vertical ? ch : cw;
+    for (const { a0, len, k, m } of swaySlices({ profile, disp, span })) {
+        ctx.save();
+        // The coordinate along the axis is left untouched (diagonal term 1, that off-diagonal 0),
+        // so the slices butt together without gaps.
+        if (vertical) { ctx.transform(1, 0, k, 1, m, 0); ctx.drawImage(src, 0, a0, cw, len, 0, a0, cw, len); }
+        else { ctx.transform(1, k, 0, 1, 0, m); ctx.drawImage(src, a0, 0, len, ch, a0, 0, len, ch); }
+        ctx.restore();
+    }
+}

--- a/test/swayRender.test.js
+++ b/test/swayRender.test.js
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { swaySlices, SWAY_SLICES } from '../src/canvas/swayRender.js';
+import { swayWeightAt } from '../src/canvas/canvasUtils.js';
+
+const SPAN = 1080;
+const DISP = 120;
+// A profile with a real bend in it, so the slices have something to disagree about.
+const PROFILE = [0, 0.2, 1, 0.4];
+
+/** The offset one slice puts at position `a`. */
+const offsetAt = (s, a) => s.k * a + s.m;
+
+test('slices tile the span exactly - no gap and no overlap', () => {
+    const s = swaySlices({ profile: PROFILE, disp: DISP, span: SPAN });
+    assert.equal(s[0].a0, 0);
+    for (let i = 1; i < s.length; i++) {
+        assert.equal(s[i].a0, s[i - 1].a0 + s[i - 1].len, `slice ${i} does not start where ${i - 1} ends`);
+    }
+    assert.equal(s.at(-1).a0 + s.at(-1).len, SPAN);
+});
+
+test('neighbouring slices agree exactly at their shared edge - this is what stops the tearing', () => {
+    const s = swaySlices({ profile: PROFILE, disp: DISP, span: SPAN });
+    for (let i = 1; i < s.length; i++) {
+        const edge = s[i].a0;
+        const left = offsetAt(s[i - 1], edge);
+        const right = offsetAt(s[i], edge);
+        // Not "close enough": both sides are computed from the same dispAt(edge), so the only
+        // difference either can have is floating-point noise from the k*a + m round trip.
+        assert.ok(Math.abs(left - right) < 1e-9, `seam of ${left - right}px at ${edge}`);
+    }
+});
+
+test('each slice hits the true displacement at both of its own ends', () => {
+    const s = swaySlices({ profile: PROFILE, disp: DISP, span: SPAN });
+    for (const sl of s) {
+        for (const a of [sl.a0, sl.a0 + sl.len]) {
+            const want = DISP * swayWeightAt(PROFILE, a / SPAN);
+            assert.ok(Math.abs(offsetAt(sl, a) - want) < 1e-9, `slice at ${sl.a0} is off by ${offsetAt(sl, a) - want} at ${a}`);
+        }
+    }
+});
+
+test('the seam property does not depend on the slice count', () => {
+    for (const slices of [1, 2, 7, 64, 256]) {
+        const s = swaySlices({ profile: PROFILE, disp: DISP, span: SPAN, slices });
+        for (let i = 1; i < s.length; i++) {
+            const edge = s[i].a0;
+            assert.ok(Math.abs(offsetAt(s[i - 1], edge) - offsetAt(s[i], edge)) < 1e-9,
+                `${slices} slices: seam at ${edge}`);
+        }
+    }
+});
+
+test('a span that does not divide by the slice count still tiles it', () => {
+    // 1001 / 64 is not whole, which is where a rounding bug would leave a one-pixel strip.
+    const s = swaySlices({ profile: PROFILE, disp: DISP, span: 1001 });
+    assert.equal(s.at(-1).a0 + s.at(-1).len, 1001);
+    for (let i = 1; i < s.length; i++) assert.equal(s[i].a0, s[i - 1].a0 + s[i - 1].len);
+});
+
+test('a span smaller than the slice count drops the empty slices rather than dividing by zero', () => {
+    const s = swaySlices({ profile: PROFILE, disp: DISP, span: 10 });
+    assert.ok(s.length <= 10 && s.length > 0);
+    for (const sl of s) assert.ok(sl.len > 0 && Number.isFinite(sl.k) && Number.isFinite(sl.m));
+    assert.equal(s.at(-1).a0 + s.at(-1).len, 10);
+});
+
+test('a flat profile is a rigid translation - every slice shares one offset and no gradient', () => {
+    const s = swaySlices({ profile: [0.5, 0.5], disp: DISP, span: SPAN });
+    for (const sl of s) {
+        assert.equal(sl.k, 0);
+        assert.ok(Math.abs(sl.m - DISP * 0.5) < 1e-9);
+    }
+});
+
+test('SWAY_SLICES is the default', () => {
+    assert.equal(swaySlices({ profile: PROFILE, disp: DISP, span: SPAN }).length,
+        swaySlices({ profile: PROFILE, disp: DISP, span: SPAN, slices: SWAY_SLICES }).length);
+});


### PR DESCRIPTION
`paintFrame` is 319 lines — the longest thing left in App. The sway slicing was the piece with the least to do with the rest of it: given a canvas and a profile it is arithmetic, and the arithmetic is where the only real hazard lives.

## The hazard, now checkable

Translating each slice rigidly by its own displacement leaves a step at every boundary, and the drawing comes out torn into visible bands. Shearing each slice instead — along a line through the true displacement at **both** of its own edges — makes neighbours agree exactly, at any slice count. More slices fit the curve better; they are not what removes the tearing.

That was a paragraph of comment inside a render loop. It is now `swaySlices`, which returns `{a0, len, k, m}` per slice, with `drawSwayed` as the thin canvas half — so the property can be tested without a canvas.

## Tests that can fail

Eight, and I checked they bite: replacing the shear with the rigid translation the comment warns about fails three of them.

```
not ok 2 - neighbouring slices agree exactly at their shared edge
not ok 3 - each slice hits the true displacement at both of its own ends
not ok 4 - the seam property does not depend on the slice count
```

They also cover the tiling (no gap, no overlap, last slice absorbs the rounding remainder at spans like 1001) and a span smaller than the slice count, where empty slices are dropped rather than dividing by zero.

## Also here

Three lines away, the onion-skin pass was the same eight lines written twice — once for the previous drawing, once for the next — each calling `onionNeighbours(cuts, primary)` again. One loop over the two, one call, and `0.35` gets the name `ONION_ALPHA`.

## Behaviour

None intended. The slicing is the same arithmetic, moved.

## Numbers

App.jsx **3883 → 3843**. `npm run check`: 829 tests, 8 hook warnings (unchanged), 261 helpers indexed, reachability 396/396, i18n 548, build clean.

Worth a look on the tablet: a layer with 흔들림 on, on both axes, at a strength high enough to see the bend — it should look exactly as it did.

Once #137 lands, this file is where the positioned-point profile gets its equivalence test (an evenly spaced `[0,1,0]` and the explicit `{p,w}` spelling of the same shape must slice identically); I left that test out here because `swayWeightAt` on main does not read the new shape yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)