### PR TITLE
refactor: where a part sits, and how a selection is cut out of it

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -553,6 +553,16 @@ The drawing engine: strokes, canvases, animation, video frames. The big one.
 | `SWING` | The three shapes a return animation can take. `through` passes the resting position and goes out the other side, which is what the layer presets are made of - 둥실둥실 bobs above and below. `there` and `along` go out to the target and back and never past the start. One cycle is one whole trip in all three, so speed means the same thing to each. |
 | `swing` | A return animation's progress for one of those shapes, or 0 once it has run out of repeats. Settling at 0 rather than mid-wave is where a whole trip would have ended anyway. |
 
+## `src/canvas/layerComposite.js`
+
+Putting one layer onto the frame: where it sits, and how a floating selection is cut out of it. Both came out of the composite loop, which runs for every layer of every visible cut, sixty times a second.
+
+| | |
+|---|---|
+| `partMatrix` | A part's placement as a 2x3 affine. A matrix rather than context calls, because the whole of the reasoning is the composition order — rotate and scale about the pivot, and a shear that pivots at `py` — and that can then be checked without a canvas. |
+| `applyPartTransform` | The same, applied to a context, with keyframe opacity multiplied rather than replaced (a part inside a fading cut has to fade with it). |
+| `drawMaskedLayer` | Layer minus the lifted region. `destination-out` on a **shared scratch**, never on the frame — erasing on the frame would take the artwork already there, and a fresh canvas per masked layer per frame is 8MB sixty times a second. |
+
 ## `src/canvas/swayRender.js`
 
 Bending a layer along an axis - hair swinging from its roots, a ribbon trailing from where it is held.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ import { fetchAsset } from './core/api.js';
 import { PLAYBACK_RATES, RATE_DEFAULT, playbackRateCodec } from './core/playbackRate.js';
 import { scaleProjectTimes, bakePlan } from './core/timeScale.js';
 import { drawSwayed } from './canvas/swayRender.js';
+import { applyPartTransform, drawMaskedLayer } from './canvas/layerComposite.js';
 import { detachMedia, safeMediaSrc } from './core/mediaEl.js';
 import { useAutosave } from './hooks/useAutosave.js';
 import { useAudioTrack } from './hooks/useAudioTrack.js';
@@ -2760,17 +2761,12 @@ export default function App() {
                 const layerCanvas = flattenClipGroup(ac.id, group);
                 if (!layerCanvas) continue; // frame still decoding (part-scoped memory); will repaint when ready
 
-                // Per-layer ("part") transform nests inside the cut transform.
+                // Per-layer ("part") transform nests inside the cut transform. The composition
+                // order - and why rotation happens about the pivot rather than the origin - is
+                // in canvas/layerComposite, where it is a matrix and can be checked.
                 const la = group.anim;
                 ctx.save();
-                if (la) {
-                    if (la.alpha != null && la.alpha < 1) ctx.globalAlpha *= la.alpha; // keyframe opacity
-                    ctx.translate(la.px + la.tx, la.py + la.ty);
-                    ctx.rotate(la.rot);
-                    ctx.scale(la.sc, la.sc);
-                    ctx.translate(-la.px, -la.py);
-                    if (la.shear) ctx.transform(1, 0, la.shear, 1, -la.shear * la.py, 0); // hair/cloth sway
-                }
+                applyPartTransform(ctx, la);
 
                 const shouldMask = selection?.maskBitmapId && selection.cutId === ac.id && selection.sourceLayerId === l.id;
                 const maskEntry = shouldMask ? bitmapStoreRef.current.get(selection.maskBitmapId) : null;
@@ -2789,22 +2785,11 @@ export default function App() {
                 } else if (!shouldMask || (!mb && !mi)) {
                     ctx.drawImage(layerCanvas, 0, 0);
                 } else {
-                    const mx = Math.round(selection.x);
-                    const my = Math.round(selection.y);
-                    // Reused rather than allocated. This runs inside the composite loop, so a
-                    // fresh canvas here is 8MB per masked layer per frame - sixty times a second
-                    // while playing, which is the shape of allocation that took a tab out once.
-                    const { canvas: tmp, ctx: tctx } = scratchCanvas(maskScratchRef, CANVAS_W, CANVAS_H);
-                    tctx.setTransform(1, 0, 0, 1, 0, 0);
-                    tctx.globalAlpha = 1.0;
-                    tctx.globalCompositeOperation = 'source-over';
-                    tctx.drawImage(layerCanvas, 0, 0);
-                    tctx.globalCompositeOperation = 'destination-out';
-                    // imageDataCanvas is a different shared canvas from this one, so nesting them
-                    // is safe - which is why they are separate helpers rather than slots of one.
-                    tctx.drawImage(mb || imageDataCanvas(mi), mx, my);
-                    tctx.globalCompositeOperation = 'source-over';
-                    ctx.drawImage(tmp, 0, 0);
+                    // imageDataCanvas is a different shared canvas from the mask scratch, so
+                    // nesting them is safe - which is why they are separate helpers rather than
+                    // two slots of one.
+                    drawMaskedLayer(ctx, layerCanvas, mb || imageDataCanvas(mi), selection,
+                        scratchCanvas(maskScratchRef, CANVAS_W, CANVAS_H));
                 }
                 ctx.restore();
             }

--- a/src/canvas/layerComposite.js
+++ b/src/canvas/layerComposite.js
@@ -1,0 +1,98 @@
+// Putting one layer onto the frame: where it sits, and how a floating selection is cut out of it.
+//
+// Both of these lived inside the composite loop in paintFrame, which is the hottest code in the
+// app - it runs for every layer of every visible cut, sixty times a second. Neither needed to be
+// there. The placement is arithmetic, and the mask is a fixed sequence of canvas operations whose
+// only subtlety is which canvas is which.
+
+/** A 2x3 affine, in the order canvas uses: [a, b, c, d, e, f]. */
+const I = [1, 0, 0, 1, 0, 0];
+
+/** m then n, as canvas applies them - n is the later transform and nests inside m. */
+function mul(m, n) {
+    return [
+        m[0] * n[0] + m[2] * n[1],
+        m[1] * n[0] + m[3] * n[1],
+        m[0] * n[2] + m[2] * n[3],
+        m[1] * n[2] + m[3] * n[3],
+        m[0] * n[4] + m[2] * n[5] + m[4],
+        m[1] * n[4] + m[3] * n[5] + m[5],
+    ];
+}
+
+/**
+ * Where a part sits: its own transform, nested inside whatever the cut is already doing.
+ *
+ * Returned as a matrix rather than applied to a context, because the whole of the reasoning is
+ * in the composition order and that can then be checked without a canvas:
+ *
+ *   translate(px + tx, py + ty)   move to the pivot, plus the animated offset
+ *   rotate, scale                 which therefore happen about the pivot, not the origin
+ *   translate(-px, -py)           and back
+ *   shear                         with `-shear * py`, so the shear pivots at py too
+ *
+ * Get that order wrong and a rotated part orbits the top-left corner instead of turning in place,
+ * which reads as the drawing flying off rather than as a wrong pivot.
+ *
+ * @param {any} la a layer animation, or null
+ * @returns {number[]} [a, b, c, d, e, f]
+ */
+export function partMatrix(la) {
+    if (!la) return I.slice();
+    let m = mul(I, [1, 0, 0, 1, la.px + la.tx, la.py + la.ty]);
+    const cos = Math.cos(la.rot || 0), sin = Math.sin(la.rot || 0);
+    m = mul(m, [cos, sin, -sin, cos, 0, 0]);
+    const s = la.sc ?? 1;
+    m = mul(m, [s, 0, 0, s, 0, 0]);
+    m = mul(m, [1, 0, 0, 1, -la.px, -la.py]);
+    // hair/cloth sway, as a single shear. A per-point profile is not this - it varies along the
+    // axis and is drawn in slices by canvas/swayRender.
+    if (la.shear) m = mul(m, [1, 0, la.shear, 1, -la.shear * la.py, 0]);
+    return m;
+}
+
+/**
+ * Apply a part's placement to a context, including its keyframe opacity.
+ *
+ * Opacity multiplies rather than replaces: the cut it sits in may already have faded, and a part
+ * inside a fading cut has to fade with it.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {any} la
+ */
+export function applyPartTransform(ctx, la) {
+    if (!la) return;
+    if (la.alpha != null && la.alpha < 1) ctx.globalAlpha *= la.alpha;
+    const [a, b, c, d, e, f] = partMatrix(la);
+    ctx.transform(a, b, c, d, e, f);
+}
+
+/**
+ * Draw a layer with a region cut out of it - what a floating selection needs, since the pixels
+ * it lifted must not also still be in the layer underneath.
+ *
+ * `destination-out` on a scratch canvas rather than on the frame: erasing straight onto the frame
+ * would take the artwork already drawn there with it.
+ *
+ * The scratch canvas is reused. This runs inside the composite loop, so a fresh one here is 8MB
+ * per masked layer per frame, sixty times a second while playing - the shape of allocation that
+ * took a tab out once.
+ *
+ * @param {CanvasRenderingContext2D} ctx the frame
+ * @param {CanvasImageSource} layerCanvas
+ * @param {CanvasImageSource} mask the lifted region, already a drawable
+ * @param {{x: number, y: number}} at where the mask sits
+ * @param {{canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D}} scratch a sized scratch pair
+ */
+export function drawMaskedLayer(ctx, layerCanvas, mask, at, scratch) {
+    const { canvas: tmp, ctx: tctx } = scratch;
+    // Reset in full: the scratch is shared, so whatever the last user left on it is still set.
+    tctx.setTransform(1, 0, 0, 1, 0, 0);
+    tctx.globalAlpha = 1.0;
+    tctx.globalCompositeOperation = 'source-over';
+    tctx.drawImage(layerCanvas, 0, 0);
+    tctx.globalCompositeOperation = 'destination-out';
+    tctx.drawImage(mask, Math.round(at.x), Math.round(at.y));
+    tctx.globalCompositeOperation = 'source-over';
+    ctx.drawImage(tmp, 0, 0);
+}

--- a/test/layerComposite.test.js
+++ b/test/layerComposite.test.js
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { partMatrix, drawMaskedLayer } from '../src/canvas/layerComposite.js';
+
+/** Where a point lands under a matrix. Easier to reason about than the six numbers. */
+const at = (m, x, y) => [m[0] * x + m[2] * y + m[4], m[1] * x + m[3] * y + m[5]];
+const near = (a, b, msg) => assert.ok(Math.abs(a - b) < 1e-9, `${msg}: ${a} vs ${b}`);
+
+const base = { px: 100, py: 50, tx: 0, ty: 0, rot: 0, sc: 1, shear: 0 };
+
+test('no animation is the identity', () => {
+    assert.deepEqual(partMatrix(null), [1, 0, 0, 1, 0, 0]);
+    assert.deepEqual(partMatrix({ ...base }), [1, 0, 0, 1, 0, 0]);
+});
+
+test('a plain offset moves everything by it', () => {
+    const [x, y] = at(partMatrix({ ...base, tx: 30, ty: -10 }), 0, 0);
+    near(x, 30, 'x'); near(y, -10, 'y');
+});
+
+test('rotation turns the part in place, about its pivot', () => {
+    // The failure this pins: get the order wrong and the part orbits the top-left corner, which
+    // reads as the drawing flying off screen rather than as a wrong pivot.
+    const m = partMatrix({ ...base, rot: Math.PI / 2 });
+    const [px, py] = at(m, 100, 50);
+    near(px, 100, 'pivot x stays'); near(py, 50, 'pivot y stays');
+});
+
+test('scale also happens about the pivot', () => {
+    const m = partMatrix({ ...base, sc: 2 });
+    const [px, py] = at(m, 100, 50);
+    near(px, 100, 'pivot x stays'); near(py, 50, 'pivot y stays');
+    // A point 10 to the right of the pivot ends up 20 away.
+    const [qx] = at(m, 110, 50);
+    near(qx, 120, 'scaled about the pivot');
+});
+
+test('a quarter turn sends a point right of the pivot to below it', () => {
+    const m = partMatrix({ ...base, rot: Math.PI / 2 });
+    const [x, y] = at(m, 110, 50);          // 10 to the right of the pivot
+    near(x, 100, 'x back to the pivot'); near(y, 60, 'y ten below');
+});
+
+test('shear pivots at py, so the pivot row does not slide', () => {
+    // Without the -shear*py term the whole layer slides sideways by shear*py, which looks like
+    // the drawing jumping the moment sway is switched on.
+    const m = partMatrix({ ...base, shear: 0.25 });
+    const [x] = at(m, 0, 50);               // on the pivot row
+    near(x, 0, 'pivot row stays put');
+    const [x2] = at(m, 0, 150);             // 100 below it
+    near(x2, 25, 'a row 100 below shifts by shear*100');
+});
+
+test('offset and rotation compose - the offset moves the pivot too', () => {
+    const m = partMatrix({ ...base, tx: 20, ty: 5, rot: Math.PI / 2 });
+    const [x, y] = at(m, 100, 50);
+    near(x, 120, 'pivot carried by tx'); near(y, 55, 'pivot carried by ty');
+});
+
+test('a missing scale reads as 1, not as 0', () => {
+    // `la.sc ?? 1` rather than `la.sc || 1`: both give 1 for undefined, but an explicit 0 is a
+    // real request to collapse the part, and || would silently turn it into full size.
+    const [x] = at(partMatrix({ ...base, sc: undefined }), 110, 50);
+    near(x, 110, 'undefined scale leaves the point alone');
+    const m0 = partMatrix({ ...base, sc: 0 });
+    const [cx, cy] = at(m0, 110, 60);
+    near(cx, 100, 'zero scale collapses to the pivot'); near(cy, 50, 'and in y');
+});
+
+// ---------------------------------------------------------------------------------------------
+
+/** Enough of a 2D context to record the call order, which is the whole of what matters here. */
+function fakeCtx(name, log) {
+    return {
+        globalAlpha: 1, globalCompositeOperation: 'source-over',
+        setTransform: (...a) => log.push(`${name}.setTransform(${a.join(',')})`),
+        drawImage: (src, x = '', y = '') => log.push(`${name}.draw(${src},${x},${y})`),
+    };
+}
+
+test('the mask is erased on the scratch, never on the frame', () => {
+    // Erasing straight onto the frame would take the artwork already drawn there with it.
+    const log = [];
+    const tctx = fakeCtx('scratch', log);
+    const ctx = fakeCtx('frame', log);
+    const ops = [];
+    Object.defineProperty(tctx, 'globalCompositeOperation', {
+        get: () => ops.at(-1) || 'source-over', set: (v) => ops.push(v),
+    });
+    drawMaskedLayer(ctx, 'LAYER', 'MASK', { x: 12.4, y: 7.6 }, { canvas: 'TMP', ctx: tctx });
+
+    assert.deepEqual(ops, ['source-over', 'destination-out', 'source-over']);
+    assert.deepEqual(log, [
+        'scratch.setTransform(1,0,0,1,0,0)',
+        'scratch.draw(LAYER,0,0)',
+        'scratch.draw(MASK,12,8)',      // rounded - a half pixel would resample the mask edge
+        'frame.draw(TMP,0,0)',
+    ]);
+});
+
+test('the scratch is reset before use, because it is shared', () => {
+    const log = [];
+    const tctx = fakeCtx('scratch', log);
+    tctx.globalAlpha = 0.3;                     // left over from whoever used it last
+    drawMaskedLayer(fakeCtx('frame', log), 'L', 'M', { x: 0, y: 0 }, { canvas: 'T', ctx: tctx });
+    assert.equal(tctx.globalAlpha, 1.0);
+    assert.equal(log[0], 'scratch.setTransform(1,0,0,1,0,0)');
+});


### PR DESCRIPTION
Two pieces out of `paintFrame`'s composite loop — the hottest code in the app, running for every layer of every visible cut, sixty times a second. Neither needed to be there.

## The placement is a matrix now

Not five context calls. That is the point: the whole of the reasoning **is** the composition order —

```
translate(px + tx, py + ty)   move to the pivot, plus the animated offset
rotate, scale                 which therefore happen about the pivot, not the origin
translate(-px, -py)           and back
shear                         with -shear*py, so the shear pivots at py too
```

As context calls that order can only be read. As a matrix it can be **checked**.

Ten tests. Writing the classic mistake — rotating *before* moving to the pivot — fails four:

```
not ok 3 - rotation turns the part in place, about its pivot
not ok 5 - a quarter turn sends a point right of the pivot to below it
not ok 6 - shear pivots at py, so the pivot row does not slide
not ok 7 - offset and rotation compose - the offset moves the pivot too
```

Worth pinning because **getting it wrong does not look like a wrong pivot**: a rotated part orbits the top-left corner and reads as the drawing flying off screen. Dropping the shear's pivot term slides the whole layer sideways the moment sway is switched on.

## `drawMaskedLayer` keeps the two non-obvious things

- The erase happens on a **shared scratch**, never on the frame — `destination-out` on the frame would take the artwork already drawn there.
- The scratch is **reused** — a fresh canvas per masked layer per frame is 8MB, sixty times a second, which is the shape of allocation that took a tab out once.

A fake context pins the call order, including that the mask offset is rounded (a half pixel would resample its edge).

## One guard added on the way

`la.sc ?? 1`. `ctx.scale(undefined, undefined)` makes the matrix NaN and the layer vanishes. `??` rather than `||` also keeps an explicit `0` meaning *collapse*, which `|| 1` would have turned into full size.

## Numbers

App.jsx **3863 → 3848**. `npm run check`: 923 tests, 8 hook warnings (unchanged), 289 helpers indexed, reachability 364/364, import check clean, i18n 584, build clean.

## Worth a manual look

Behaviour-preserving, but it is the paint path:

1. A part with 파츠 애니메이션 — move, **rotate**, scale. The rotation should turn it in place.
2. A layer with 흔들림 (single shear, no per-point profile) — it should not jump sideways when enabled.
3. Lasso a region and drag it — the lifted pixels must not also still show in the layer underneath.
4. A part inside a fading cut — it should fade with the cut, not at full opacity.
