### PR TITLE
refactor: the decode budget and what a decode invalidates

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -169,6 +169,17 @@ Every change the document can undergo, as named actions. Build them with these c
 | `updateLayer` | Change fields on one layer. |
 | `upsertText` | Add a text if it is new, otherwise update it in place. |
 
+## `src/core/decodeBudget.js`
+
+How many decoded frames to hold, which to let go of, and which cached layers a decode invalidates. Both answers fail quietly when wrong.
+
+| | |
+|---|---|
+| `DECODED_CAP` | How many decoded frames may be held. **Must stay above the prefetch window (~50)** — below it, the trim evicts what the prefetcher just decoded and the two fight each other, which reads as stutter rather than as a memory problem. |
+| `framesToRelease` | Oldest use first, never the prefetch window or the caller's protected set. A skipped id is not counted against the quota, or the trim stops early and leaves the store over cap. |
+| `layerKeysUsingBitmaps` | The layer-canvas keys holding pixels from given frames. Only these are dropped — clearing everything made on-screen frames flicker while playing. |
+| `keysWithPhases` | Includes a boiling layer's `cut:layer#phase` variants. Dropping the plain key alone leaves the phases holding the replaced bitmap. |
+
 ## `src/core/frameExport.js`
 
 What a frame export is going to be, before any of it happens — the arithmetic three exports were each working out again from the same constants.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,6 +46,7 @@ import { importPlacement, buildImportedCuts } from './core/videoCuts.js';
 import { playRange } from './core/playRange.js';
 import { pieceRange } from './core/exportQueue.js';
 import { frameExportPlan, exportFileInfo, LONG_EXPORT_FRAMES } from './core/frameExport.js';
+import { DECODED_CAP, framesToRelease, layerKeysUsingBitmaps, keysWithPhases } from './core/decodeBudget.js';
 import { brushUp, brushDown } from './core/brushSize.js';
 import {
     cutsReducer, replaceCuts, addCuts, updateCut, setCutAnim, setCutCamera, clearCut,
@@ -520,7 +521,6 @@ export default function App() {
     };
     // LRU cap on how many frame ImageBitmaps stay decoded at once (bounds memory regardless of
     // import size or which mode you're in). Released frames keep their Blob and re-decode on view.
-    const DECODED_CAP = 120; // must exceed the prefetch window (~50) so prefetched frames aren't evicted
     const decodeOrderRef = useRef(new Map()); // id -> monotonically increasing use counter
     const decodeSeqRef = useRef(0);
     const [frameDecodeTick, setFrameDecodeTick] = useState(0); // bumped when a frame finishes decoding → forces cache rebuild
@@ -529,30 +529,25 @@ export default function App() {
         const store = bitmapStoreRef.current;
         const decoded = [];
         for (const [id, e] of store) if (e.blob && e.imageBitmap) decoded.push(id);
-        if (decoded.length <= DECODED_CAP) return;
-        const order = decodeOrderRef.current;
-        const hot = hotWindowRef.current; // the on-screen / prefetch window is never evicted
-        decoded.sort((a, b) => (order.get(a) || 0) - (order.get(b) || 0)); // oldest first
-        let toRelease = decoded.length - DECODED_CAP;
-        for (const id of decoded) {
-            if (toRelease <= 0) break;
-            if ((protect && protect.has(id)) || hot.has(id)) continue;
+        // Which to let go of is decided in core/decodeBudget, where the reason the cap has to
+        // stay above the prefetch window is written down and tested. Here is only the letting go.
+        const release = framesToRelease({
+            decoded, order: decodeOrderRef.current, cap: DECODED_CAP,
+            protect, hot: hotWindowRef.current,
+        });
+        for (const id of release) {
             const e = store.get(id); try { e.imageBitmap.close?.(); } catch { } e.imageBitmap = null;
-            order.delete(id); toRelease--;
+            decodeOrderRef.current.delete(id);
         }
     };
     // Invalidate ONLY the cached layer canvases of cuts that use the given (just-decoded) frames,
     // instead of nuking the whole cache — nuking made on-screen frames flicker while playing.
     const invalidateCutsUsing = (ids) => {
-        const idset = new Set(ids);
-        const affected = new Set();
-        for (const c of cuts) for (const l of safeArray(c.layers)) if (safeArray(l.strokes).some(s => s.tool === 'paste' && idset.has(s.bitmapId))) affected.add(layerKey(c.id, l.id));
+        const affected = layerKeysUsingBitmaps(cuts, ids, layerKey);
         if (!affected.size) return;
-        // A boiling layer holds one canvas per phase, keyed "cut:layer#phase", so dropping the
-        // plain key alone would leave its phases behind holding the stale bitmap.
-        for (const k of [...fallbackCanvasRef.current.keys()]) {
-            const base = k.includes('#') ? k.slice(0, k.indexOf('#')) : k;
-            if (affected.has(base)) fallbackCanvasRef.current.delete(k);
+        // The phase keys of a boiling layer go with the plain one; core/decodeBudget says why.
+        for (const k of keysWithPhases([...fallbackCanvasRef.current.keys()], affected)) {
+            fallbackCanvasRef.current.delete(k);
         }
         setLayerCanvasCache(prev => { const n = { ...prev }; for (const k of affected) delete n[k]; return n; });
     };

--- a/src/core/decodeBudget.js
+++ b/src/core/decodeBudget.js
@@ -1,0 +1,95 @@
+// How many decoded frames to hold, which to let go of, and which cached layers a decode invalidates.
+//
+// Both answers here are small and both fail quietly when they are wrong. Releasing a frame that
+// is about to be shown makes playback flicker, and it flickers in a way that looks like a decode
+// problem rather than an eviction problem. Invalidating too much makes the whole cache rebuild
+// mid-playback; invalidating too little leaves a layer showing pixels that have been replaced.
+//
+// Neither needs a canvas or a bitmap to decide, which is why they are here and not in App.
+
+/**
+ * How many decoded frames may be held at once.
+ *
+ * **This must stay above the prefetch window (~50).** If it does not, the trim below evicts
+ * frames the prefetcher has just decoded, the prefetcher decodes them again, and the two spend
+ * playback fighting each other - which shows up as stutter, not as a memory problem. The hot set
+ * is a second guard on the same hazard.
+ */
+export const DECODED_CAP = 120;
+
+/**
+ * Which decoded frames to release, oldest use first.
+ *
+ * Two sets are never released whatever their age: `hot` is the prefetch window - the frames about
+ * to be shown - and `protect` is whatever the caller knows it is using this instant. An id in
+ * either is skipped rather than counted against the quota, so a run of protected frames does not
+ * silently stop the trim early.
+ *
+ * @param {object} args
+ * @param {Iterable<string>} args.decoded every id currently holding a decoded bitmap
+ * @param {Map<string, number>} args.order id -> use counter, higher is more recent
+ * @param {number} [args.cap]
+ * @param {Set<string>} [args.protect]
+ * @param {Set<string>} [args.hot]
+ * @returns {string[]} ids to release, in the order they should go
+ */
+export function framesToRelease({ decoded, order, cap = DECODED_CAP, protect, hot }) {
+    const ids = [...decoded];
+    if (ids.length <= cap) return [];
+    // Oldest first. An id with no recorded use sorts as 0, which is right: it was never touched
+    // through the accounting path, so nothing says it is wanted.
+    ids.sort((a, b) => (order.get(a) || 0) - (order.get(b) || 0));
+    const out = [];
+    let want = ids.length - cap;
+    for (const id of ids) {
+        if (want <= 0) break;
+        if (protect?.has(id) || hot?.has(id)) continue;
+        out.push(id);
+        want--;
+    }
+    return out;
+}
+
+/**
+ * The layer-canvas keys that hold pixels from any of the given frames.
+ *
+ * Only these are dropped, rather than the whole cache: clearing everything made on-screen frames
+ * flicker while playing, because a decode finishing mid-playback rebuilt every visible layer.
+ *
+ * @param {Array<{id: any, layers?: any[]}>} cuts
+ * @param {Iterable<string>} ids the frames that just changed
+ * @param {(cutId: any, layerId: any) => string} key
+ * @returns {Set<string>}
+ */
+export function layerKeysUsingBitmaps(cuts, ids, key) {
+    const want = new Set(ids);
+    const out = new Set();
+    if (!want.size) return out;
+    for (const c of cuts || []) {
+        for (const l of c?.layers || []) {
+            const strokes = l?.strokes || [];
+            if (strokes.some(s => s?.tool === 'paste' && want.has(s.bitmapId))) out.add(key(c.id, l.id));
+        }
+    }
+    return out;
+}
+
+/**
+ * Every cache key that belongs to one of `bases`, including a boiling layer's phase variants.
+ *
+ * A boiling layer holds one canvas per phase, keyed `cut:layer#phase`. Dropping the plain key
+ * alone leaves the phases behind, still holding the bitmap that was just replaced - a layer that
+ * updates when still and shows stale pixels the moment it starts boiling.
+ *
+ * @param {Iterable<string>} keys every key currently in the cache
+ * @param {Set<string>} bases the keys to drop, without phase suffixes
+ * @returns {string[]}
+ */
+export function keysWithPhases(keys, bases) {
+    const out = [];
+    for (const k of keys) {
+        const hash = k.indexOf('#');
+        if (bases.has(hash === -1 ? k : k.slice(0, hash))) out.push(k);
+    }
+    return out;
+}

--- a/test/decodeBudget.test.js
+++ b/test/decodeBudget.test.js
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { framesToRelease, layerKeysUsingBitmaps, keysWithPhases, DECODED_CAP } from '../src/core/decodeBudget.js';
+
+const ids = (n, prefix = 'f') => Array.from({ length: n }, (_, i) => `${prefix}${i}`);
+/** Used in the order given: f0 oldest, last newest. */
+const usedInOrder = (list) => new Map(list.map((id, i) => [id, i + 1]));
+
+test('nothing is released while under the cap', () => {
+    const list = ids(10);
+    assert.deepEqual(framesToRelease({ decoded: list, order: usedInOrder(list), cap: 20 }), []);
+    // Exactly at the cap is still under it - releasing here would thrash at the boundary.
+    assert.deepEqual(framesToRelease({ decoded: list, order: usedInOrder(list), cap: 10 }), []);
+});
+
+test('the oldest go first, and only as many as the overflow', () => {
+    const list = ids(13);
+    const out = framesToRelease({ decoded: list, order: usedInOrder(list), cap: 10 });
+    assert.deepEqual(out, ['f0', 'f1', 'f2']);
+});
+
+test('the prefetch window is never released, however old', () => {
+    // The hazard this exists for: evicting a frame the prefetcher just decoded makes it decode
+    // again, and the two spend playback fighting each other. It reads as stutter, not as memory.
+    const list = ids(13);
+    const hot = new Set(['f0', 'f1']);
+    const out = framesToRelease({ decoded: list, order: usedInOrder(list), cap: 10, hot });
+    assert.equal(out.includes('f0'), false);
+    assert.equal(out.includes('f1'), false);
+    assert.deepEqual(out, ['f2', 'f3', 'f4']);
+});
+
+test('a protected frame is skipped rather than counted, so the trim still frees enough', () => {
+    // Counting a skipped id against the quota would stop the trim early and leave the store over
+    // cap, quietly, for as long as those frames stay protected.
+    const list = ids(13);
+    const out = framesToRelease({ decoded: list, order: usedInOrder(list), cap: 10, protect: new Set(['f0', 'f1']) });
+    assert.equal(out.length, 3);
+    assert.deepEqual(out, ['f2', 'f3', 'f4']);
+});
+
+test('when everything is protected nothing is released rather than something being forced out', () => {
+    const list = ids(13);
+    const out = framesToRelease({ decoded: list, order: usedInOrder(list), cap: 10, hot: new Set(list) });
+    assert.deepEqual(out, []);
+});
+
+test('a frame that was never touched sorts as oldest', () => {
+    // No recorded use means nothing says it is wanted - it should go before one that was used.
+    const order = new Map([['b', 5], ['c', 9]]);
+    const out = framesToRelease({ decoded: ['a', 'b', 'c'], order, cap: 2 });
+    assert.deepEqual(out, ['a']);
+});
+
+test('the cap is above the prefetch window, which is the whole reason it has a number', () => {
+    const PREFETCH_WINDOW = 50;
+    assert.ok(DECODED_CAP > PREFETCH_WINDOW, `${DECODED_CAP} must exceed the ~${PREFETCH_WINDOW} frame window`);
+});
+
+// ---------------------------------------------------------------------------------------------
+
+const key = (cutId, layerId) => `${cutId}:${layerId}`;
+const film = () => ([
+    { id: 1, layers: [
+        { id: 10, strokes: [{ tool: 'paste', bitmapId: 'A' }] },
+        { id: 11, strokes: [{ tool: 'pen' }] },
+    ] },
+    { id: 2, layers: [
+        { id: 20, strokes: [{ tool: 'brush' }, { tool: 'paste', bitmapId: 'B' }] },
+    ] },
+]);
+
+test('only the layers holding those frames are named', () => {
+    assert.deepEqual([...layerKeysUsingBitmaps(film(), ['A'], key)], ['1:10']);
+    assert.deepEqual([...layerKeysUsingBitmaps(film(), ['B'], key)], ['2:20']);
+    assert.deepEqual([...layerKeysUsingBitmaps(film(), ['A', 'B'], key)], ['1:10', '2:20']);
+});
+
+test('an unknown frame names nothing, so nothing is invalidated for it', () => {
+    assert.equal(layerKeysUsingBitmaps(film(), ['Z'], key).size, 0);
+    assert.equal(layerKeysUsingBitmaps(film(), [], key).size, 0);
+});
+
+test('a fill or a stroke is not a paste, and does not tie a layer to a frame', () => {
+    const cuts = [{ id: 1, layers: [{ id: 10, strokes: [{ tool: 'fill', bitmapId: 'A' }] }] }];
+    assert.equal(layerKeysUsingBitmaps(cuts, ['A'], key).size, 0);
+});
+
+test('a cut with no layers, or a layer with no strokes, is not a crash', () => {
+    const cuts = [{ id: 1 }, { id: 2, layers: [{ id: 20 }] }, null];
+    assert.equal(layerKeysUsingBitmaps(/** @type {any} */(cuts), ['A'], key).size, 0);
+    assert.equal(layerKeysUsingBitmaps(/** @type {any} */(null), ['A'], key).size, 0);
+});
+
+test("a boiling layer's phase keys go with the plain one", () => {
+    // Dropping `1:10` alone leaves `1:10#3` behind holding the bitmap that was just replaced -
+    // a layer that updates when still and shows stale pixels the moment it boils.
+    const all = ['1:10', '1:10#0', '1:10#3', '1:11', '2:20', '2:20#1'];
+    assert.deepEqual(keysWithPhases(all, new Set(['1:10'])), ['1:10', '1:10#0', '1:10#3']);
+});
+
+test('a phase key does not drag in a different layer that shares a prefix', () => {
+    // `1:1` must not match `1:10`, or invalidating one layer clears its neighbour every time.
+    const all = ['1:1', '1:1#2', '1:10', '1:10#2'];
+    assert.deepEqual(keysWithPhases(all, new Set(['1:1'])), ['1:1', '1:1#2']);
+});
+
+test('nothing to drop drops nothing', () => {
+    assert.deepEqual(keysWithPhases(['1:10', '1:10#0'], new Set()), []);
+});


### PR DESCRIPTION
Two small pieces of the bitmap cache, both of which **fail quietly**:

- Releasing a frame that is about to be shown makes playback flicker — and it flickers in a way that looks like a *decode* problem rather than an *eviction* problem, which is where the time goes.
- Invalidating too much rebuilds the whole cache mid-playback; too little leaves a layer showing pixels that have already been replaced.

Neither needs a canvas or a bitmap to decide. Both are now in `core/decodeBudget`, with the reasoning attached to the numbers instead of trailing off the end of a line.

## What the extraction found

`framesToRelease` **skips** a protected id rather than counting it against the quota. The loop it replaces did the same — but nothing said so, and the opposite is the natural way to write it. Counted, a run of protected frames stops the trim early and the store sits over cap, quietly, for as long as they stay protected.

`DECODED_CAP` had its most important property as a trailing comment:

```js
const DECODED_CAP = 120; // must exceed the prefetch window (~50) so prefetched frames aren't evicted
```

That is now a test. Below the window, the trim evicts what the prefetcher just decoded, the prefetcher decodes it again, and the two spend playback fighting each other — which reads as stutter, not as memory pressure.

## Fourteen tests, and they bite

Writing each bug deliberately:

```
# counting protected ids against the quota
not ok 3 - the prefetch window is never released, however old
not ok 4 - a protected frame is skipped rather than counted, so the trim still frees enough

# matching phase keys by prefix instead of by base
not ok 13 - a phase key does not drag in a different layer that shares a prefix
```

That last one is real: `1:1` matched by prefix would clear `1:10` every single time its neighbour was invalidated.

## Numbers

App.jsx **3868 → 3863**. `npm run check`: 913 tests, 286 helpers indexed, reachability 364/364, import check clean, i18n 584, build clean.

## Worth a manual look

Behaviour-preserving, but this is the memory and decode path, so the failure modes are visual rather than loud:

1. Play a project with **many imported video frames** through more than once — no flicker, no stutter building up.
2. A layer with 자글자글 (boiling) that uses pasted frames — it should update when a frame finishes decoding, both while still and while boiling.
3. Scrub back and forth quickly over an imported sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)