### PR TITLE
chore: drop two tool cases nothing can reach

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2083,9 +2083,7 @@ export default function App() {
             case 'pencil':
             case 'soft':
             case 'blur':
-            case 'marker':
-            case 'rough':
-            case 'calligraphy': {
+            case 'marker': {
                 // Draw on the live overlay only — no layer-state writes per move (that was the lag).
                 liveStrokeRef.current = { id: nextId(), tool: etool, color, opacity, size: brushSize, points: [pos], pen: pressureOn && e.pointerType === 'pen' };
                 liveDrawnRef.current = 0; renderLiveStroke(true);
@@ -2209,8 +2207,6 @@ export default function App() {
             case 'soft':
             case 'blur':
             case 'marker':
-            case 'rough':
-            case 'calligraphy':
             case 'eraser': {
                 // Fast strokes get coalesced by the browser into one event; recover every
                 // intermediate sample so quick curves stay curved instead of going polygonal.

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -733,6 +733,12 @@ export function drawStrokesOnCtx(ctx, strokes, clear = true, bitmapStore = null,
         }
         if (!s.points?.length) return;
         // Boiling, from either the per-stroke "rough" pen or the layer effect (layerRough).
+        //
+        // The rough pen has had no button since the layer effect replaced it, so no new stroke
+        // can be made with it - but projects saved before that still contain some, and dropping
+        // this branch would redraw them as plain lines with nothing to say so. Read it as a file
+        // format rather than as a tool.
+        //
         // The dot pen uses this below, so it has to be computed before the pen branch.
         // Strokes under the minimum width are skipped: the thinner the line, the more violent
         // the same amplitude looks.


### PR DESCRIPTION
`startDraw` and `onDraw` both list `'rough'` and `'calligraphy'` among the freehand pens. Neither is reachable: `etool` can only be a `PEN_TYPES` id, a ruler mode, or an Air mode, and neither appears in any of those.

- **`rough`** was a real button (자글) removed in 1eec451, when the layer-level boiling effect replaced it. The gesture cases were left behind.
- **`calligraphy`** came in with the merge in 07e4e2c and has never had a button *or* a renderer branch — a calligraphy stroke would have drawn as a plain brush.

Checked by enumerating every reachable `etool` value and diffing it against the case labels in all three gesture handlers: these four labels are the only unreachable ones.

The renderer's `s.tool === 'rough'` branch **stays** and now explains itself — projects saved before 1eec451 contain those strokes, and deleting it would quietly redraw them as plain lines. It is a file format, not a tool.

No behaviour change. `npm run check` clean, 932 tests.

**To check by hand:** every pen still draws (Dot, 펜, 연필, 에어, 블러, Marker, 지우개), the ruler's line and curve modes still work, and a layer with boiling on still shimmers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)