### PR TITLE
refactor: which pixels a lasso takes, and the hole it leaves

### DIFF
--- a/HELPERS.md
+++ b/HELPERS.md
@@ -239,6 +239,7 @@ Lasso selection: closing the path, bounding it, lifting the pixels.
 |---|---|
 | `applyResize` | Resize a selection by dragging one of its handles. The handle names read as compass points, so which edges move falls out of the letters: 'nw' moves the top and left, 'e' moves the right edge alone. |
 | `closeLassoPath` | Close a freehand path into a polygon. If the ends are far apart the path is left as drawn and joined back to the start, adding an edge. |
+| `cutOutPolygon` | The pixels inside a lasso, and the hole they leave, from one pass — they describe the same set from both sides, and a mask that drifts from its selection leaves a ghost in the layer. Only non-transparent pixels are lifted, and the inside test is at the pixel centre so a boundary on the grid is not a coin toss. |
 | `lassoBounds` | The pixel rectangle a lasso covers, clamped to the canvas. Returned as integers because it indexes into image data: the left and top round down and the right and bottom round up, so a region is never clipped by a fraction of a pixel. |
 | `MIN_SELECTION_SIZE` | Smallest a selection may be dragged to, in pixels. Below this it is impossible to grab again. |
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ import { ProjectPicker, ProgressOverlay, SettingsModal, HelpModal, VideoImportMo
 import { tr, loadLang, saveLang, setLangValue } from './i18n';
 import { moveLayer } from './core/layerOps.js';
 import { resolveDrawLayer as resolveDrawLayerPure, commitStroke, insertFill, patchLayer } from './core/layerOps.js';
-import { closeLassoPath, lassoBounds, applyResize } from './core/lassoOps.js';
+import { closeLassoPath, lassoBounds, applyResize, cutOutPolygon } from './core/lassoOps.js';
 import { useTimelineGestures } from './hooks/useTimelineGestures.js';
 import { fmt, parseClock } from './core/timeCode.js';
 import { textFromEdit, editFromText, blankTextEdit } from './core/textEdit.js';
@@ -2352,33 +2352,22 @@ export default function App() {
         const { x: minX, y: minY, w, h } = lassoBounds(points, CANVAS_W, CANVAS_H);
         if (w <= 0 || h <= 0) return;
 
-        const layerImageData = ctx.getImageData(minX, minY, w, h);
-        const selectionImageData = new ImageData(w, h);
-        const eraseMaskImageData = new ImageData(w, h);
-        let hasContent = false;
-        for (let y = 0; y < h; y++) {
-            for (let x = 0; x < w; x++) {
-                const i = (y * w + x) * 4;
-                // Tested at the pixel centre: on the boundary itself the crossing test could go
-                // either way, and a half-pixel offset makes the answer definite.
-                if (!pointInPolygon([minX + x + 0.5, minY + y + 0.5], poly)) continue;
-                const a = layerImageData.data[i + 3];
-                if (a === 0) continue;
-                hasContent = true;
-                selectionImageData.data[i] = layerImageData.data[i];
-                selectionImageData.data[i + 1] = layerImageData.data[i + 1];
-                selectionImageData.data[i + 2] = layerImageData.data[i + 2];
-                selectionImageData.data[i + 3] = a;
-                eraseMaskImageData.data[i + 3] = 255;
-            }
-        }
+        // Which pixels come along, and the hole they leave, are worked out in core/lassoOps -
+        // both from one pass, because a mask that drifts from its selection leaves a ghost of
+        // the lifted artwork behind in the layer.
+        const { selection: sel, eraseMask, hasContent } = cutOutPolygon({
+            layer: ctx.getImageData(minX, minY, w, h),
+            poly, minX, minY, w, h,
+            makeImageData: (iw, ih) => new ImageData(iw, ih),
+            inside: pointInPolygon,
+        });
         if (!hasContent) return;
 
         setSelection({
             cutId: currentCutId,
             sourceLayerId: activeLayer.id,
-            bitmapId: storeBitmap(selectionImageData),
-            maskBitmapId: storeBitmap(eraseMaskImageData),
+            bitmapId: storeBitmap(sel),
+            maskBitmapId: storeBitmap(eraseMask),
             x: minX, y: minY, w, h,
             tx: minX, ty: minY, tw: w, th: h,
         });

--- a/src/core/lassoOps.js
+++ b/src/core/lassoOps.js
@@ -103,3 +103,54 @@ export function applyResize(handle, startSel, dx, dy) {
 
     return { tx: left, ty: top, tw: Math.max(min, right - left), th: Math.max(min, bottom - top) };
 }
+
+/**
+ * Split a rectangle of layer pixels into the part inside a polygon and a mask of where it was.
+ *
+ * Two images out of one pass, because they describe the same set of pixels from both sides: the
+ * selection is what now floats, and the mask is the hole it leaves behind. Building them
+ * separately is how they drift, and a mask that does not match its selection shows as a ghost of
+ * the lifted artwork left in the layer.
+ *
+ * Only pixels that are **both** inside the polygon and not fully transparent are taken. Lifting
+ * empty pixels would make the selection box larger than the artwork in it, and erase a
+ * rectangle's worth of nothing from the layer underneath.
+ *
+ * `makeImageData` is injected rather than `new ImageData(...)` being called here, the same way
+ * the rest of `core/` takes its browser functions - so the awkward cases can be checked without
+ * a canvas.
+ *
+ * @param {object} args
+ * @param {{data: Uint8ClampedArray}} args.layer pixels already cropped to the bounds
+ * @param {number[][]} args.poly a closed ring, in canvas coordinates
+ * @param {number} args.minX left edge of the bounds, in canvas coordinates
+ * @param {number} args.minY top edge
+ * @param {number} args.w
+ * @param {number} args.h
+ * @param {(w: number, h: number) => {data: Uint8ClampedArray}} args.makeImageData
+ * @param {(pt: number[], poly: number[][]) => boolean} args.inside
+ * @returns {{selection: {data: Uint8ClampedArray}, eraseMask: {data: Uint8ClampedArray}, hasContent: boolean}}
+ */
+export function cutOutPolygon({ layer, poly, minX, minY, w, h, makeImageData, inside }) {
+    const selection = makeImageData(w, h);
+    const eraseMask = makeImageData(w, h);
+    let hasContent = false;
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            const i = (y * w + x) * 4;
+            // Tested at the pixel centre. On the boundary itself the crossing test could go
+            // either way, and the half-pixel offset makes the answer definite - otherwise which
+            // pixels come along depends on where the polygon happens to land on the grid.
+            if (!inside([minX + x + 0.5, minY + y + 0.5], poly)) continue;
+            const a = layer.data[i + 3];
+            if (a === 0) continue;
+            hasContent = true;
+            selection.data[i] = layer.data[i];
+            selection.data[i + 1] = layer.data[i + 1];
+            selection.data[i + 2] = layer.data[i + 2];
+            selection.data[i + 3] = a;
+            eraseMask.data[i + 3] = 255;
+        }
+    }
+    return { selection, eraseMask, hasContent };
+}

--- a/test/cutOutPolygon.test.js
+++ b/test/cutOutPolygon.test.js
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cutOutPolygon } from '../src/core/lassoOps.js';
+import { pointInPolygon } from '../src/canvas/canvasUtils.js';
+
+/** Node has no ImageData; core/ takes it as an argument for exactly this reason. */
+const makeImageData = (w, h) => ({ width: w, height: h, data: new Uint8ClampedArray(w * h * 4) });
+
+/** A w*h block of opaque pixels, each a distinguishable colour. */
+function filled(w, h, alpha = 255) {
+    const img = makeImageData(w, h);
+    for (let i = 0; i < w * h; i++) {
+        img.data[i * 4] = i + 1;          // r, so a copied pixel can be identified
+        img.data[i * 4 + 1] = 2;
+        img.data[i * 4 + 2] = 3;
+        img.data[i * 4 + 3] = alpha;
+    }
+    return img;
+}
+
+const px = (img, w, x, y) => [...img.data.slice((y * w + x) * 4, (y * w + x) * 4 + 4)];
+const cut = (args) => cutOutPolygon({ makeImageData, inside: pointInPolygon, ...args });
+
+/** A square covering the whole 4x4 bounds. */
+const wholeBox = [[0, 0], [4, 0], [4, 4], [0, 4], [0, 0]];
+
+test('pixels inside the polygon are copied, with their colour', () => {
+    const r = cut({ layer: filled(4, 4), poly: wholeBox, minX: 0, minY: 0, w: 4, h: 4 });
+    assert.equal(r.hasContent, true);
+    assert.deepEqual(px(r.selection, 4, 0, 0), [1, 2, 3, 255]);
+    assert.deepEqual(px(r.selection, 4, 3, 3), [16, 2, 3, 255]);
+});
+
+test('pixels outside are left untouched', () => {
+    // A polygon over the left half only.
+    const left = [[0, 0], [2, 0], [2, 4], [0, 4], [0, 0]];
+    const r = cut({ layer: filled(4, 4), poly: left, minX: 0, minY: 0, w: 4, h: 4 });
+    assert.deepEqual(px(r.selection, 4, 0, 0), [1, 2, 3, 255], 'inside taken');
+    assert.deepEqual(px(r.selection, 4, 3, 0), [0, 0, 0, 0], 'outside empty');
+});
+
+test('the mask marks exactly the pixels the selection took', () => {
+    // They describe the same set from both sides. If they drift, the layer keeps a ghost of the
+    // artwork that is now floating.
+    const left = [[0, 0], [2, 0], [2, 4], [0, 4], [0, 0]];
+    const r = cut({ layer: filled(4, 4), poly: left, minX: 0, minY: 0, w: 4, h: 4 });
+    for (let i = 0; i < 16; i++) {
+        const taken = r.selection.data[i * 4 + 3] > 0;
+        const masked = r.eraseMask.data[i * 4 + 3] > 0;
+        assert.equal(taken, masked, `pixel ${i}: selection ${taken}, mask ${masked}`);
+    }
+});
+
+test('fully transparent pixels are not lifted, even inside the polygon', () => {
+    // Otherwise the selection box is bigger than the artwork in it, and a rectangle of nothing
+    // gets erased from the layer underneath.
+    const r = cut({ layer: filled(4, 4, 0), poly: wholeBox, minX: 0, minY: 0, w: 4, h: 4 });
+    assert.equal(r.hasContent, false);
+    assert.ok(r.eraseMask.data.every(v => v === 0), 'nothing marked for erasing');
+});
+
+test('a partly transparent pixel keeps its own alpha', () => {
+    const layer = filled(2, 2);
+    layer.data[3] = 77;                                  // first pixel half-there
+    const r = cut({ layer, poly: [[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]], minX: 0, minY: 0, w: 2, h: 2 });
+    assert.equal(px(r.selection, 2, 0, 0)[3], 77, 'alpha carried, not forced to 255');
+    assert.equal(r.eraseMask.data[3], 255, 'but the mask erases it fully');
+});
+
+test('a pixel counts by its centre, not by its top-left corner', () => {
+    // The edge is at x=1.2, which falls *inside* pixel 1 (it spans 1..2). Its corner at x=1 is
+    // left of the edge and its centre at x=1.5 is right of it, so the two rules disagree here -
+    // which is what makes this a test rather than a restatement. A pixel barely clipped by the
+    // lasso should not come along whole.
+    const poly = [[0, -1], [1.2, -1], [1.2, 2], [0, 2], [0, -1]];
+    const r = cut({ layer: filled(4, 1), poly, minX: 0, minY: 0, w: 4, h: 1 });
+    assert.ok(r.selection.data[0 * 4 + 3] > 0, 'pixel 0 (centre 0.5) is in');
+    assert.equal(r.selection.data[1 * 4 + 3], 0, 'pixel 1 (centre 1.5, corner 1.0) is out');
+});
+
+test('the bounds offset is applied, so a selection away from the origin still lines up', () => {
+    // The layer data is already cropped to the bounds, but the polygon is in canvas coordinates.
+    // Forget minX/minY and the region is taken from the wrong place entirely.
+    const poly = [[10, 20], [12, 20], [12, 22], [10, 22], [10, 20]];
+    const r = cut({ layer: filled(2, 2), poly, minX: 10, minY: 20, w: 2, h: 2 });
+    assert.equal(r.hasContent, true);
+    assert.ok(r.selection.data.every((v, i) => i % 4 !== 3 || v === 255), 'all four taken');
+
+    const wrong = cut({ layer: filled(2, 2), poly, minX: 0, minY: 0, w: 2, h: 2 });
+    assert.equal(wrong.hasContent, false, 'without the offset, nothing is inside');
+});
+
+test('an empty polygon takes nothing rather than throwing', () => {
+    const r = cut({ layer: filled(2, 2), poly: [], minX: 0, minY: 0, w: 2, h: 2 });
+    assert.equal(r.hasContent, false);
+});
+
+test('a zero-size region produces empty images rather than failing', () => {
+    const r = cut({ layer: filled(1, 1), poly: wholeBox, minX: 0, minY: 0, w: 0, h: 0 });
+    assert.equal(r.hasContent, false);
+    assert.equal(r.selection.data.length, 0);
+});


### PR DESCRIPTION
The pixel loop inside `liftLassoSelection` is arithmetic over an `ImageData` — no canvas, no state — and it decides two things that fail quietly when wrong.

## Both images from one pass

They describe the **same set of pixels from opposite sides**: the selection is what now floats, the mask is the hole it leaves. Built separately they drift, and a mask that does not match its selection shows as a **ghost of the lifted artwork still sitting in the layer**.

A test walks every pixel and asserts the two agree. Making the mask threshold on alpha (`if (a > 128)`) fails it.

## Only non-empty pixels are lifted

Inside the polygon **and** not fully transparent. Lifting empty ones makes the selection box larger than the artwork in it, and erases a rectangle of nothing from the layer underneath.

`ImageData` is injected rather than constructed, the way the rest of `core/` takes its browser functions, so the awkward cases can be checked in node.

## One of my tests was wrong on the way in

It claimed to pin *"tested at the pixel centre, not the corner"* using a polygon edge at `x=2` — where **both rules give the same answer**. It passed under either, so it pinned nothing. I only found that by writing the corner version and watching the suite stay green.

Rewritten with the edge at `x=1.2`, which falls *inside* pixel 1: its corner (1.0) is left of the edge and its centre (1.5) is right of it, so the rules genuinely disagree. The corner version now fails it:

```
not ok 6 - a pixel counts by its centre, not by its top-left corner
```

That is the real property — a pixel barely clipped by the lasso should not come along whole.

## Numbers

App.jsx **3848 → 3837**. Nine tests. `npm run check`: 932 tests, reachability 364/364, import check clean, build clean.

## Worth a manual look

Lassoing is all pixels, so tests can only go so far:

1. Lasso a shape and drag it — the lifted pixels must not still show underneath.
2. Lasso an area that is **partly empty** — the selection box should hug the artwork, and the empty part must not be erased from the layer.
3. Lasso across a soft/anti-aliased edge — the faded pixels should keep their own alpha rather than becoming solid.
