### PR TITLE
chore: thirty-three dead imports, and a gate so they stop piling up

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -198,6 +198,9 @@ codebase for the least benefit.
     from the index someone would have checked before writing a second one.
   - `unreachable` — App-level names nothing reaches. Catches a feature cut from the UI and left
     behind: a group that only refers to itself is dead however busy it looks.
+  - `unused-imports` — a name imported and never used, or imported twice. The other checks
+    cannot see these: `unreachable` asks what App's own names reach and an import is not one of
+    them. Twenty-eight had piled up in App.jsx alone, left behind by the extractions.
   - `i18n-check` — every `tr()` string is translated, or the English UI shows Korean.
 - `npm test` alone runs the suite (Node's built-in runner, no test framework dependency).
 - Build: `npm run build`. Android: `npm run android:sync` then `android:open`.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bench": "node scripts/bench.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
-    "check": "npm run typecheck && npm test && node scripts/hook-baseline.mjs && node scripts/helper-index.mjs && node scripts/unreachable.mjs && node scripts/i18n-check.mjs && npm run build",
+    "check": "npm run typecheck && npm test && node scripts/hook-baseline.mjs && node scripts/helper-index.mjs && node scripts/unreachable.mjs && node scripts/unused-imports.mjs && node scripts/i18n-check.mjs && npm run build",
     "smoke": "node test/smoke/boot.mjs"
   },
   "dependencies": {

--- a/scripts/unused-imports.mjs
+++ b/scripts/unused-imports.mjs
@@ -1,0 +1,118 @@
+// Imports nothing in the file uses.
+//
+// The refactoring that pulled hooks and pure modules out of App.jsx left its import list behind:
+// twenty-eight names at the top of the file that nothing below them mentioned, and one name
+// imported twice from the same module because the second import was easier to add than to check
+// for the first. None of it broke anything, which is the problem - a dead import is invisible
+// while it makes the header of a file lie about what the file needs.
+//
+// The other gates could not see it. `unreachable` asks what App's own names reach, and an import
+// is not one of App's names. `helper-index` asks whether an export is written down. Neither asks
+// whether anything actually imports what is imported.
+//
+// Comments count as use. A name kept alive only by a JSDoc @type is genuinely needed by the
+// typechecker, and one merely mentioned in prose is not worth a false alarm.
+//
+// Run with UPDATE=1 to see the list without failing.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOTS = ['src', 'server', 'scripts'];
+const CODE = /\.(jsx?|mjs)$/;
+
+/** @param {string} dir */
+function files(dir) {
+    /** @type {string[]} */
+    const out = [];
+    for (const name of readdirSync(dir)) {
+        if (name === 'node_modules' || name === 'dist') continue;
+        const path = join(dir, name);
+        if (statSync(path).isDirectory()) out.push(...files(path));
+        else if (CODE.test(name)) out.push(path.replaceAll('\\', '/'));
+    }
+    return out;
+}
+
+/**
+ * The names one file imports, and where each was written.
+ *
+ * @param {string} src
+ * @returns {Array<{name: string, line: number, from: string}>}
+ */
+export function importedNames(src) {
+    /** @type {Array<{name: string, line: number, from: string}>} */
+    const out = [];
+    // Only the clause before `from`, so a path containing a word like `camera` is never read as
+    // a name. The clause may not contain a `;`, or a side-effect import (`import './App.css';`)
+    // would be swallowed into the clause of the statement after it and its names read as one.
+    const re = /^import\s+([^;]*?)\s+from\s+'([^']+)';/gm;
+    for (const m of src.matchAll(re)) {
+        const line = src.slice(0, m.index).split('\n').length;
+        const clause = m[1];
+        const braces = clause.match(/\{([\s\S]*)\}/);
+        // `import React, { useState }` - the part before the brace is the default binding.
+        const lead = (braces ? clause.slice(0, clause.indexOf('{')) : clause).replace(/,\s*$/, '').trim();
+        if (lead && !lead.startsWith('*')) out.push({ name: lead, line, from: m[2] });
+        // A namespace import is used as `ns.thing`, which the word check below still finds.
+        const star = lead.match(/^\*\s+as\s+(\w+)$/);
+        if (star) out.push({ name: star[1], line, from: m[2] });
+        if (braces) {
+            for (const part of braces[1].split(',')) {
+                const name = part.trim().split(/\s+as\s+/).pop()?.trim();
+                if (name) out.push({ name, line, from: m[2] });
+            }
+        }
+    }
+    return out;
+}
+
+/**
+ * Which of a file's imports nothing else in it mentions.
+ *
+ * @param {string} src
+ * @returns {Array<{name: string, line: number, from: string, why: string}>}
+ */
+export function unusedImports(src) {
+    const imports = importedNames(src);
+    // Everything after the last import is the body. Anything before it is another import, and an
+    // import mentioning a name does not count as using it - otherwise a duplicate would hide
+    // itself.
+    const lastEnd = [...src.matchAll(/^import\s+[^;]*?\s+from\s+'[^']+';/gm)]
+        .reduce((end, m) => Math.max(end, (m.index ?? 0) + m[0].length), 0);
+    const body = src.slice(lastEnd);
+    const seen = new Set();
+    /** @type {Array<{name: string, line: number, from: string, why: string}>} */
+    const out = [];
+    for (const imp of imports) {
+        if (seen.has(imp.name)) { out.push({ ...imp, why: 'imported twice' }); continue; }
+        seen.add(imp.name);
+        if (!new RegExp(`\\b${imp.name.replace(/[$]/g, '\\$&')}\\b`).test(body)) {
+            out.push({ ...imp, why: 'never used' });
+        }
+    }
+    return out;
+}
+
+// Only when this file is what was run. The two functions above are imported by the tests, and a
+// scan that exits the process on import would take the whole test run down with it.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    const rows = [];
+    for (const root of ROOTS) {
+        for (const path of files(root)) {
+            for (const bad of unusedImports(readFileSync(path, 'utf8'))) {
+                rows.push(`  ${path}:${bad.line}  ${bad.name}  (${bad.why}, from '${bad.from}')`);
+            }
+        }
+    }
+
+    if (!rows.length) {
+        console.log('Import check passed - every imported name is used.');
+    } else {
+        console.log(`${rows.length} unused import(s):`);
+        console.log(rows.join('\n'));
+        console.log('\nA dead import makes the header of a file lie about what the file needs. Delete it.');
+        if (!process.env.UPDATE) process.exit(1);
+    }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef, useCallback, useLayoutEffect, useMemo } from 'react';
-import { X, Plus, Trash2, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, ClipboardPaste, GitBranch, Move, Type, Cloud, Film, Repeat, Minus, Waves, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw, ArrowDownToLine, CornerDownRight } from 'lucide-react';
+import { X, Plus, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, Folder, ClipboardPaste, GitBranch, Move, Type, Cloud, Repeat, Minus, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw } from 'lucide-react';
 import './App.css';
 import { saveAutosave, loadAutosave, saveProject, loadProject, listProjects, deleteProject, autosaveKey } from './db';
-import { CutAnimPanel, LayerAnimPanel, JitterPanel } from './ui/AnimPanels';
+import { CutAnimPanel } from './ui/AnimPanels';
 import { NumField, clampNum } from './ui/NumField';
 import ColorPanel, { RECENT_SLOTS } from './ui/ColorPanel';
 import { TopBar } from './ui/TopBar';
@@ -49,7 +49,7 @@ import {
     cutsReducer, replaceCuts, addCuts, updateCut, setCutAnim, setCutCamera, clearCut,
     updateLayer, setLayerAnim, moveLayers, upsertText, moveText, deleteText, toggleTextVisible as toggleTextVisibleAction,
     assignPartTo, renamePart as renamePartAction, ungroupPart as ungroupPartAction, removeBatch,
-    insertCutsShifting, deleteTrack, moveCutGroup, replaceBatchCuts, mergeLayerDown, patchCut, patchCuts,
+    insertCutsShifting, deleteTrack, moveCutGroup, replaceBatchCuts, patchCut, patchCuts,
 } from './core/cutsReducer.js';
 import { measureTextBox as measureTextBoxPure, textNeedsBox, drawTextObject } from './canvas/textRender.js';
 import { migrateCuts, projectSettings, makeLoadProgress } from './core/projectFormat.js';
@@ -62,8 +62,7 @@ import { dragOnWindow } from './core/windowDrag.js';
 // rather than of whichever layer happens to be selected.
 
 import { computeCamera, applyCamera } from './core/camera.js';
-import { clipGroups, canClip } from './core/clipping.js';
-import { setLayerClipped } from './core/cutsReducer.js';
+import { clipGroups } from './core/clipping.js';
 import { onionNeighbours, topCutAt } from './engine/selectCuts.js';
 import { evaluateFrame } from './engine/evaluateFrame.js';
 import { pendingBitmapIds, scanLayerBitmaps } from './engine/pendingBitmaps.js';
@@ -78,7 +77,7 @@ import {
     layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas,
     flattenForCanvas, flattenLayersInUiOrder, layerSig, applyCutAnim, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, morphPrepare,
     accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
-    targetCanvasFor, imageDataCanvas, cutProgress, seekTarget,
+    targetCanvasFor, imageDataCanvas, seekTarget,
 } from './canvas/canvasUtils';
 
 
@@ -198,22 +197,6 @@ const TOOL_TYPES = [
     ...PEN_TYPES,
 ];
 
-function LayerThumbnail({ layer, cutId, layerCanvasCache }) {
-    const ref = useRef(null);
-    const key = layerKey(cutId, layer.id);
-    // Read outside the effect so the dependency is a value the linter can check, rather than an
-    // expression it has to give up on - which is what hid 'key' and the cache itself from it.
-    const layerCanvas = layerCanvasCache[key];
-    useEffect(() => {
-        const c = ref.current; if (!c) return;
-        const ctx = c.getContext('2d');
-        ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, 56, 31);
-        if (layerCanvas) {
-            ctx.drawImage(layerCanvas, 0, 0, 56, 31);
-        }
-    }, [layer, layerCanvas]);
-    return <canvas ref={ref} width={56} height={31} style={{ width: 42, height: 23, borderRadius: 3, background: '#fff', flexShrink: 0, border: '1px solid hsl(var(--ui-h) var(--ui-s) 22%)' }} />;
-}
 
 
 export default function App() {
@@ -3361,86 +3344,17 @@ export default function App() {
         exportEndRef.current = playEnd; isExporting.current = true; mediaRecorderRef.current = mr; mr.start(); setIsPlaying(true);
     };
 
-    const renderLayers = (cut, parentId = null, depth = 0) => {
-        return cut.layers.filter(l => (l.parentId ?? null) === parentId).map(layer => {
-            const isFolder = layer.type === 'folder';
-            const isDragging = dragLayerInfo?.layerId === layer.id;
-            const dt = dropInfo?.layerId === layer.id ? dropInfo.position : null;
-            return (
-                <div key={layer.id} style={{ opacity: isDragging ? 0.4 : 1 }}>
-                    {dt === 'before' && <div className="drop-line" />}
-                    <div
-                        className={`layer-row${!isFolder && cut.activeLayerId === layer.id ? ' layer-active' : ''}${isFolder ? ' layer-folder' : ''}${dt === 'inside' ? ' drop-inside' : ''}`}
-                        style={{ paddingLeft: depth * 14 + 6 }}
-                        draggable
-                        onDragStart={e => onLayerDragStart(e, cut.id, layer.id)}
-                        onDragOver={e => onLayerDragOver(e, layer.id, layer.type)}
-                        onDrop={e => onLayerDrop(e, cut.id, layer.id)}
-                        onDragEnd={onLayerDragEnd}
-                        onClick={e => !isFolder && handleSetActive(e, cut.id, layer.id)}
-                    >
-                        {isFolder
-                            ? <button className="icon-btn" onClick={e => handleToggleFolder(e, cut.id, layer.id)}>{layer.collapsed ? <ChevronRight size={11} /> : <ChevronDown size={11} />}</button>
-                            : <span style={{ width: 11, flexShrink: 0, display: 'inline-block' }} />}
-                        {isFolder
-                            ? (layer.collapsed ? <Folder size={13} style={{ color: '#888', marginRight: 4, flexShrink: 0 }} /> : <FolderOpen size={13} style={{ color: '#aaa', marginRight: 4, flexShrink: 0 }} />)
-                            : <LayerThumbnail layer={layer} cutId={cut.id} layerCanvasCache={layerCanvasCache} />}
-                        <button className="icon-btn" style={{ marginLeft: 4 }} onClick={e => handleToggleVisible(e, cut.id, layer.id)}>
-                            {layer.visible ? <Eye size={10} /> : <EyeOff size={10} style={{ color: '#555' }} />}
-                        </button>
-                        <span className="layer-name">{layer.name}</span>
-                        {!isFolder && (
-                            <button className="icon-btn" style={{ color: layer.roughen ? '#e0a84e' : undefined }}
-                                title={layer.roughen ? tr('자글자글 모션 (강도 {0}) — 클릭: 설정 열기', layer.roughen) : tr('자글자글 모션 설정 (이미 그린 선이 제자리에서 부글거림)')}
-                                onClick={e => toggleJitterPanel(e, cut.id, layer.id)}>
-                                <Waves size={11} />
-                            </button>
-                        )}
-                        {!isFolder && (() => {
-                            // Shown even where it cannot apply, greyed out: hiding it would make
-                            // the row's controls shift position as layers are reordered, which is
-                            // worse than a disabled button.
-                            const clippable = canClip(flattenLayersInUiOrder(cut.layers || []).filter(l => l.type === 'layer'), layer.id);
-                            return (
-                                <button className="icon-btn" disabled={!clippable && !layer.clipped}
-                                    style={{ color: layer.clipped ? 'var(--accent-pale)' : undefined, opacity: (clippable || layer.clipped) ? 1 : 0.3 }}
-                                    title={layer.clipped
-                                        ? tr('클리핑 해제 (지금은 아래 레이어가 그려진 곳에만 보입니다)')
-                                        : clippable
-                                            ? tr('아래 레이어에 클리핑 — 아래 레이어가 그려진 곳에만 보이게 합니다')
-                                            : tr('맨 아래 레이어는 클리핑할 대상이 없습니다')}
-                                    onClick={e => { e.stopPropagation(); dispatchCuts(setLayerClipped(cut.id, layer.id, !layer.clipped)); }}>
-                                    <CornerDownRight size={11} />
-                                </button>
-                            );
-                        })()}
-                        {!isFolder && (
-                            <button className="icon-btn" title={tr('아래 레이어와 병합')}
-                                onClick={e => { e.stopPropagation(); dispatchCuts(mergeLayerDown(cut.id, layer.id, flattenLayersInUiOrder)); }}>
-                                <ArrowDownToLine size={11} />
-                            </button>
-                        )}
-                        {!isFolder && (
-                            <button className="icon-btn" style={{ color: layer.anim ? 'var(--accent-soft)' : undefined }} title={tr('파츠 애니메이션')}
-                                onClick={e => { e.stopPropagation(); setAnimLayer(a => (a && a.cutId === cut.id && a.layerId === layer.id) ? null : { cutId: cut.id, layerId: layer.id }); }}>
-                                <Film size={11} />
-                            </button>
-                        )}
-                        <button className="icon-btn del-btn" onClick={e => handleDeleteLayer(e, cut.id, layer.id)}><Trash2 size={11} /></button>
-                    </div>
-                    {!isFolder && jitterLayer && jitterLayer.cutId === cut.id && jitterLayer.layerId === layer.id && (
-                        <JitterPanel cut={cut} layer={layer} updLayer={updLayerProps} />
-                    )}
-                    {!isFolder && animLayer && animLayer.cutId === cut.id && animLayer.layerId === layer.id && (
-                        <LayerAnimPanel cut={cut} layer={layer} updLayerAnim={updLayerAnim} updLayers={updLayers} pathCapture={pathCapture} setPathCapture={setPathCapture}
-                            cutProgress={cutProgress(cut, currentTime)} />
-                    )}
-                    {dt === 'after' && <div className="drop-line" />}
-                    {isFolder && !layer.collapsed && renderLayers(cut, layer.id, depth + 1)}
-                </div>
-            );
-        });
+    // Everything a layer row needs, as against everything the panel around it needs. Grouped
+    // rather than listed flat for the same reason usePlayback groups its inputs: twenty names
+    // threaded one by one through a panel that uses none of them is not clearer than one that
+    // says what the bundle is.
+    const layerRows = {
+        animLayer, currentTime, dispatchCuts, dragLayerInfo, dropInfo, handleDeleteLayer,
+        handleSetActive, handleToggleFolder, handleToggleVisible, jitterLayer, layerCanvasCache,
+        onLayerDragEnd, onLayerDragOver, onLayerDragStart, onLayerDrop, pathCapture,
+        setAnimLayer, setPathCapture, toggleJitterPanel, updLayerAnim, updLayerProps, updLayers,
     };
+
 
     // Tool panel: the buttons keep a comfortable size and the column count follows the width.
     // Named rather than inlined as [!!textEdit]: a dependency the linter cannot read is a
@@ -3507,7 +3421,7 @@ export default function App() {
                     handleCutClick={handleCutClick} handleDeleteCut={handleDeleteCut}
                     handleDuplicateCut={handleDuplicateCut} handlePasteCut={handlePasteCut}
                     handleSetTool={handleSetTool} openEditText={openEditText} renameCut={renameCut}
-                    renamingCutId={renamingCutId} renderLayers={renderLayers} rightW={rightW}
+                    renamingCutId={renamingCutId} layerRows={layerRows} rightW={rightW}
                     selectedCutIds={selectedCutIds} selectedText={selectedText} setDragLayerInfo={setDragLayerInfo}
                     setDropInfo={setDropInfo} setRenamingCutId={setRenamingCutId} setSelectedText={setSelectedText}
                     setShowRight={setShowRight} showRight={showRight} toggleCutCollapse={toggleCutCollapse}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,14 @@
 import React, { useState, useEffect, useRef, useCallback, useLayoutEffect, useMemo } from 'react';
-import { X, Plus, PenLine, Pen, Feather, Eraser, Undo, Redo, Layers, Trash, ChevronRight, Folder, ClipboardPaste, GitBranch, Move, Type, Cloud, Repeat, Minus, Grid3x3, Palette, Menu, PaintBucket, Pipette, RotateCcw } from 'lucide-react';
+import { Plus, PenLine, Pen, Feather, Eraser, Undo, Layers, ChevronRight, Folder, GitBranch, Move, Type, Cloud, Minus, Grid3x3, Palette, Menu, PaintBucket, RotateCcw } from 'lucide-react';
 import './App.css';
-import { saveAutosave, loadAutosave, saveProject, loadProject, listProjects, deleteProject, autosaveKey } from './db';
-import { CutAnimPanel } from './ui/AnimPanels';
-import { NumField, clampNum } from './ui/NumField';
+import { saveAutosave } from './db';
 import ColorPanel, { RECENT_SLOTS } from './ui/ColorPanel';
 import { TopBar } from './ui/TopBar';
 import { CutLayerPanel } from './ui/CutLayerPanel';
 import { useStored } from './hooks/useStored.js';
 import { nextId, randomId } from './core/ids.js';
 import { clampZoom } from './core/viewZoom.js';
-import { readStored, writeStored, arrayCodec, onOffCodec, oneZeroCodec, numberCodec } from './core/persist.js';
+import { arrayCodec, onOffCodec, oneZeroCodec, numberCodec } from './core/persist.js';
 import { TextEditor } from './ui/TextEditor';
 import { ToolsPanel } from './ui/ToolsPanel';
 import { Timeline } from './ui/Timeline';
@@ -33,8 +31,6 @@ import { drawSwayed } from './canvas/swayRender.js';
 import { detachMedia } from './core/mediaEl.js';
 import { useAutosave } from './hooks/useAutosave.js';
 import { useAudioTrack } from './hooks/useAudioTrack.js';
-import { nextProbeDelay } from './core/probeBackoff.js';
-import { playbackStartFrom } from './core/playbackStart.js';
 import {
     mediaReducer, EMPTY_MEDIA, loadAudio, setAudioDuration, setAudioClip, clearAudio,
     loadVideo, clearVideo, setVideoCuts, setVideoOpacity, clearVideoCuts, moveTrack, resizeAudio,
@@ -61,8 +57,7 @@ import { dragOnWindow } from './core/windowDrag.js';
 // active at once, and startDraw checks this one first because a camera is a property of the cut
 // rather than of whichever layer happens to be selected.
 
-import { computeCamera, applyCamera } from './core/camera.js';
-import { clipGroups } from './core/clipping.js';
+import { applyCamera } from './core/camera.js';
 import { onionNeighbours, topCutAt } from './engine/selectCuts.js';
 import { evaluateFrame } from './engine/evaluateFrame.js';
 import { pendingBitmapIds, scanLayerBitmaps } from './engine/pendingBitmaps.js';
@@ -72,11 +67,10 @@ import { downloadBlob } from './export/download.js';
 import { unusedBitmapIds } from './core/bitmapRefs.js';
 import { dragCut, resizeCut } from './core/cutOps.js';
 import {
-    DEFAULT_CUT_DURATION, CANVAS_W as CANVAS_W_DEFAULT, CANVAS_H as CANVAS_H_DEFAULT, FONT_PRESETS, fontGroups,
+    DEFAULT_CUT_DURATION, CANVAS_W as CANVAS_W_DEFAULT, CANVAS_H as CANVAS_H_DEFAULT,
     pointInPolygon, dist, safeArray, hexToRgb, bucketFillTransparentRegion,
-    layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas,
-    flattenForCanvas, flattenLayersInUiOrder, layerSig, applyCutAnim, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, morphPrepare,
-    accentSoft, computeCutAnim, computeLayerAnim, TEXT_ANIM_DEFAULT, computeTextAnim,
+    layerKey, imageDataToDataURL, dataURLToImageData, drawStrokesOnCtx, sizeCanvas, scratchCanvas, flattenLayersInUiOrder, layerSig, applyCutAnim, extractVideoFrames, fitRect, detectSceneCuts, curveToWave, morphPrepare,
+    accentSoft,
     targetCanvasFor, imageDataCanvas, seekTarget,
 } from './canvas/canvasUtils';
 

--- a/src/ui/CutLayerPanel.jsx
+++ b/src/ui/CutLayerPanel.jsx
@@ -2,18 +2,19 @@ import React from 'react';
 import { Plus, FolderPlus, Trash2, Copy, CopyPlus, ClipboardPaste, Eye, EyeOff, Settings, ChevronDown, ChevronRight } from 'lucide-react';
 import { safeArray } from '../canvas/canvasUtils';
 import { CutAnimPanel, CameraPanel } from './AnimPanels';
+import { LayerRows } from './LayerRows';
 import { tr } from '../i18n';
 
 // CUT / LAYER panel: the cut list, each cut's layer tree, cut animation and text list.
-// The layer rows themselves are drawn by App's renderLayers - the drag state lives in App,
-// so that part stays delegated.
+// The rows of each tree are LayerRows; everything they need arrives as the `layerRows` bundle
+// and is passed straight through, because none of it is this panel's business.
 export function CutLayerPanel({
     collapsedCutIds, copiedCut, currentCutId, cuts, deleteTextObject,
     deleteVideoBatch, dragLayerInfo, expandedCuts, handleAddCut, handleAddFolder,
     handleAddLayer, handleCopyCut, handleCutClick, handleDeleteCut, handleDuplicateCut,
     handlePasteCut, handleSetTool, openEditText, renameCut, renamingCutId,
     updCutCamera, cameraCapture, setCameraCapture, canvasW, canvasH,
-    renderLayers, rightW, selectedCutIds, selectedText, setDragLayerInfo,
+    layerRows, rightW, selectedCutIds, selectedText, setDragLayerInfo,
     setDropInfo, setRenamingCutId, setSelectedText, setShowRight, showRight,
     toggleCutCollapse, toggleCutSettings, toggleTextVisible, updCutAnim, updCutTime,
     updLayers, videoBatches, rightTab, setRightTab, textEditorBody, cancelText,
@@ -91,7 +92,7 @@ export function CutLayerPanel({
                                 </div>
                             )}
                             <div className="layer-list" onDragOver={e => e.preventDefault()} onDrop={e => { e.preventDefault(); if (dragLayerInfo && dragLayerInfo.cutId === cut.id) { updLayers(cut.id, c => { const layers = [...c.layers], di = layers.findIndex(l => l.id === dragLayerInfo.layerId), dragged = { ...layers[di], parentId: null }; layers.splice(di, 1); layers.push(dragged); return { layers }; }); setDragLayerInfo(null); setDropInfo(null); } }}>
-                                {renderLayers(cut)}
+                                <LayerRows cut={cut} rows={layerRows} />
                             </div>
                             {cut.id === currentCutId && (
                                 <div className="text-panel">

--- a/src/ui/LayerRows.jsx
+++ b/src/ui/LayerRows.jsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useRef } from 'react';
+import { ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, Waves, CornerDownRight, ArrowDownToLine, Film, Trash2 } from 'lucide-react';
+import { flattenLayersInUiOrder, layerKey, cutProgress } from '../canvas/canvasUtils';
+import { canClip } from '../core/clipping.js';
+import { setLayerClipped, mergeLayerDown } from '../core/cutsReducer.js';
+import { JitterPanel, LayerAnimPanel } from './AnimPanels';
+import { tr } from '../i18n';
+
+// One cut's layer tree, in the CUT/LAYER panel.
+//
+// This was a render function App passed down to CutLayerPanel as a prop, with a comment saying it
+// had to stay in App because the drag state lives there. Drag state is a prop like any other;
+// what the render prop actually bought was that nobody had to write the row's inputs down. There
+// are twenty of them. They arrive as one `rows` object because that is what they are - everything
+// a layer row needs, as against everything the panel around it needs - and they are now at least
+// named in one place.
+
+/** A layer's contents at thumbnail size. */
+function LayerThumbnail({ layer, cutId, layerCanvasCache }) {
+    const ref = useRef(/** @type {HTMLCanvasElement|null} */(null));
+    const key = layerKey(cutId, layer.id);
+    // Read outside the effect so the dependency is a value the linter can check, rather than an
+    // expression it has to give up on - which is what hid 'key' and the cache itself from it.
+    const layerCanvas = layerCanvasCache[key];
+    useEffect(() => {
+        const c = ref.current; if (!c) return;
+        const ctx = c.getContext('2d');
+        ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, 56, 31);
+        if (layerCanvas) {
+            ctx.drawImage(layerCanvas, 0, 0, 56, 31);
+        }
+    }, [layer, layerCanvas]);
+    return <canvas ref={ref} width={56} height={31} style={{ width: 42, height: 23, borderRadius: 3, background: '#fff', flexShrink: 0, border: '1px solid hsl(var(--ui-h) var(--ui-s) 22%)' }} />;
+}
+
+/**
+ * The rows for one cut, nesting into folders.
+ *
+ * @param {object} props
+ * @param {any} props.cut
+ * @param {string|number|null} [props.parentId] whose children to draw; null is the root
+ * @param {number} [props.depth] indent level, so a nested call lines its rows up
+ * @param {any} props.rows everything a row needs - see the destructure below
+ */
+export function LayerRows({ cut, parentId = null, depth = 0, rows }) {
+    const {
+        animLayer, currentTime, dispatchCuts, dragLayerInfo, dropInfo, handleDeleteLayer,
+        handleSetActive, handleToggleFolder, handleToggleVisible, jitterLayer, layerCanvasCache,
+        onLayerDragEnd, onLayerDragOver, onLayerDragStart, onLayerDrop, pathCapture,
+        setAnimLayer, setPathCapture, toggleJitterPanel, updLayerAnim, updLayerProps, updLayers,
+    } = rows;
+    return cut.layers.filter(l => (l.parentId ?? null) === parentId).map(layer => {
+        const isFolder = layer.type === 'folder';
+        const isDragging = dragLayerInfo?.layerId === layer.id;
+        const dt = dropInfo?.layerId === layer.id ? dropInfo.position : null;
+        return (
+            <div key={layer.id} style={{ opacity: isDragging ? 0.4 : 1 }}>
+                {dt === 'before' && <div className="drop-line" />}
+                <div
+                    className={`layer-row${!isFolder && cut.activeLayerId === layer.id ? ' layer-active' : ''}${isFolder ? ' layer-folder' : ''}${dt === 'inside' ? ' drop-inside' : ''}`}
+                    style={{ paddingLeft: depth * 14 + 6 }}
+                    draggable
+                    onDragStart={e => onLayerDragStart(e, cut.id, layer.id)}
+                    onDragOver={e => onLayerDragOver(e, layer.id, layer.type)}
+                    onDrop={e => onLayerDrop(e, cut.id, layer.id)}
+                    onDragEnd={onLayerDragEnd}
+                    onClick={e => !isFolder && handleSetActive(e, cut.id, layer.id)}
+                >
+                    {isFolder
+                        ? <button className="icon-btn" onClick={e => handleToggleFolder(e, cut.id, layer.id)}>{layer.collapsed ? <ChevronRight size={11} /> : <ChevronDown size={11} />}</button>
+                        : <span style={{ width: 11, flexShrink: 0, display: 'inline-block' }} />}
+                    {isFolder
+                        ? (layer.collapsed ? <Folder size={13} style={{ color: '#888', marginRight: 4, flexShrink: 0 }} /> : <FolderOpen size={13} style={{ color: '#aaa', marginRight: 4, flexShrink: 0 }} />)
+                        : <LayerThumbnail layer={layer} cutId={cut.id} layerCanvasCache={layerCanvasCache} />}
+                    <button className="icon-btn" style={{ marginLeft: 4 }} onClick={e => handleToggleVisible(e, cut.id, layer.id)}>
+                        {layer.visible ? <Eye size={10} /> : <EyeOff size={10} style={{ color: '#555' }} />}
+                    </button>
+                    <span className="layer-name">{layer.name}</span>
+                    {!isFolder && (
+                        <button className="icon-btn" style={{ color: layer.roughen ? '#e0a84e' : undefined }}
+                            title={layer.roughen ? tr('자글자글 모션 (강도 {0}) — 클릭: 설정 열기', layer.roughen) : tr('자글자글 모션 설정 (이미 그린 선이 제자리에서 부글거림)')}
+                            onClick={e => toggleJitterPanel(e, cut.id, layer.id)}>
+                            <Waves size={11} />
+                        </button>
+                    )}
+                    {!isFolder && (() => {
+                        // Shown even where it cannot apply, greyed out: hiding it would make
+                        // the row's controls shift position as layers are reordered, which is
+                        // worse than a disabled button.
+                        const clippable = canClip(flattenLayersInUiOrder(cut.layers || []).filter(l => l.type === 'layer'), layer.id);
+                        return (
+                            <button className="icon-btn" disabled={!clippable && !layer.clipped}
+                                style={{ color: layer.clipped ? 'var(--accent-pale)' : undefined, opacity: (clippable || layer.clipped) ? 1 : 0.3 }}
+                                title={layer.clipped
+                                    ? tr('클리핑 해제 (지금은 아래 레이어가 그려진 곳에만 보입니다)')
+                                    : clippable
+                                        ? tr('아래 레이어에 클리핑 — 아래 레이어가 그려진 곳에만 보이게 합니다')
+                                        : tr('맨 아래 레이어는 클리핑할 대상이 없습니다')}
+                                onClick={e => { e.stopPropagation(); dispatchCuts(setLayerClipped(cut.id, layer.id, !layer.clipped)); }}>
+                                <CornerDownRight size={11} />
+                            </button>
+                        );
+                    })()}
+                    {!isFolder && (
+                        <button className="icon-btn" title={tr('아래 레이어와 병합')}
+                            onClick={e => { e.stopPropagation(); dispatchCuts(mergeLayerDown(cut.id, layer.id, flattenLayersInUiOrder)); }}>
+                            <ArrowDownToLine size={11} />
+                        </button>
+                    )}
+                    {!isFolder && (
+                        <button className="icon-btn" style={{ color: layer.anim ? 'var(--accent-soft)' : undefined }} title={tr('파츠 애니메이션')}
+                            onClick={e => { e.stopPropagation(); setAnimLayer(a => (a && a.cutId === cut.id && a.layerId === layer.id) ? null : { cutId: cut.id, layerId: layer.id }); }}>
+                            <Film size={11} />
+                        </button>
+                    )}
+                    <button className="icon-btn del-btn" onClick={e => handleDeleteLayer(e, cut.id, layer.id)}><Trash2 size={11} /></button>
+                </div>
+                {!isFolder && jitterLayer && jitterLayer.cutId === cut.id && jitterLayer.layerId === layer.id && (
+                    <JitterPanel cut={cut} layer={layer} updLayer={updLayerProps} />
+                )}
+                {!isFolder && animLayer && animLayer.cutId === cut.id && animLayer.layerId === layer.id && (
+                    <LayerAnimPanel cut={cut} layer={layer} updLayerAnim={updLayerAnim} updLayers={updLayers} pathCapture={pathCapture} setPathCapture={setPathCapture}
+                        cutProgress={cutProgress(cut, currentTime)} />
+                )}
+                {dt === 'after' && <div className="drop-line" />}
+                {isFolder && !layer.collapsed && <LayerRows cut={cut} parentId={layer.id} depth={depth + 1} rows={rows} />}
+            </div>
+        );
+    });
+}
+
+export default LayerRows;

--- a/src/ui/LayerRows.jsx
+++ b/src/ui/LayerRows.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { ChevronRight, ChevronDown, Folder, FolderOpen, Eye, EyeOff, Waves, CornerDownRight, ArrowDownToLine, Film, Trash2 } from 'lucide-react';
 import { flattenLayersInUiOrder, layerKey, cutProgress } from '../canvas/canvasUtils';
 import { canClip } from '../core/clipping.js';

--- a/src/ui/Logo.jsx
+++ b/src/ui/Logo.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 /**
  * The app mark: three frames receding, the front one carrying a play mark.

--- a/src/ui/Timeline.jsx
+++ b/src/ui/Timeline.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ChevronDown, ChevronUp, Grid3x3, Pause, Play, Plus, Repeat, Square, Trash2, Eye, EyeOff, Settings } from 'lucide-react';
 import { safeArray, accentSoft } from '../canvas/canvasUtils';
 import { tr } from '../i18n';

--- a/src/ui/ToolsPanel.jsx
+++ b/src/ui/ToolsPanel.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Layers, Undo, Redo, Trash, Repeat, ClipboardPaste, Pipette } from 'lucide-react';
 import { NumField } from './NumField';
 import { tr } from '../i18n';

--- a/src/ui/TopBar.jsx
+++ b/src/ui/TopBar.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ChevronDown, Download, Upload, Film, Settings, AlertTriangle, DatabaseBackup } from 'lucide-react';
 import { tr } from '../i18n';
 import { Logo } from './Logo.jsx';

--- a/test/unusedImports.test.js
+++ b/test/unusedImports.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { importedNames, unusedImports } from '../scripts/unused-imports.mjs';
+
+const names = (src) => importedNames(src).map(i => i.name);
+const unused = (src) => unusedImports(src).map(i => `${i.name}:${i.why}`);
+
+test('a side-effect import is not swallowed into the next statement', () => {
+    // The bug this caught on its first run: with a greedy clause, `import './App.css';` ran into
+    // the import below it and the whole thing came back as one name called "'./App.css';\nimport".
+    const src = `import './App.css';\nimport { a, b } from './x.js';\na(); b();\n`;
+    assert.deepEqual(names(src), ['a', 'b']);
+    assert.deepEqual(unused(src), []);
+});
+
+test('a default and named imports on one line are both seen', () => {
+    const src = `import React, { useState } from 'react';\nReact; useState();\n`;
+    assert.deepEqual(names(src), ['React', 'useState']);
+});
+
+test('a renamed import is checked under the name the file actually uses', () => {
+    const used = `import { thing as other } from './x.js';\nother();\n`;
+    assert.deepEqual(unused(used), []);
+    const not = `import { thing as other } from './x.js';\nthing();\n`;
+    assert.deepEqual(unused(not), ['other:never used']);
+});
+
+test('a namespace import counts as used when a member of it is', () => {
+    assert.deepEqual(unused(`import * as fs from 'node:fs';\nfs.readFileSync('x');\n`), []);
+});
+
+test('the same name imported twice is reported even though it is used', () => {
+    // This really happened: `setLayerClipped` had its own import line while the big cutsReducer
+    // block already brought it in. Both were "used", so a plain usage check would say nothing.
+    const src = `import { a, b } from './x.js';\nimport { a } from './x.js';\na(); b();\n`;
+    assert.deepEqual(unused(src), ['a:imported twice']);
+});
+
+test('a name used only in a comment is left alone', () => {
+    // A JSDoc @type is a real use as far as the typechecker is concerned, and prose is not worth
+    // a false alarm.
+    assert.deepEqual(unused(`import { Thing } from './x.js';\n/** @type {Thing} */\nlet v;\n`), []);
+});
+
+test('a module path that contains an imported name does not count as using it', () => {
+    // `import { applyCamera } from './core/camera.js'` - the word camera is in the path.
+    const src = `import { camera } from './core/camera.js';\nnothing();\n`;
+    assert.deepEqual(unused(src), ['camera:never used']);
+});
+
+test('an unused name among used ones is picked out', () => {
+    const src = `import { a, b, c } from './x.js';\na(); c();\n`;
+    assert.deepEqual(unused(src), ['b:never used']);
+});
+
+test('a multi-line import clause is read', () => {
+    const src = `import {\n    a,\n    b,\n} from './x.js';\na();\n`;
+    assert.deepEqual(names(src), ['a', 'b']);
+    assert.deepEqual(unused(src), ['b:never used']);
+});
+
+test('a name that only appears as part of a longer identifier is not a use', () => {
+    assert.deepEqual(unused(`import { pad } from './x.js';\npadding();\n`), ['pad:never used']);
+});


### PR DESCRIPTION
Reopened against `main` — the original (#145) closed itself when its base branch was deleted by #144's merge.

## What was there

The extractions left App.jsx's import list behind:

- **28 names** at the top of App.jsx that nothing below them mentioned — `loadAutosave`, `saveProject`, `computeCutAnim`, `playbackStartFrom`, `clipGroups`, six lucide icons, and the rest.
- **`setLayerClipped` imported twice** from `core/cutsReducer.js`, because a second import line was easier to add than checking for the first.
- **5 UI files importing React by hand**, which this project has not needed since `"jsx": "react-jsx"`.

None of it broke anything, which is the problem. A dead import is invisible while it makes the header of a file lie about what the file needs — and reading that header is how anyone works out what a four-thousand-line component depends on.

## Why a new check

No existing gate could see this. `unreachable` asks what App's own names reach, and an import is not one of App's names. `helper-index` asks whether an export is written down, not whether anything imports it. So `scripts/unused-imports.mjs` joins the chain between them and `i18n-check`.

Proved it fails by adding an unused `readFileSync` to `core/ids.js`:

```
1 unused import(s):
  src/core/ids.js:1  readFileSync  (never used, from 'node:fs')
exit=1
```

## Ten tests, each pinned to something that actually went wrong

- A side-effect import (`import './App.css';`) was swallowed into the clause of the statement after it, so the pair came back as one name called `'./App.css';\nimport`. The clause may not contain a `;`.
- A module path containing one of its own imported names (`camera` in `'./core/camera.js'`) must not count as a use.
- A renamed import is checked under the name the file actually uses.
- **The duplicate case a plain usage check misses**: both copies of `setLayerClipped` were "used", so only comparing imports against the body would say nothing.
- Comments count as a use — a JSDoc `@type` is a real dependency for the typechecker.

## Numbers

App.jsx **3695 → 3689**. `npm run check`: 839 tests, 8 hook warnings (unchanged), reachability 385/385, **import check clean**, i18n 548, build clean.

Nothing to test by hand — if any of these had been live, the build would have failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)