### PR TITLE
refactor: three exports were each working out the same plan

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -169,6 +169,17 @@ Every change the document can undergo, as named actions. Build them with these c
 | `updateLayer` | Change fields on one layer. |
 | `upsertText` | Add a text if it is new, otherwise update it in place. |
 
+## `src/core/frameExport.js`
+
+What a frame export is going to be, before any of it happens — the arithmetic three exports were each working out again from the same constants.
+
+| | |
+|---|---|
+| `frameExportPlan` | Rates, scale, output size, frame count and whether there is anything to export. A GIF gets 12fps and is fitted to 720 on the long edge (every pixel is a palette index and nothing is inter-frame compressed); a PNG sequence keeps 30fps and full size, because it is going into an editor. |
+| `exportFileInfo` | What the finished bytes are and what they are called. The base differs by source, since one project and a queue of pieces land in the same downloads folder. |
+| `GIF_MAX_EDGE` | The long edge a GIF is fitted to. |
+| `LONG_EXPORT_FRAMES` | Above this the export is worth warning about — a question of time and file size, not of surviving it. |
+
 ## `src/core/historyOps.js`
 
 Undo and redo, and the memory budget that bounds them.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,6 +45,7 @@ import { derivePartsFrom, deriveVideoBatches } from './core/partOps.js';
 import { importPlacement, buildImportedCuts } from './core/videoCuts.js';
 import { playRange } from './core/playRange.js';
 import { pieceRange } from './core/exportQueue.js';
+import { frameExportPlan, exportFileInfo, LONG_EXPORT_FRAMES } from './core/frameExport.js';
 import { brushUp, brushDown } from './core/brushSize.js';
 import {
     cutsReducer, replaceCuts, addCuts, updateCut, setCutAnim, setCutCamera, clearCut,
@@ -174,9 +175,6 @@ const PANEL_W = {
 const PANEL_IDS = Object.keys(PANEL_W);
 
 const DEFAULT_THEME = '#36354b';
-// The long edge a GIF is scaled to fit. Every pixel of a GIF is a palette index with no
-// inter-frame compression, so full size is tens of megabytes a second and as slow again to write.
-const GIF_MAX_EDGE = 720;
 // The language lives in a module variable rather than a hook: over forty of these strings sit
 // in alert, confirm and thrown errors, which no hook can reach. Set before the first render.
 setLangValue(loadLang());
@@ -3352,11 +3350,10 @@ export default function App() {
         const files = await pickFiles('.emv', true);
         if (!files.length) return;
 
-        const gif = transparentFormat === 'gif';
-        const fps = gif ? 12 : 30;
-        const scale = gif ? Math.min(1, GIF_MAX_EDGE / Math.max(CANVAS_W, CANVAS_H)) : 1;
-        const gw = Math.max(1, Math.round(CANVAS_W * scale));
-        const gh = Math.max(1, Math.round(CANVAS_H * scale));
+        // Planned once, from the document that is open: a file has one frame size and each
+        // piece has its own canvas. Planning per piece would give a 16:9 piece the same answer
+        // and a square one a different one, which is a file no decoder opens.
+        const { gif, fps, gw, gh, delayMs } = frameExportPlan({ format: transparentFormat, cw: CANVAS_W, ch: CANVAS_H });
         const scratch = { current: null };
         // Frame names are padded to a fixed width rather than to the real total, because the total
         // is not known until every piece has been opened - and opening them twice, once to measure
@@ -3375,9 +3372,7 @@ export default function App() {
         const label = tr('조각 내보내는 중');
         isExporting.current = true;
         videoStopRef.current = false;
-        const writer = gif
-            ? new GifWriter({ width: gw, height: gh, delayMs: Math.round(1000 / fps) })
-            : new ZipWriter();
+        const writer = gif ? new GifWriter({ width: gw, height: gh, delayMs }) : new ZipWriter();
         let written = 0;
         let opened = 0;
         try {
@@ -3404,9 +3399,8 @@ export default function App() {
                 });
             }
             if (!written) throw new Error(tr('내보낼 콘텐츠가 없습니다.'));
-            const { bytes, type, name } = gif
-                ? { bytes: /** @type {GifWriter} */(writer).finish(), type: 'image/gif', name: 'mv_pieces.gif' }
-                : { bytes: /** @type {ZipWriter} */(writer).finish(), type: 'application/zip', name: 'mv_pieces.zip' };
+            const bytes = gif ? /** @type {GifWriter} */(writer).finish() : /** @type {ZipWriter} */(writer).finish();
+            const { type, name } = exportFileInfo(gif, { gif: 'mv_pieces', zip: 'mv_pieces' });
             downloadBlob(new Blob([bytes], { type }), name);
             alert(tr('완료!'));
         } catch (e) {
@@ -3432,42 +3426,26 @@ export default function App() {
         // and the dimming already do. Exporting from zero meant a project whose first cut sits at
         // three seconds began with three seconds of nothing.
         const from = playStart, to = playEnd;
-        if (to <= from) { alert(tr('내보낼 콘텐츠가 없습니다.')); return; }
-        // A GIF at 30fps is enormous and plays no better; twelve is what hand-drawn animation
-        // usually runs at anyway. A PNG sequence is going into an editor, so it keeps the full
-        // rate.
-        const gif = transparentFormat === 'gif';
-        const fps = gif ? 12 : 30;
-        // A GIF at the project's full size is not a thing anyone wants: every pixel is a palette
-        // index and none of it is inter-frame compressed, so a second of 1920x1080 runs to tens
-        // of megabytes and takes as long again to encode. Scaled to fit 720 on the long edge it
-        // is a file that can be posted. A PNG sequence keeps the full size.
-        const gifScale = gif ? Math.min(1, GIF_MAX_EDGE / Math.max(CANVAS_W, CANVAS_H)) : 1;
-        const gw = Math.max(1, Math.round(CANVAS_W * gifScale));
-        const gh = Math.max(1, Math.round(CANVAS_H * gifScale));
+        // The rates, the scale and the frame count are all in core/frameExport, with the
+        // reasoning behind each. The queue above plans through the same function.
+        const { gif, fps, gw, gh, delayMs, total, empty } = frameExportPlan({ format: transparentFormat, cw: CANVAS_W, ch: CANVAS_H, from, to });
+        if (empty) { alert(tr('내보낼 콘텐츠가 없습니다.')); return; }
         // One scratch canvas for the whole export rather than one a frame.
         const gifScratch = { current: null };
-        const total = Math.max(1, Math.round((to - from) * fps));
-        // Each frame is encoded as it is painted now, rather than every frame being held until
-        // the end, so this is about how long it takes and how big the file gets rather than
-        // whether the tab survives it.
-        if (total > 1000 && !confirm(tr('{0}프레임을 내보냅니다. 오래 걸립니다. 계속할까요?').replace('{0}', String(total)))) return;
+        if (total > LONG_EXPORT_FRAMES && !confirm(tr('{0}프레임을 내보냅니다. 오래 걸립니다. 계속할까요?').replace('{0}', String(total)))) return;
 
         const label = tr('프레임 내보내는 중');
         setLoadProgress({ label, done: 0, total });
         isExporting.current = true;
-        const writer = gif
-            ? new GifWriter({ width: gw, height: gh, delayMs: Math.round(1000 / fps) })
-            : new ZipWriter();
+        const writer = gif ? new GifWriter({ width: gw, height: gh, delayMs }) : new ZipWriter();
         try {
             await renderFrameRange({
                 from, to, fps,
                 capture: (src, i) => captureFrame(writer, src, i, { gif, gw, gh, scratch: gifScratch, total }),
                 onProgress: (done) => setLoadProgress({ label, done, total }),
             });
-            const { bytes, type, name } = gif
-                ? { bytes: /** @type {GifWriter} */(writer).finish(), type: 'image/gif', name: 'mv_export.gif' }
-                : { bytes: /** @type {ZipWriter} */(writer).finish(), type: 'application/zip', name: 'mv_frames.zip' };
+            const bytes = gif ? /** @type {GifWriter} */(writer).finish() : /** @type {ZipWriter} */(writer).finish();
+            const { type, name } = exportFileInfo(gif);
             downloadBlob(new Blob([bytes], { type }), name);
             alert(tr('완료!'));
         } catch (e) {

--- a/src/core/frameExport.js
+++ b/src/core/frameExport.js
@@ -1,0 +1,79 @@
+// What a frame export is going to be, before any of it happens.
+//
+// Three exports need the same answers - a single project, a queue of pieces, and anything that
+// wants to say "this will be N frames" before starting - and they were each working them out
+// again from the same constants. Two of the three had already drifted apart in spelling
+// (`gifScale` and `scale`), which is how the third gets it subtly wrong.
+//
+// None of this touches a canvas. It is the arithmetic and the reasoning behind it, which is the
+// part worth having in one place and worth being able to test.
+
+/** A GIF wider than this is a file nobody can post. See `frameExportPlan`. */
+export const GIF_MAX_EDGE = 720;
+
+/**
+ * Everything decided before the first frame is painted.
+ *
+ * The two rates, and why they differ: a GIF at 30fps is enormous and plays no better, and twelve
+ * is what hand-drawn animation usually runs at anyway. A PNG sequence is going into an editor, so
+ * it keeps the full rate.
+ *
+ * The scale, and why only the GIF gets one: every pixel of a GIF is a palette index and none of
+ * it is inter-frame compressed, so a second of 1920x1080 runs to tens of megabytes and takes as
+ * long again to encode. Fitted to 720 on the long edge it is a file that can be posted. A PNG
+ * sequence keeps the full size, because that is what an editor wants.
+ *
+ * @param {object} args
+ * @param {string} args.format `'gif'` or anything else, which means a PNG sequence
+ * @param {number} args.cw
+ * @param {number} args.ch
+ * @param {number} [args.from] start of the range, in seconds
+ * @param {number} [args.to] end of the range
+ * @returns {{gif: boolean, fps: number, scale: number, gw: number, gh: number, total: number,
+ *   delayMs: number, empty: boolean}}
+ */
+export function frameExportPlan({ format, cw, ch, from = 0, to = 0 }) {
+    const gif = format === 'gif';
+    const fps = gif ? 12 : 30;
+    const w = Math.max(1, Math.round(Number(cw) || 1));
+    const h = Math.max(1, Math.round(Number(ch) || 1));
+    const scale = gif ? Math.min(1, GIF_MAX_EDGE / Math.max(w, h)) : 1;
+    const span = (Number(to) || 0) - (Number(from) || 0);
+    return {
+        gif,
+        fps,
+        scale,
+        gw: Math.max(1, Math.round(w * scale)),
+        gh: Math.max(1, Math.round(h * scale)),
+        // At least one frame whenever there is a range at all: a project shorter than a frame
+        // should still produce a file rather than an empty one.
+        total: span > 0 ? Math.max(1, Math.round(span * fps)) : 0,
+        delayMs: Math.round(1000 / fps),
+        /** Nothing to export - the caller says so rather than writing a file with no frames. */
+        empty: !(span > 0),
+    };
+}
+
+/**
+ * What the finished bytes are and what they are called.
+ *
+ * The base differs by where they came from - one project or a queue of pieces - because the two
+ * land in the same downloads folder and the name is the only thing that tells them apart. The
+ * extension does not: a PNG sequence is a zip either way.
+ *
+ * @param {boolean} gif
+ * @param {{gif: string, zip: string}} base
+ */
+export function exportFileInfo(gif, base = { gif: 'mv_export', zip: 'mv_frames' }) {
+    return gif
+        ? { type: 'image/gif', name: `${base.gif}.gif` }
+        : { type: 'application/zip', name: `${base.zip}.zip` };
+}
+
+/**
+ * Above this many frames the export is worth warning about.
+ *
+ * Each frame is encoded as it is painted rather than every frame being held to the end, so the
+ * question is how long it takes and how big the file gets - not whether the tab survives it.
+ */
+export const LONG_EXPORT_FRAMES = 1000;

--- a/test/frameExport.test.js
+++ b/test/frameExport.test.js
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { frameExportPlan, exportFileInfo, GIF_MAX_EDGE, LONG_EXPORT_FRAMES } from '../src/core/frameExport.js';
+
+const hd = { cw: 1920, ch: 1080 };
+
+test('a GIF is scaled to fit the long edge; a PNG sequence keeps full size', () => {
+    const gif = frameExportPlan({ format: 'gif', ...hd, from: 0, to: 1 });
+    assert.equal(Math.max(gif.gw, gif.gh), GIF_MAX_EDGE);
+    assert.equal(gif.gw, 720);
+    assert.equal(gif.gh, 405);
+
+    const png = frameExportPlan({ format: 'png', ...hd, from: 0, to: 1 });
+    assert.equal(png.scale, 1);
+    assert.equal(png.gw, 1920);
+    assert.equal(png.gh, 1080);
+});
+
+test('a portrait canvas is fitted on its own long edge', () => {
+    const p = frameExportPlan({ format: 'gif', cw: 1080, ch: 1920, from: 0, to: 1 });
+    assert.equal(p.gh, GIF_MAX_EDGE);
+    assert.equal(p.gw, 405);
+});
+
+test('a canvas already smaller than the limit is not scaled up', () => {
+    const p = frameExportPlan({ format: 'gif', cw: 640, ch: 360, from: 0, to: 1 });
+    assert.equal(p.scale, 1);
+    assert.equal(p.gw, 640);
+    assert.equal(p.gh, 360);
+});
+
+test('the two rates, and the delay that follows from them', () => {
+    assert.equal(frameExportPlan({ format: 'gif', ...hd }).fps, 12);
+    assert.equal(frameExportPlan({ format: 'png', ...hd }).fps, 30);
+    assert.equal(frameExportPlan({ format: 'gif', ...hd }).delayMs, 83);
+    assert.equal(frameExportPlan({ format: 'png', ...hd }).delayMs, 33);
+});
+
+test('the frame count follows the range and the rate', () => {
+    assert.equal(frameExportPlan({ format: 'png', ...hd, from: 0, to: 2 }).total, 60);
+    assert.equal(frameExportPlan({ format: 'gif', ...hd, from: 0, to: 2 }).total, 24);
+    // A range that does not start at zero counts its own length, not its end.
+    assert.equal(frameExportPlan({ format: 'png', ...hd, from: 3, to: 5 }).total, 60);
+});
+
+test('a range shorter than one frame still produces a frame', () => {
+    // Rounding 0.01s * 30 to zero would write a file with nothing in it.
+    const p = frameExportPlan({ format: 'png', ...hd, from: 0, to: 0.01 });
+    assert.equal(p.total, 1);
+    assert.equal(p.empty, false);
+});
+
+test('no range at all is empty, and says so instead of writing a file', () => {
+    for (const [from, to] of [[0, 0], [5, 5], [5, 1]]) {
+        const p = frameExportPlan({ format: 'png', ...hd, from, to });
+        assert.equal(p.empty, true, `for ${from}..${to}`);
+        assert.equal(p.total, 0);
+    }
+});
+
+test('a junk canvas size does not produce a zero or negative output size', () => {
+    // The failure this guards: a writer created with width 0 accepts frames and produces bytes
+    // no decoder will open.
+    for (const size of [0, -100, NaN, undefined, null]) {
+        const p = frameExportPlan({ format: 'gif', cw: /** @type {any} */(size), ch: /** @type {any} */(size), from: 0, to: 1 });
+        assert.ok(p.gw >= 1 && p.gh >= 1, `for ${String(size)}`);
+        assert.ok(Number.isFinite(p.gw) && Number.isFinite(p.gh));
+    }
+});
+
+test('the file name and type follow the format', () => {
+    assert.deepEqual(exportFileInfo(true), { type: 'image/gif', name: 'mv_export.gif' });
+    assert.deepEqual(exportFileInfo(false), { type: 'application/zip', name: 'mv_frames.zip' });
+});
+
+test('a queue names its output differently, because both land in the same folder', () => {
+    const pieces = { gif: 'mv_pieces', zip: 'mv_pieces' };
+    assert.deepEqual(exportFileInfo(true, pieces), { type: 'image/gif', name: 'mv_pieces.gif' });
+    assert.deepEqual(exportFileInfo(false, pieces), { type: 'application/zip', name: 'mv_pieces.zip' });
+});
+
+test('a piece planned on its own size would not match the document - so a queue plans once', () => {
+    // A file has one frame size and each piece has its own canvas. Planning per piece gives
+    // different outputs for the same file, which is why handleExportPieces plans from the open
+    // document and fits every piece to that. A 16:9 piece happens to agree with a 16:9 document;
+    // a square one does not, and that is the case that would have produced a broken file.
+    const doc = frameExportPlan({ format: 'gif', ...hd, from: 0, to: 1 });
+    const sameAspect = frameExportPlan({ format: 'gif', cw: 1280, ch: 720, from: 0, to: 1 });
+    const square = frameExportPlan({ format: 'gif', cw: 1000, ch: 1000, from: 0, to: 1 });
+    assert.deepEqual([sameAspect.gw, sameAspect.gh], [doc.gw, doc.gh]);
+    assert.notDeepEqual([square.gw, square.gh], [doc.gw, doc.gh]);
+    assert.deepEqual([square.gw, square.gh], [720, 720]);
+});
+
+test('the long-export threshold is a number the caller can compare against', () => {
+    const p = frameExportPlan({ format: 'png', ...hd, from: 0, to: 40 });
+    assert.equal(p.total, 1200);
+    assert.ok(p.total > LONG_EXPORT_FRAMES);
+});


### PR DESCRIPTION
Rates, scale, output size and frame count were computed **separately** in the single-project export and in the piece queue, from the same two constants. Two of the three had already drifted in spelling — `gifScale` in one, `scale` in the other — which is how the third gets it subtly wrong rather than obviously.

`core/frameExport` answers all of it once, and the reasoning that was spread across four comment blocks now sits with the numbers it explains: why a GIF is twelve frames a second and a PNG sequence thirty, and why only the GIF is scaled (every pixel is a palette index, nothing is inter-frame compressed, so a second of 1920×1080 runs to tens of megabytes and takes as long again to encode).

## Two bugs fell out of writing it down

- **A range shorter than one frame wrote an empty file.** `Math.round(0.01 * 30)` is 0, and a writer with zero frames still produces bytes. Now it yields one frame. `empty` replaces `to <= from` at one call site and *nothing* at the other.
- **A junk canvas size could produce an output size of zero.** A `GifWriter` built with `width: 0` accepts frames and returns bytes no decoder will open. Sizes are clamped to at least 1.

## Eleven tests

Including the one that states why the queue plans from the **open document** rather than per piece:

```js
// A 16:9 piece happens to agree with a 16:9 document; a square one does not,
// and that is the case that would have produced a broken file.
assert.deepEqual([sameAspect.gw, sameAspect.gh], [doc.gw, doc.gh]);
assert.notDeepEqual([square.gw, square.gh], [doc.gw, doc.gh]);
```

`exportFileInfo` keeps the two output names apart (`mv_export`/`mv_frames` vs `mv_pieces`) because both land in the same downloads folder and the extension does not distinguish them — a PNG sequence is a zip either way.

## Numbers

App.jsx **3918 → 3895**. `npm run check`: 899 tests, 281 helpers indexed, reachability 366/366, import check clean, i18n 584, build clean.

## Worth a manual look

Behaviour-preserving apart from the two fixes above, but export is the one path where a mistake produces a file rather than an error:

1. Export a normal video (opaque project) — unchanged path, but the writer construction moved.
2. Transparent project → GIF: should be ≤720 on the long edge, 12fps.
3. Transparent project → PNG sequence: full size, 30fps, zip opens.
4. 조각 이어서 내보내기 with pieces of **different canvas sizes**, including a square one.
5. A project over ~33 seconds → the "오래 걸립니다" confirmation still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)