### PR TITLE
refactor: the layer rows are a component, not a render prop

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef, useCallback, useLayoutEffect, useMemo } from 'react';
-import { X, Plus, Trash2, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, ClipboardPaste, GitBranch, Move, Type, Cloud, Film, Repeat, Minus, Waves, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw, ArrowDownToLine, CornerDownRight } from 'lucide-react';
+import { X, Plus, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, Folder, ClipboardPaste, GitBranch, Move, Type, Cloud, Repeat, Minus, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw } from 'lucide-react';
 import './App.css';
 import { saveAutosave, loadAutosave, saveProject, loadProject, listProjects, deleteProject, autosaveKey } from './db';
-import { CutAnimPanel, LayerAnimPanel, JitterPanel } from './ui/AnimPanels';
+import { CutAnimPanel } from './ui/AnimPanels';
 import { NumField, clampNum } from './ui/NumField';
 import ColorPanel, { RECENT_SLOTS } from './ui/ColorPanel';
 import { TopBar } from './ui/TopBar';
@@ -49,7 +49,7 @@ import {
     cutsReducer, replaceCuts, addCuts, updateCut, setCutAnim, setCutCamera, clearCut,
     updateLayer, setLayerAnim, moveLayers, upsertText, moveText, deleteText, toggleTextVisible as toggleTextVisibleAction,
     assignPartTo, renamePart as renamePartAction, ungroupPart as ungroupPartAction, removeBatch,
-    insertCutsShifting, deleteTrack, moveCutGroup, replaceBatchCuts, mergeLayerDown, patchCut, patchCuts,
+    insertCutsShifting, deleteTrack, moveCutGroup, replaceBatchCuts, patchCut, patchCuts,
 } from './core/cutsReducer.js';
 import { measureTextBox as measureTextBoxPure, textNeedsBox, drawTextObject } from './canvas/textRender.js';
 import { migrateCuts, projectSettings, makeLoadProgress } from './core/projectFormat.js';
@@ -62,8 +62,7 @@ import { dragOnWindow } from './core/windowDrag.js';
 // rather than of whichever layer happens to be selected.
 
 import { computeCamera, applyCamera } from './core/camera.js';
-import { clipGroups, canClip } from './core/clipping.js';
-import { setLayerClipped } from './core/cutsReducer.js';
+import { clipGroups } from './core/clipping.js';
 import { onionNeighbours, topCutAt } from './engine/selectCuts.js';
 import { evaluateFrame } from './engine/evaluateFrame.js';
 import { pendingBitmapIds, scanLayerBitmaps } from './engine/pendingBitmaps.js';
@@ -78,7 +77,7 @@ import {
     layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas,
     flattenForCanvas, flattenLayersInUiOrder, layerSig, applyCutAnim, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, morphPrepare,
     accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
-    targetCanvasFor, imageDataCanvas, cutProgress, seekTarget,
+    targetCanvasFor, imageDataCanvas, seekTarget,
 } from './canvas/canvasUtils';
 
 
@@ -198,22 +197,6 @@ const TOOL_TYPES = [
     ...PEN_TYPES,
 ];
 
-function LayerThumbnail({ layer, cutId, layerCanvasCache }) {
-    const ref = useRef(null);
-    const key = layerKey(cutId, layer.id);
-    // Read outside the effect so the dependency is a value the linter can check, rather than an
-    // expression it has to give up on - which is what hid 'key' and the cache itself from it.
-    const layerCanvas = layerCanvasCache[key];
-    useEffect(() => {
-        const c = ref.current; if (!c) return;
-        const ctx = c.getContext('2d');
-        ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, 56, 31);
-        if (layerCanvas) {
-            ctx.drawImage(layerCanvas, 0, 0, 56, 31);
-        }
-    }, [layer, layerCanvas]);
-    return <canvas ref={ref} width={56} height={31} style={{ width: 42, height: 23, borderRadius: 3, background: '#fff', flexShrink: 0, border: '1px solid hsl(var(--ui-h) var(--ui-s) 22%)' }} />;
-}
 
 
 export default function App() {
@@ -3361,86 +3344,17 @@ export default function App() {
         exportEndRef.current = playEnd; isExporting.current = true; mediaRecorderRef.current = mr; mr.start(); setIsPlaying(true);
     };
 
-    const renderLayers = (cut, parentId = null, depth = 0) => {
-        return cut.layers.filter(l => (l.parentId ?? null) === parentId).map(layer => {
-            const isFolder = layer.type === 'folder';
-            const isDragging = dragLayerInfo?.layerId === layer.id;
-            const dt = dropInfo?.layerId === layer.id ? dropInfo.position : null;
-            return (
-                <div key={layer.id} style={{ opacity: isDragging ? 0.4 : 1 }}>
-                    {dt === 'before' && <div className="drop-line" />}
-                    <div
-                        className={`layer-row${!isFolder && cut.activeLayerId === layer.id ? ' layer-active' : ''}${isFolder ? ' layer-folder' : ''}${dt === 'inside' ? ' drop-inside' : ''}`}
-                        style={{ paddingLeft: depth * 14 + 6 }}
-                        draggable
-                        onDragStart={e => onLayerDragStart(e, cut.id, layer.id)}
-                        onDragOver={e => onLayerDragOver(e, layer.id, layer.type)}
-                        onDrop={e => onLayerDrop(e, cut.id, layer.id)}
-                        onDragEnd={onLayerDragEnd}
-                        onClick={e => !isFolder && handleSetActive(e, cut.id, layer.id)}
-                    >
-                        {isFolder
-                            ? <button className="icon-btn" onClick={e => handleToggleFolder(e, cut.id, layer.id)}>{layer.collapsed ? <ChevronRight size={11} /> : <ChevronDown size={11} />}</button>
-                            : <span style={{ width: 11, flexShrink: 0, display: 'inline-block' }} />}
-                        {isFolder
-                            ? (layer.collapsed ? <Folder size={13} style={{ color: '#888', marginRight: 4, flexShrink: 0 }} /> : <FolderOpen size={13} style={{ color: '#aaa', marginRight: 4, flexShrink: 0 }} />)
-                            : <LayerThumbnail layer={layer} cutId={cut.id} layerCanvasCache={layerCanvasCache} />}
-                        <button className="icon-btn" style={{ marginLeft: 4 }} onClick={e => handleToggleVisible(e, cut.id, layer.id)}>
-                            {layer.visible ? <Eye size={10} /> : <EyeOff size={10} style={{ color: '#555' }} />}
-                        </button>
-                        <span className="layer-name">{layer.name}</span>
-                        {!isFolder && (
-                            <button className="icon-btn" style={{ color: layer.roughen ? '#e0a84e' : undefined }}
-                                title={layer.roughen ? tr('자글자글 모션 (강도 {0}) — 클릭: 설정 열기', layer.roughen) : tr('자글자글 모션 설정 (이미 그린 선이 제자리에서 부글거림)')}
-                                onClick={e => toggleJitterPanel(e, cut.id, layer.id)}>
-                                <Waves size={11} />
-                            </button>
-                        )}
-                        {!isFolder && (() => {
-                            // Shown even where it cannot apply, greyed out: hiding it would make
-                            // the row's controls shift position as layers are reordered, which is
-                            // worse than a disabled button.
-                            const clippable = canClip(flattenLayersInUiOrder(cut.layers || []).filter(l => l.type === 'layer'), layer.id);
-                            return (
-                                <button className="icon-btn" disabled={!clippable && !layer.clipped}
-                                    style={{ color: layer.clipped ? 'var(--accent-pale)' : undefined, opacity: (clippable || layer.clipped) ? 1 : 0.3 }}
-                                    title={layer.clipped
-                                        ? tr('클리핑 해제 (지금은 아래 레이어가 그려진 곳에만 보입니다)')
-                                        : clippable
-                                            ? tr('아래 레이어에 클리핑 — 아래 레이어가 그려진 곳에만 보이게 합니다')
-                                            : tr('맨 아래 레이어는 클리핑할 대상이 없습니다')}
-                                    onClick={e => { e.stopPropagation(); dispatchCuts(setLayerClipped(cut.id, layer.id, !layer.clipped)); }}>
-                                    <CornerDownRight size={11} />
-                                </button>
-                            );
-                        })()}
-                        {!isFolder && (
-                            <button className="icon-btn" title={tr('아래 레이어와 병합')}
-                                onClick={e => { e.stopPropagation(); dispatchCuts(mergeLayerDown(cut.id, layer.id, flattenLayersInUiOrder)); }}>
-                                <ArrowDownToLine size={11} />
-                            </button>
-                        )}
-                        {!isFolder && (
-                            <button className="icon-btn" style={{ color: layer.anim ? 'var(--accent-soft)' : undefined }} title={tr('파츠 애니메이션')}
-                                onClick={e => { e.stopPropagation(); setAnimLayer(a => (a && a.cutId === cut.id && a.layerId === layer.id) ? null : { cutId: cut.id, layerId: layer.id }); }}>
-                                <Film size={11} />
-                            </button>
-                        )}
-                        <button className="icon-btn del-btn" onClick={e => handleDeleteLayer(e, cut.id, layer.id)}><Trash2 size={11} /></button>
-                    </div>
-                    {!isFolder && jitterLayer && jitterLayer.cutId === cut.id && jitterLayer.layerId === layer.id && (
-                        <JitterPanel cut={cut} layer={layer} updLayer={updLayerProps} />
-                    )}
-                    {!isFolder && animLayer && animLayer.cutId === cut.id && animLayer.layerId === layer.id && (
-                        <LayerAnimPanel cut={cut} layer={layer} updLayerAnim={updLayerAnim} updLayers={updLayers} pathCapture={pathCapture} setPathCapture={setPathCapture}
-                            cutProgress={cutProgress(cut, currentTime)} />
-                    )}
-                    {dt === 'after' && <div className="drop-line" />}
-                    {isFolder && !layer.collapsed && renderLayers(cut, layer.id, depth + 1)}
-                </div>
-            );
-        });
+    // Everything a layer row needs, as against everything the panel around it needs. Grouped
+    // rather than listed flat for the same reason usePlayback groups its inputs: twenty names
+    // threaded one by one through a panel that uses none of them is not clearer than one that
+    // says what the bundle is.
+    const layerRows = {
+        animLayer, currentTime, dispatchCuts, dragLayerInfo, dropInfo, handleDeleteLayer,
+        handleSetActive, handleToggleFolder, handleToggleVisible, jitterLayer, layerCanvasCache,
+        onLayerDragEnd, onLayerDragOver, onLayerDragStart, onLayerDrop, pathCapture,
+        setAnimLayer, setPathCapture, toggleJitterPanel, updLayerAnim, updLayerProps, updLayers,
     };
+
 
     // Tool panel: the buttons keep a comfortable size and the column count follows the width.
     // Named rather than inlined as [!!textEdit]: a dependency the linter cannot read is a
@@ -3507,7 +3421,7 @@ export default function App() {
                     handleCutClick={handleCutClick} handleDeleteCut={handleDeleteCut}
                     handleDuplicateCut={handleDuplicateCut} handlePasteCut={handlePasteCut}
                     handleSetTool={handleSetTool} openEditText={openEditText} renameCut={renameCut}
-                    renamingCutId={renamingCutId} renderLayers={renderLayers} rightW={rightW}
+                    renamingCutId={renamingCutId} layerRows={layerRows} rightW={rightW}
                     selectedCutIds={selectedCutIds} selectedText={selectedText} setDragLayerInfo={setDragLayerInfo}
                     setDropInfo={setDropInfo} setRenamingCutId={setRenamingCutId} setSelectedText={setSelectedText}
                     setShowRight={setShowRight} showRight={showRight} toggleCutCollapse={toggleCutCollapse}

--- a/src/ui/CutLayerPanel.jsx
+++ b/src/ui/CutLayerPanel.jsx
@@ -2,18 +2,19 @@ import React from 'react';
 import { Plus, FolderPlus, Trash2, Copy, CopyPlus, ClipboardPaste, Eye, EyeOff, Settings, ChevronDown, ChevronRight } from 'lucide-react';
 import { safeArray } from '../canvas/canvasUtils';
 import { CutAnimPanel, CameraPanel } from './AnimPanels';
+import { LayerRows } from './LayerRows';
 import { tr } from '../i18n';
 
 // CUT / LAYER panel: the cut list, each cut's layer tree, cut animation and text list.
-// The layer rows themselves are drawn by App's renderLayers - the drag state lives in App,
-// so that part stays delegated.
+// The rows of each tree are LayerRows; everything they need arrives as the `layerRows` bundle
+// and is passed straight through, because none of it is this panel's business.
 export function CutLayerPanel({
     collapsedCutIds, copiedCut, currentCutId, cuts, deleteTextObject,
     deleteVideoBatch, dragLayerInfo, expandedCuts, handleAddCut, handleAddFolder,
     handleAddLayer, handleCopyCut, handleCutClick, handleDeleteCut, handleDuplicateCut,
     handlePasteCut, handleSetTool, openEditText, renameCut, renamingCutId,
     updCutCamera, cameraCapture, setCameraCapture, canvasW, canvasH,
-    renderLayers, rightW, selectedCutIds, selectedText, setDragLayerInfo,
+    layerRows, rightW, selectedCutIds, selectedText, setDragLayerInfo,
     setDropInfo, setRenamingCutId, setSelectedText, setShowRight, showRight,
     toggleCutCollapse, toggleCutSettings, toggleTextVisible, updCutAnim, updCutTime,
     updLayers, videoBatches, rightTab, setRightTab, textEditorBody, cancelText,
@@ -91,7 +92,7 @@ export function CutLayerPanel({
                                 </div>
                             )}
                             <div className="layer-list" onDragOver={e => e.preventDefault()} onDrop={e => { e.preventDefault(); if (dragLayerInfo && dragLayerInfo.cutId === cut.id) { updLayers(cut.id, c => { const layers = [...c.layers], di = layers.findIndex(l => l.id === dragLayerInfo.layerId), dragged = { ...layers[di], parentId: null }; layers.splice(di, 1); layers.push(dragged); return { layers }; }); setDragLayerInfo(null); setDropInfo(null); } }}>
-                                {renderLayers(cut)}
+                                <LayerRows cut={cut} rows={layerRows} />
                             </div>
                             {cut.id === currentCutId && (
                                 <div className="text-panel">

--- a/src/ui/LayerRows.jsx
+++ b/src/ui/LayerRows.jsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useRef } from 'react';
+import { ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, Waves, CornerDownRight, ArrowDownToLine, Film, Trash2 } from 'lucide-react';
+import { flattenLayersInUiOrder, layerKey, cutProgress } from '../canvas/canvasUtils';
+import { canClip } from '../core/clipping.js';
+import { setLayerClipped, mergeLayerDown } from '../core/cutsReducer.js';
+import { JitterPanel, LayerAnimPanel } from './AnimPanels';
+import { tr } from '../i18n';
+
+// One cut's layer tree, in the CUT/LAYER panel.
+//
+// This was a render function App passed down to CutLayerPanel as a prop, with a comment saying it
+// had to stay in App because the drag state lives there. Drag state is a prop like any other;
+// what the render prop actually bought was that nobody had to write the row's inputs down. There
+// are twenty of them. They arrive as one `rows` object because that is what they are - everything
+// a layer row needs, as against everything the panel around it needs - and they are now at least
+// named in one place.
+
+/** A layer's contents at thumbnail size. */
+function LayerThumbnail({ layer, cutId, layerCanvasCache }) {
+    const ref = useRef(/** @type {HTMLCanvasElement|null} */(null));
+    const key = layerKey(cutId, layer.id);
+    // Read outside the effect so the dependency is a value the linter can check, rather than an
+    // expression it has to give up on - which is what hid 'key' and the cache itself from it.
+    const layerCanvas = layerCanvasCache[key];
+    useEffect(() => {
+        const c = ref.current; if (!c) return;
+        const ctx = c.getContext('2d');
+        ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, 56, 31);
+        if (layerCanvas) {
+            ctx.drawImage(layerCanvas, 0, 0, 56, 31);
+        }
+    }, [layer, layerCanvas]);
+    return <canvas ref={ref} width={56} height={31} style={{ width: 42, height: 23, borderRadius: 3, background: '#fff', flexShrink: 0, border: '1px solid hsl(var(--ui-h) var(--ui-s) 22%)' }} />;
+}
+
+/**
+ * The rows for one cut, nesting into folders.
+ *
+ * @param {object} props
+ * @param {any} props.cut
+ * @param {string|number|null} [props.parentId] whose children to draw; null is the root
+ * @param {number} [props.depth] indent level, so a nested call lines its rows up
+ * @param {any} props.rows everything a row needs - see the destructure below
+ */
+export function LayerRows({ cut, parentId = null, depth = 0, rows }) {
+    const {
+        animLayer, currentTime, dispatchCuts, dragLayerInfo, dropInfo, handleDeleteLayer,
+        handleSetActive, handleToggleFolder, handleToggleVisible, jitterLayer, layerCanvasCache,
+        onLayerDragEnd, onLayerDragOver, onLayerDragStart, onLayerDrop, pathCapture,
+        setAnimLayer, setPathCapture, toggleJitterPanel, updLayerAnim, updLayerProps, updLayers,
+    } = rows;
+    return cut.layers.filter(l => (l.parentId ?? null) === parentId).map(layer => {
+        const isFolder = layer.type === 'folder';
+        const isDragging = dragLayerInfo?.layerId === layer.id;
+        const dt = dropInfo?.layerId === layer.id ? dropInfo.position : null;
+        return (
+            <div key={layer.id} style={{ opacity: isDragging ? 0.4 : 1 }}>
+                {dt === 'before' && <div className="drop-line" />}
+                <div
+                    className={`layer-row${!isFolder && cut.activeLayerId === layer.id ? ' layer-active' : ''}${isFolder ? ' layer-folder' : ''}${dt === 'inside' ? ' drop-inside' : ''}`}
+                    style={{ paddingLeft: depth * 14 + 6 }}
+                    draggable
+                    onDragStart={e => onLayerDragStart(e, cut.id, layer.id)}
+                    onDragOver={e => onLayerDragOver(e, layer.id, layer.type)}
+                    onDrop={e => onLayerDrop(e, cut.id, layer.id)}
+                    onDragEnd={onLayerDragEnd}
+                    onClick={e => !isFolder && handleSetActive(e, cut.id, layer.id)}
+                >
+                    {isFolder
+                        ? <button className="icon-btn" onClick={e => handleToggleFolder(e, cut.id, layer.id)}>{layer.collapsed ? <ChevronRight size={11} /> : <ChevronDown size={11} />}</button>
+                        : <span style={{ width: 11, flexShrink: 0, display: 'inline-block' }} />}
+                    {isFolder
+                        ? (layer.collapsed ? <Folder size={13} style={{ color: '#888', marginRight: 4, flexShrink: 0 }} /> : <FolderOpen size={13} style={{ color: '#aaa', marginRight: 4, flexShrink: 0 }} />)
+                        : <LayerThumbnail layer={layer} cutId={cut.id} layerCanvasCache={layerCanvasCache} />}
+                    <button className="icon-btn" style={{ marginLeft: 4 }} onClick={e => handleToggleVisible(e, cut.id, layer.id)}>
+                        {layer.visible ? <Eye size={10} /> : <EyeOff size={10} style={{ color: '#555' }} />}
+                    </button>
+                    <span className="layer-name">{layer.name}</span>
+                    {!isFolder && (
+                        <button className="icon-btn" style={{ color: layer.roughen ? '#e0a84e' : undefined }}
+                            title={layer.roughen ? tr('자글자글 모션 (강도 {0}) — 클릭: 설정 열기', layer.roughen) : tr('자글자글 모션 설정 (이미 그린 선이 제자리에서 부글거림)')}
+                            onClick={e => toggleJitterPanel(e, cut.id, layer.id)}>
+                            <Waves size={11} />
+                        </button>
+                    )}
+                    {!isFolder && (() => {
+                        // Shown even where it cannot apply, greyed out: hiding it would make
+                        // the row's controls shift position as layers are reordered, which is
+                        // worse than a disabled button.
+                        const clippable = canClip(flattenLayersInUiOrder(cut.layers || []).filter(l => l.type === 'layer'), layer.id);
+                        return (
+                            <button className="icon-btn" disabled={!clippable && !layer.clipped}
+                                style={{ color: layer.clipped ? 'var(--accent-pale)' : undefined, opacity: (clippable || layer.clipped) ? 1 : 0.3 }}
+                                title={layer.clipped
+                                    ? tr('클리핑 해제 (지금은 아래 레이어가 그려진 곳에만 보입니다)')
+                                    : clippable
+                                        ? tr('아래 레이어에 클리핑 — 아래 레이어가 그려진 곳에만 보이게 합니다')
+                                        : tr('맨 아래 레이어는 클리핑할 대상이 없습니다')}
+                                onClick={e => { e.stopPropagation(); dispatchCuts(setLayerClipped(cut.id, layer.id, !layer.clipped)); }}>
+                                <CornerDownRight size={11} />
+                            </button>
+                        );
+                    })()}
+                    {!isFolder && (
+                        <button className="icon-btn" title={tr('아래 레이어와 병합')}
+                            onClick={e => { e.stopPropagation(); dispatchCuts(mergeLayerDown(cut.id, layer.id, flattenLayersInUiOrder)); }}>
+                            <ArrowDownToLine size={11} />
+                        </button>
+                    )}
+                    {!isFolder && (
+                        <button className="icon-btn" style={{ color: layer.anim ? 'var(--accent-soft)' : undefined }} title={tr('파츠 애니메이션')}
+                            onClick={e => { e.stopPropagation(); setAnimLayer(a => (a && a.cutId === cut.id && a.layerId === layer.id) ? null : { cutId: cut.id, layerId: layer.id }); }}>
+                            <Film size={11} />
+                        </button>
+                    )}
+                    <button className="icon-btn del-btn" onClick={e => handleDeleteLayer(e, cut.id, layer.id)}><Trash2 size={11} /></button>
+                </div>
+                {!isFolder && jitterLayer && jitterLayer.cutId === cut.id && jitterLayer.layerId === layer.id && (
+                    <JitterPanel cut={cut} layer={layer} updLayer={updLayerProps} />
+                )}
+                {!isFolder && animLayer && animLayer.cutId === cut.id && animLayer.layerId === layer.id && (
+                    <LayerAnimPanel cut={cut} layer={layer} updLayerAnim={updLayerAnim} updLayers={updLayers} pathCapture={pathCapture} setPathCapture={setPathCapture}
+                        cutProgress={cutProgress(cut, currentTime)} />
+                )}
+                {dt === 'after' && <div className="drop-line" />}
+                {isFolder && !layer.collapsed && <LayerRows cut={cut} parentId={layer.id} depth={depth + 1} rows={rows} />}
+            </div>
+        );
+    });
+}
+
+export default LayerRows;


### PR DESCRIPTION
App built the rows of every layer tree and handed the function down to `CutLayerPanel` as a prop. The comment there said it had to stay in App because the drag state lives in App:

> The layer rows themselves are drawn by App's renderLayers - the drag state lives in App, so that part stays delegated.

Drag state is a prop like any other. What the render prop actually bought was that nobody had to write the row's inputs down.

## What changed

There are **twenty** inputs. They are written down now, in `ui/LayerRows.jsx`, and they travel as one `layerRows` object rather than twenty names threaded one at a time through a panel that uses none of them — the same grouping `usePlayback` uses, for the same reason. `LayerThumbnail` moves with them, since nothing else ever drew one.

Fifteen imports in App were left with nothing to import for, including a second standalone `import { setLayerClipped }` that duplicated a name the big `cutsReducer` block already had.

## Behaviour

None intended — the JSX is moved verbatim, including the greyed-out clip button that is shown where it cannot apply (hiding it would shift the row's controls as layers are reordered).

## Numbers

App.jsx **3781 → 3695**. `npm run check`: 829 tests, 8 hook warnings (unchanged), 263 helpers indexed, reachability 385/385, i18n 548, build clean.

## Worth a manual look

This is the layer panel, so it is all visual and none of it is covered by tests:

1. Drag a layer between others, and into and out of a folder — the drop lines and the faded original.
2. Collapse/expand a folder; nested indentation.
3. The row buttons: visibility, 자글자글, 클리핑 (including the greyed-out state on the bottom layer), 아래와 병합, 파츠 애니메이션, delete.
4. Open the 자글자글 and 파츠 애니메이션 panels from a row — they are drawn under the row they belong to.
5. Thumbnails update as you draw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)