### PR TITLE
chore: thirty-three dead imports, and a gate so they stop piling up

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -198,6 +198,9 @@ codebase for the least benefit.
     from the index someone would have checked before writing a second one.
   - `unreachable` — App-level names nothing reaches. Catches a feature cut from the UI and left
     behind: a group that only refers to itself is dead however busy it looks.
+  - `unused-imports` — a name imported and never used, or imported twice. The other checks
+    cannot see these: `unreachable` asks what App's own names reach and an import is not one of
+    them. Twenty-eight had piled up in App.jsx alone, left behind by the extractions.
   - `i18n-check` — every `tr()` string is translated, or the English UI shows Korean.
 - `npm test` alone runs the suite (Node's built-in runner, no test framework dependency).
 - Build: `npm run build`. Android: `npm run android:sync` then `android:open`.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bench": "node scripts/bench.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
-    "check": "npm run typecheck && npm test && node scripts/hook-baseline.mjs && node scripts/helper-index.mjs && node scripts/unreachable.mjs && node scripts/i18n-check.mjs && npm run build",
+    "check": "npm run typecheck && npm test && node scripts/hook-baseline.mjs && node scripts/helper-index.mjs && node scripts/unreachable.mjs && node scripts/unused-imports.mjs && node scripts/i18n-check.mjs && npm run build",
     "smoke": "node test/smoke/boot.mjs"
   },
   "dependencies": {

--- a/scripts/unused-imports.mjs
+++ b/scripts/unused-imports.mjs
@@ -1,0 +1,118 @@
+// Imports nothing in the file uses.
+//
+// The refactoring that pulled hooks and pure modules out of App.jsx left its import list behind:
+// twenty-eight names at the top of the file that nothing below them mentioned, and one name
+// imported twice from the same module because the second import was easier to add than to check
+// for the first. None of it broke anything, which is the problem - a dead import is invisible
+// while it makes the header of a file lie about what the file needs.
+//
+// The other gates could not see it. `unreachable` asks what App's own names reach, and an import
+// is not one of App's names. `helper-index` asks whether an export is written down. Neither asks
+// whether anything actually imports what is imported.
+//
+// Comments count as use. A name kept alive only by a JSDoc @type is genuinely needed by the
+// typechecker, and one merely mentioned in prose is not worth a false alarm.
+//
+// Run with UPDATE=1 to see the list without failing.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOTS = ['src', 'server', 'scripts'];
+const CODE = /\.(jsx?|mjs)$/;
+
+/** @param {string} dir */
+function files(dir) {
+    /** @type {string[]} */
+    const out = [];
+    for (const name of readdirSync(dir)) {
+        if (name === 'node_modules' || name === 'dist') continue;
+        const path = join(dir, name);
+        if (statSync(path).isDirectory()) out.push(...files(path));
+        else if (CODE.test(name)) out.push(path.replaceAll('\\', '/'));
+    }
+    return out;
+}
+
+/**
+ * The names one file imports, and where each was written.
+ *
+ * @param {string} src
+ * @returns {Array<{name: string, line: number, from: string}>}
+ */
+export function importedNames(src) {
+    /** @type {Array<{name: string, line: number, from: string}>} */
+    const out = [];
+    // Only the clause before `from`, so a path containing a word like `camera` is never read as
+    // a name. The clause may not contain a `;`, or a side-effect import (`import './App.css';`)
+    // would be swallowed into the clause of the statement after it and its names read as one.
+    const re = /^import\s+([^;]*?)\s+from\s+'([^']+)';/gm;
+    for (const m of src.matchAll(re)) {
+        const line = src.slice(0, m.index).split('\n').length;
+        const clause = m[1];
+        const braces = clause.match(/\{([\s\S]*)\}/);
+        // `import React, { useState }` - the part before the brace is the default binding.
+        const lead = (braces ? clause.slice(0, clause.indexOf('{')) : clause).replace(/,\s*$/, '').trim();
+        if (lead && !lead.startsWith('*')) out.push({ name: lead, line, from: m[2] });
+        // A namespace import is used as `ns.thing`, which the word check below still finds.
+        const star = lead.match(/^\*\s+as\s+(\w+)$/);
+        if (star) out.push({ name: star[1], line, from: m[2] });
+        if (braces) {
+            for (const part of braces[1].split(',')) {
+                const name = part.trim().split(/\s+as\s+/).pop()?.trim();
+                if (name) out.push({ name, line, from: m[2] });
+            }
+        }
+    }
+    return out;
+}
+
+/**
+ * Which of a file's imports nothing else in it mentions.
+ *
+ * @param {string} src
+ * @returns {Array<{name: string, line: number, from: string, why: string}>}
+ */
+export function unusedImports(src) {
+    const imports = importedNames(src);
+    // Everything after the last import is the body. Anything before it is another import, and an
+    // import mentioning a name does not count as using it - otherwise a duplicate would hide
+    // itself.
+    const lastEnd = [...src.matchAll(/^import\s+[^;]*?\s+from\s+'[^']+';/gm)]
+        .reduce((end, m) => Math.max(end, (m.index ?? 0) + m[0].length), 0);
+    const body = src.slice(lastEnd);
+    const seen = new Set();
+    /** @type {Array<{name: string, line: number, from: string, why: string}>} */
+    const out = [];
+    for (const imp of imports) {
+        if (seen.has(imp.name)) { out.push({ ...imp, why: 'imported twice' }); continue; }
+        seen.add(imp.name);
+        if (!new RegExp(`\\b${imp.name.replace(/[$]/g, '\\$&')}\\b`).test(body)) {
+            out.push({ ...imp, why: 'never used' });
+        }
+    }
+    return out;
+}
+
+// Only when this file is what was run. The two functions above are imported by the tests, and a
+// scan that exits the process on import would take the whole test run down with it.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    const rows = [];
+    for (const root of ROOTS) {
+        for (const path of files(root)) {
+            for (const bad of unusedImports(readFileSync(path, 'utf8'))) {
+                rows.push(`  ${path}:${bad.line}  ${bad.name}  (${bad.why}, from '${bad.from}')`);
+            }
+        }
+    }
+
+    if (!rows.length) {
+        console.log('Import check passed - every imported name is used.');
+    } else {
+        console.log(`${rows.length} unused import(s):`);
+        console.log(rows.join('\n'));
+        console.log('\nA dead import makes the header of a file lie about what the file needs. Delete it.');
+        if (!process.env.UPDATE) process.exit(1);
+    }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,14 @@
 import React, { useState, useEffect, useRef, useCallback, useLayoutEffect, useMemo } from 'react';
-import { X, Plus, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, Folder, ClipboardPaste, GitBranch, Move, Type, Cloud, Repeat, Minus, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw } from 'lucide-react';
+import { Plus, PenLine, Pen, Feather, Eraser, Undo, Layers, ChevronRight, Folder, GitBranch, Move, Type, Cloud, Minus, Grid3x3, Palette, Menu, PaintBucket, RotateCcw } from 'lucide-react';
 import './App.css';
-import { saveAutosave, loadAutosave, saveProject, loadProject, listProjects, deleteProject, autosaveKey } from './db';
-import { CutAnimPanel } from './ui/AnimPanels';
-import { NumField, clampNum } from './ui/NumField';
+import { saveAutosave } from './db';
 import ColorPanel, { RECENT_SLOTS } from './ui/ColorPanel';
 import { TopBar } from './ui/TopBar';
 import { CutLayerPanel } from './ui/CutLayerPanel';
 import { useStored } from './hooks/useStored.js';
 import { nextId, randomId } from './core/ids.js';
 import { clampZoom } from './core/viewZoom.js';
-import { readStored, writeStored, arrayCodec, onOffCodec, oneZeroCodec, numberCodec } from './core/persist.js';
+import { arrayCodec, onOffCodec, oneZeroCodec, numberCodec } from './core/persist.js';
 import { TextEditor } from './ui/TextEditor';
 import { ToolsPanel } from './ui/ToolsPanel';
 import { Timeline } from './ui/Timeline';
@@ -33,8 +31,6 @@ import { drawSwayed } from './canvas/swayRender.js';
 import { detachMedia } from './core/mediaEl.js';
 import { useAutosave } from './hooks/useAutosave.js';
 import { useAudioTrack } from './hooks/useAudioTrack.js';
-import { nextProbeDelay } from './core/probeBackoff.js';
-import { playbackStartFrom } from './core/playbackStart.js';
 import {
     mediaReducer, EMPTY_MEDIA, loadAudio, setAudioDuration, setAudioClip, clearAudio,
     loadVideo, clearVideo, setVideoCuts, setVideoOpacity, clearVideoCuts, moveTrack, resizeAudio,
@@ -61,8 +57,7 @@ import { dragOnWindow } from './core/windowDrag.js';
 // active at once, and startDraw checks this one first because a camera is a property of the cut
 // rather than of whichever layer happens to be selected.
 
-import { computeCamera, applyCamera } from './core/camera.js';
-import { clipGroups } from './core/clipping.js';
+import { applyCamera } from './core/camera.js';
 import { onionNeighbours, topCutAt } from './engine/selectCuts.js';
 import { evaluateFrame } from './engine/evaluateFrame.js';
 import { pendingBitmapIds, scanLayerBitmaps } from './engine/pendingBitmaps.js';
@@ -72,11 +67,10 @@ import { downloadBlob } from './export/download.js';
 import { unusedBitmapIds } from './core/bitmapRefs.js';
 import { dragCut, resizeCut } from './core/cutOps.js';
 import {
-    DEFAULT_CUT_DURATION, CANVAS_W as CANVAS_W_DEFAULT, CANVAS_H as CANVAS_H_DEFAULT, FONT_PRESETS, fontGroups,
+    DEFAULT_CUT_DURATION, CANVAS_W as CANVAS_W_DEFAULT, CANVAS_H as CANVAS_H_DEFAULT,
     pointInPolygon, dist, safeArray, hexToRgb, bucketFillTransparentRegion,
-    layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas,
-    flattenForCanvas, flattenLayersInUiOrder, layerSig, applyCutAnim, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, morphPrepare,
-    accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
+    layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas, flattenLayersInUiOrder, layerSig, applyCutAnim, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, morphPrepare,
+    accentSoft,
     targetCanvasFor, imageDataCanvas, seekTarget,
 } from './canvas/canvasUtils';
 

--- a/src/ui/LayerRows.jsx
+++ b/src/ui/LayerRows.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, Waves, CornerDownRight, ArrowDownToLine, Film, Trash2 } from 'lucide-react';
 import { flattenLayersInUiOrder, layerKey, cutProgress } from '../canvas/canvasUtils';
 import { canClip } from '../core/clipping.js';

--- a/src/ui/Logo.jsx
+++ b/src/ui/Logo.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 /**
  * The app mark: three frames receding, the front one carrying a play mark.

--- a/src/ui/Timeline.jsx
+++ b/src/ui/Timeline.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ChevronDown, ChevronUp, Grid3x3, Pause, Play, Plus, Repeat, Square, Trash2, Eye, EyeOff, Settings } from 'lucide-react';
 import { safeArray, accentSoft } from '../canvas/canvasUtils';
 import { tr } from '../i18n';

--- a/src/ui/ToolsPanel.jsx
+++ b/src/ui/ToolsPanel.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Layers, Undo, Redo, Trash, Repeat, ClipboardPaste, Pipette } from 'lucide-react';
 import { NumField } from './NumField';
 import { tr } from '../i18n';

--- a/src/ui/TopBar.jsx
+++ b/src/ui/TopBar.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ChevronDown, Download, Upload, Film, Settings, AlertTriangle, DatabaseBackup } from 'lucide-react';
 import { tr } from '../i18n';
 import { Logo } from './Logo.jsx';

--- a/test/unusedImports.test.js
+++ b/test/unusedImports.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { importedNames, unusedImports } from '../scripts/unused-imports.mjs';
+
+const names = (src) => importedNames(src).map(i => i.name);
+const unused = (src) => unusedImports(src).map(i => `${i.name}:${i.why}`);
+
+test('a side-effect import is not swallowed into the next statement', () => {
+    // The bug this caught on its first run: with a greedy clause, `import './App.css';` ran into
+    // the import below it and the whole thing came back as one name called "'./App.css';\nimport".
+    const src = `import './App.css';\nimport { a, b } from './x.js';\na(); b();\n`;
+    assert.deepEqual(names(src), ['a', 'b']);
+    assert.deepEqual(unused(src), []);
+});
+
+test('a default and named imports on one line are both seen', () => {
+    const src = `import React, { useState } from 'react';\nReact; useState();\n`;
+    assert.deepEqual(names(src), ['React', 'useState']);
+});
+
+test('a renamed import is checked under the name the file actually uses', () => {
+    const used = `import { thing as other } from './x.js';\nother();\n`;
+    assert.deepEqual(unused(used), []);
+    const not = `import { thing as other } from './x.js';\nthing();\n`;
+    assert.deepEqual(unused(not), ['other:never used']);
+});
+
+test('a namespace import counts as used when a member of it is', () => {
+    assert.deepEqual(unused(`import * as fs from 'node:fs';\nfs.readFileSync('x');\n`), []);
+});
+
+test('the same name imported twice is reported even though it is used', () => {
+    // This really happened: `setLayerClipped` had its own import line while the big cutsReducer
+    // block already brought it in. Both were "used", so a plain usage check would say nothing.
+    const src = `import { a, b } from './x.js';\nimport { a } from './x.js';\na(); b();\n`;
+    assert.deepEqual(unused(src), ['a:imported twice']);
+});
+
+test('a name used only in a comment is left alone', () => {
+    // A JSDoc @type is a real use as far as the typechecker is concerned, and prose is not worth
+    // a false alarm.
+    assert.deepEqual(unused(`import { Thing } from './x.js';\n/** @type {Thing} */\nlet v;\n`), []);
+});
+
+test('a module path that contains an imported name does not count as using it', () => {
+    // `import { applyCamera } from './core/camera.js'` - the word camera is in the path.
+    const src = `import { camera } from './core/camera.js';\nnothing();\n`;
+    assert.deepEqual(unused(src), ['camera:never used']);
+});
+
+test('an unused name among used ones is picked out', () => {
+    const src = `import { a, b, c } from './x.js';\na(); c();\n`;
+    assert.deepEqual(unused(src), ['b:never used']);
+});
+
+test('a multi-line import clause is read', () => {
+    const src = `import {\n    a,\n    b,\n} from './x.js';\na();\n`;
+    assert.deepEqual(names(src), ['a', 'b']);
+    assert.deepEqual(unused(src), ['b:never used']);
+});
+
+test('a name that only appears as part of a longer identifier is not a use', () => {
+    assert.deepEqual(unused(`import { pad } from './x.js';\npadding();\n`), ['pad:never used']);
+});


### PR DESCRIPTION
Stacked on #144.

## What was there

The extractions left App.jsx's import list behind:

- **28 names** at the top of App.jsx that nothing below them mentioned — `loadAutosave`, `saveProject`, `computeCutAnim`, `playbackStartFrom`, `clipGroups`, six lucide icons, and the rest.
- **`setLayerClipped` imported twice** from `core/cutsReducer.js`, because a second import line was easier to add than checking for the first.
- **5 UI files importing React by hand**, which this project has not needed since `"jsx": "react-jsx"`.

None of it broke anything, which is the problem. A dead import is invisible while it makes the header of a file lie about what the file needs — and reading that header is how anyone works out what a four-thousand-line component depends on.

## Why a new check

No existing gate could see this. `unreachable` asks what App's own names reach, and an import is not one of App's names. `helper-index` asks whether an export is written down, not whether anything imports it. So `scripts/unused-imports.mjs` joins the chain between them and `i18n-check`.

I proved it fails by adding an unused `readFileSync` to `core/ids.js`:

```
1 unused import(s):
  src/core/ids.js:1  readFileSync  (never used, from 'node:fs')
exit=1
```

## Ten tests, each pinned to something that actually went wrong

Writing the script produced its own bugs, and the tests are those:

- A side-effect import (`import './App.css';`) was swallowed into the clause of the statement after it, so the pair came back as one name called `'./App.css';\nimport`. The clause may not contain a `;`.
- A module path containing one of its own imported names (`camera` in `'./core/camera.js'`) must not count as a use.
- A renamed import is checked under the name the file actually uses.
- **The duplicate case a plain usage check misses**: both copies of `setLayerClipped` were "used", so only comparing imports against the body would say nothing.
- Comments count as a use — a JSDoc `@type` is a real dependency for the typechecker.

## Numbers

`npm run check`: 839 tests, 8 hook warnings (unchanged), reachability 385/385, **import check clean**, i18n 548, build clean.

Nothing to test by hand — if any of these had been live, the build would have failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)