### PR TITLE
refactor: putting the audio back belongs with the audio

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -384,6 +384,7 @@ How each piece of a project is stored, and how it comes back.
 | `frameLoad` | How a bitmap read back from a saved project has to be loaded. Only drawing layers are decoded to ImageData up front, because those are the ones the user can still edit pixel by pixel. |
 | `frameStorage` | Which of the three ways a frame is saved. A legacy entry with no Blob still embeds rather than being dropped. |
 | `loadBitmapStore` | Rebuild a bitmap store from a saved project's bitmaps, the reverse of `collectBitmaps`. Written inline in App's restore before, which meant the only way to read a project's pixels was to open the project and replace whatever was on screen. An entry that will not load is skipped and counted, so one bad frame costs that frame rather than the file. |
+| `blobToDataURL` | A Blob as a base64 dataURL — the conversion the "a local .emv must stand alone" rule rests on, and the way back for bytes that have to reach a media element and then be saved again. |
 | `collectBitmaps` | Every bitmap the cuts reference, packed the way this kind of save wants them. The loop around frameStorage, which used to live in App.jsx where it could be read but never run. Encoders are injected because one needs FileReader and the other a canvas. |
 | `imageExt` | The file extension for a frame bitmap. |
 | `imageExtFromType` | The file extension for an image, from a Blob MIME type. |
@@ -626,7 +627,7 @@ The music track: the element that plays it, the copies of it a save needs, and t
 
 | | |
 |---|---|
-| `useAudioTrack` | Owns `audioRef` and the AudioContext the export recorder taps, plus the two extra shapes of the same sound — a base64 dataURL so an `.emv` is self-contained, and a Blob (cached by the dataURL it came from) because IndexedDB can hold one and autosave cannot afford base64. |
+| `useAudioTrack` | Owns `audioRef` and the AudioContext the export recorder taps, plus the two extra shapes of the same sound — a base64 dataURL so an `.emv` is self-contained, and a Blob (cached by the dataURL it came from) because IndexedDB can hold one and autosave cannot afford base64. Also `restoreAudio`, which puts a saved track back from any of its three stored shapes. |
 
 ## `src/hooks/useAutosave.js`
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,7 +36,7 @@ import { useAutosave } from './hooks/useAutosave.js';
 import { useAudioTrack } from './hooks/useAudioTrack.js';
 import { useToolSettings } from './hooks/useToolSettings.js';
 import {
-    mediaReducer, EMPTY_MEDIA, loadAudio, setAudioDuration, setAudioClip, clearAudio,
+    mediaReducer, EMPTY_MEDIA, setAudioClip, clearAudio,
     loadVideo, clearVideo, setVideoCuts, setVideoOpacity, clearVideoCuts, moveTrack, resizeAudio,
 } from './core/mediaReducer.js';
 import { cloneCutContents as cloneCutContentsPure } from './core/cutClone.js';
@@ -55,7 +55,7 @@ import {
 } from './core/cutsReducer.js';
 import { measureTextBox as measureTextBoxPure, textNeedsBox, drawTextObject } from './canvas/textRender.js';
 import { migrateCuts, projectSettings, makeLoadProgress } from './core/projectFormat.js';
-import { imageExtFromType, audioExt, videoExt, collectBitmaps, loadBitmapStore } from './core/projectAssets.js';
+import { imageExtFromType, audioExt, videoExt, collectBitmaps, loadBitmapStore, blobToDataURL } from './core/projectAssets.js';
 import { xAtTime, timeAtX, zoomAnchored, pinchZoom } from './core/timelineZoom.js';
 import { preparePath } from './core/pathMotion.js';
 import { dragOnWindow } from './core/windowDrag.js';
@@ -276,7 +276,7 @@ export default function App() {
 
     const {
         audioRef, audioB64Ref, audioCtxRef, audioSourceRef, audioDestRef,
-        audioAsBlob, loadAudioUrl, handleAudioUpload, handleDeleteAudio, loadYoutubeAudio,
+        audioAsBlob, restoreAudio, loadAudioUrl, handleAudioUpload, handleDeleteAudio, loadYoutubeAudio,
     } = useAudioTrack({ audioUrl, dispatchMedia, setLinkPrompt });
     // Make failures visible. Once the browser blocks dialogs, alert is swallowed and the app
     // looks like it simply did nothing - which is exactly why one bug here took so long to find.
@@ -556,7 +556,6 @@ export default function App() {
         }
         setLayerCanvasCache(prev => { const n = { ...prev }; for (const k of affected) delete n[k]; return n; });
     };
-    const blobToDataURL = (blob) => new Promise((res, rej) => { const fr = new FileReader(); fr.onload = () => res(fr.result); fr.onerror = rej; fr.readAsDataURL(blob); });
 
     // Duplicate a stored bitmap under a fresh id so a pasted/duplicated cut owns its
     // own pixels instead of aliasing the source's. `cache` dedups within one operation.
@@ -1171,35 +1170,9 @@ export default function App() {
         setOnionPrev(s.onionPrev); setOnionNext(s.onionNext); setPps(s.pps); setExpandedCuts(new Set());
         setCopiedCut(null); // clipboard may reference bitmaps from the old project
         setLayerCanvasCache({}); // Clear cache on new project
-        // Restore audio: embedded (dataUrl) or externalized as a server asset. Either way we end
-        // up with a dataURL in audioB64Ref so a later LOCAL save stays self-contained.
-        let audioDataUrl = data.audio?.dataUrl || null;
-        if (!audioDataUrl && data.audio?.blob instanceof Blob) {
-            // Back to a dataURL, because everything downstream - the <audio> src, a later local
-            // save - wants one, and this keeps that invariant in the one place that states it.
-            try {
-                audioDataUrl = await new Promise((res, rej) => { const fr = new FileReader(); fr.onload = () => res(fr.result); fr.onerror = rej; fr.readAsDataURL(data.audio.blob); });
-            } catch { }
-        }
-        if (!audioDataUrl && data.audio?.asset && assetBase) {
-            try {
-                const blob = await fetchAsset(`${assetBase}/asset/__audio__`);
-                audioDataUrl = await new Promise((res, rej) => { const fr = new FileReader(); fr.onload = () => res(fr.result); fr.onerror = rej; fr.readAsDataURL(blob); });
-            } catch { missingAssets++; }
-        }
-        if (audioDataUrl) {
-            audioB64Ref.current = audioDataUrl;
-            dispatchMedia(loadAudio(data.audio.name || tr('오디오'), audioDataUrl));
-            dispatchMedia(setAudioDuration(data.audio.duration || 30));
-            dispatchMedia(setAudioClip({ startTime: data.audio.startTime ?? 0, endTime: data.audio.endTime ?? (data.audio.duration || 30), offset: data.audio.offset ?? 0 }));
-            // Checked, not trusted: this URL came out of a project file. See core/mediaEl.
-            const audioSrc = safeMediaSrc(audioDataUrl, 'audio');
-            if (audioRef.current && audioSrc) audioRef.current.src = audioSrc;
-        } else {
-            audioB64Ref.current = null;
-            detachMedia(audioRef.current);
-            dispatchMedia(clearAudio());
-        }
+        // The audio lives in useAudioTrack, and so does putting it back: the element, the
+        // base64 copy a local save needs, and the three shapes a stored track can arrive in.
+        missingAssets += await restoreAudio(data, assetBase);
         // Restore the video overlay track (Blob from IDB / server asset / embedded dataURL).
         let videoBlob = null;
         if (data.video?.blob instanceof Blob) videoBlob = data.video.blob;

--- a/src/core/projectAssets.js
+++ b/src/core/projectAssets.js
@@ -231,3 +231,25 @@ export async function loadBitmapStore(data, { dataURLToImageData, createBitmap, 
     }
     return { store, failed };
 }
+
+/**
+ * A Blob as a base64 dataURL.
+ *
+ * The conversion the "local .emv must stand alone" rule above rests on: bytes held as a Blob
+ * have to become text before they can go into a JSON file. Also the way back for a Blob that has
+ * to reach an <audio> or <video> element and then be saved again.
+ *
+ * `readAsDataURL` rather than a manual base64: it sets the media type from the Blob itself, and
+ * the type is what tells the element what it is being given.
+ *
+ * @param {Blob} blob
+ * @returns {Promise<string>}
+ */
+export function blobToDataURL(blob) {
+    return new Promise((res, rej) => {
+        const fr = new FileReader();
+        fr.onload = () => res(/** @type {string} */(fr.result));
+        fr.onerror = rej;
+        fr.readAsDataURL(blob);
+    });
+}

--- a/src/hooks/useAudioTrack.js
+++ b/src/hooks/useAudioTrack.js
@@ -1,6 +1,8 @@
 import { useRef } from 'react';
 import { loadAudio, setAudioDuration, setAudioClip, clearAudio } from '../core/mediaReducer.js';
-import { detachMedia } from '../core/mediaEl.js';
+import { detachMedia, safeMediaSrc } from '../core/mediaEl.js';
+import { fetchAsset } from '../core/api.js';
+import { blobToDataURL } from '../core/projectAssets.js';
 import { tr } from '../i18n';
 
 /**
@@ -71,6 +73,53 @@ export function useAudioTrack({ audioUrl, dispatchMedia, setLinkPrompt }) {
         else { fetch(url).then(r => r.blob()).then(b => { const fr = new FileReader(); fr.onload = () => { audioB64Ref.current = /** @type {string} */(fr.result); }; fr.readAsDataURL(b); }).catch(() => { }); }
     };
 
+
+    /**
+     * Put a saved project's audio back, or clear the track when it has none.
+     *
+     * Here rather than in `restore` because everything it touches is this hook's: the element,
+     * the base64 copy, and the reducer actions. What it needed from App was a fetch and a
+     * counter, and both are smaller than the eighteen lines they were holding.
+     *
+     * A track can be stored three ways and this is the one place that knows all three - embedded
+     * as a dataURL in an `.emv`, as a Blob in an IndexedDB autosave, or as a separate asset on
+     * the server. All three end as a dataURL in `audioB64Ref`, because everything downstream
+     * wants one: the element's src, and a later local save that has to stay self-contained.
+     *
+     * @param {any} data the document
+     * @param {string | null} assetBase project asset path, when the document came from the server
+     * @returns {Promise<number>} how many assets could not be fetched, for the caller's tally
+     */
+    const restoreAudio = async (data, assetBase = null) => {
+        let missing = 0;
+        let url = data.audio?.dataUrl || null;
+        if (!url && data.audio?.blob instanceof Blob) {
+            try { url = await blobToDataURL(data.audio.blob); } catch { }
+        }
+        if (!url && data.audio?.asset && assetBase) {
+            try { url = await blobToDataURL(await fetchAsset(`${assetBase}/asset/__audio__`)); }
+            catch { missing++; }
+        }
+        if (!url) {
+            audioB64Ref.current = null;
+            detachMedia(audioRef.current);
+            dispatchMedia(clearAudio());
+            return missing;
+        }
+        audioB64Ref.current = url;
+        dispatchMedia(loadAudio(data.audio.name || tr('오디오'), url));
+        dispatchMedia(setAudioDuration(data.audio.duration || 30));
+        dispatchMedia(setAudioClip({
+            startTime: data.audio.startTime ?? 0,
+            endTime: data.audio.endTime ?? (data.audio.duration || 30),
+            offset: data.audio.offset ?? 0,
+        }));
+        // Checked, not trusted: this URL came out of a project file. See core/mediaEl.
+        const src = safeMediaSrc(url, 'audio');
+        if (audioRef.current && src) audioRef.current.src = src;
+        return missing;
+    };
+
     const handleAudioUpload = (e) => {
         const file = e.target.files[0]; if (!file) return;
         loadAudioUrl(URL.createObjectURL(file), file.name);
@@ -98,6 +147,6 @@ export function useAudioTrack({ audioUrl, dispatchMedia, setLinkPrompt }) {
 
     return {
         audioRef, audioB64Ref, audioBlobRef, audioCtxRef, audioSourceRef, audioDestRef,
-        audioAsBlob, loadAudioUrl, handleAudioUpload, handleDeleteAudio, loadYoutubeAudio,
+        audioAsBlob, restoreAudio, loadAudioUrl, handleAudioUpload, handleDeleteAudio, loadYoutubeAudio,
     };
 }


### PR DESCRIPTION
`restore` held eighteen lines of audio restoration, and **every one of the things they touched already lived in `useAudioTrack`**: the element, the base64 copy a local save needs, the reducer actions. What they needed from App was a fetch and a counter — both smaller than the lines they were holding.

## What moved

`restoreAudio(data, assetBase)` is now the one place that knows a track can arrive three ways:

| shape | where from |
|---|---|
| a dataURL | embedded in an `.emv`, so the file stands alone |
| a Blob | an IndexedDB autosave, which stores them natively |
| a separate asset | a server save, so the JSON stays small |

…and that all three end as a dataURL in `audioB64Ref`, because everything downstream wants one: the element's `src`, and a later local save that has to stay self-contained. It returns how many assets it could not fetch, for `restore`'s tally.

`blobToDataURL` goes to `core/projectAssets` — already the file about how each piece of a project is stored and how a stored one comes back. Both App and the hook need it and neither owns it.

Two imports in App were left with nothing to import for (`loadAudio`, `setAudioDuration`); the import gate from #147 caught them.

## Numbers

App.jsx **3895 → 3868**. `npm run check`: 899 tests, 282 helpers indexed, reachability 365/365, import check clean, i18n 584, build clean.

## Worth a manual look

Opening a project with music is the whole of this change, and it has three separate paths that a test cannot reach:

1. Open a local `.emv` saved **with** music → the track is there and plays.
2. Open an IndexedDB project / crash recovery with music → same.
3. Open a **server** project with music → same, and the "assets missing" notice still counts correctly if you delete the audio asset server-side.
4. Open a project **without** music while one is loaded → the old track is cleared, not left playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)